### PR TITLE
Enable package data inclusion and adjust test exclusions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,15 +5,7 @@ global-exclude .git*
 global-exclude .DS_Store
 
 # Exclude all test directories and files
-recursive-exclude tests_ce *
-recursive-exclude tests *
-recursive-exclude * /test_*
-recursive-exclude * /*_test*
-recursive-exclude * tests
 recursive-exclude * tests_ce
 
 # Exclude specific test-related directories
 prune tests_ce
-prune tests
-prune **/tests
-prune **/tests_ce

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,14 +47,13 @@ local_scheme = "dirty-tag"  # Includes a "dirty" tag in version if working direc
 datamimic = "datamimic_ce.cli:app"  # Entry point for your CLI application
 
 [tool.setuptools]
-include-package-data = false
+include-package-data = true
 
 [tool.setuptools.packages.find]
-where = ["."]  # Changed from ["datamimic_ce"] to "." for better package discovery
+where = ["."]
+exclude = ["tests_ce"]
 namespaces = true
 
-[tool.setuptools.package-data]
-datamimic_ce = ["py.typed", "**/*.csv", "**/*.txt"]
 
 [tool.uv]
 


### PR DESCRIPTION
Set `include-package-data` to true in `pyproject.toml` to include package data during builds. Simplified and refined test-related exclusion rules in `MANIFEST.in` for better clarity and maintainability.