### PR TITLE
Add XML demo files to showcase DATAMIMIC functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ test_artifacts/
 
 /data/
 /tests_ce/test-artifacts/
+/db/
+/.run/

--- a/datamimic_ce/demos/demo-xml/1_xml_generate.xml
+++ b/datamimic_ce/demos/demo-xml/1_xml_generate.xml
@@ -1,0 +1,70 @@
+<setup>
+
+<!--    name value of 'generate' tag will become XML elements;-->
+<!--    name value of 'key' tag will become XML elements, and generated value will become text content;-->
+<!--    name of 'element' tag will become attributes, and generated value will become attribute value;-->
+    <!--  generate simple XML with key -->
+    <generate name="generate_xml" count="10" target="XML">
+        <variable name="person" entity="Person"/>
+        <key name="author" script="None">
+            <element name="name" script="person.name"/>
+            <element name="gender" script="person.gender"/>
+            <element name="birthdate" script="person.birthdate"/>
+        </key>
+    </generate>
+
+<!--    name value of 'nestedKey' tag will become XML elements;-->
+<!--    name value of 'key' tag will become XML elements, and generated value will become text content;-->
+<!--    name of 'element' tag will become attributes, and generated value will become attribute value;-->
+    <!--  generate simple XML with part -->
+    <variable name="part_count" constant="1"/>
+    <generate name="part_list" count="{part_count}" target="XML">
+        <nestedKey name="book" type="list" count="10">
+            <element name="title" values="'Book 1', 'Book 2', 'Book 3', 'Book 4'"/>
+            <element name="language" values="'de', 'en'"/>
+            <element name="pages" generator="IntegerGenerator(min=100,max=800)"/>
+            <element name="release_date" generator="DateTimeGenerator(min='2020-1-1', max='2023-12-31', input_format='%Y-%m-%d')"/>
+        </nestedKey>
+    </generate>
+
+    <generate name="part_dict" count="{part_count}" target="XML">
+        <nestedKey name="book" type="dict">
+            <key name="title" values="'Book 1', 'Book 2', 'Book 3', 'Book 4'">
+                <element name="language" values="'de', 'en'"/>
+            </key>
+            <key name="pages" generator="IntegerGenerator(min=100,max=800)"/>
+            <key name="release_date" generator="DateTimeGenerator(min='2020-1-1', max='2023-12-31', input_format='%Y-%m-%d')"/>
+        </nestedKey>
+        <nestedKey name="magazine" type="dict">
+            <key name="title" values="'Magazine #1', 'Magazine #2', 'Magazine #3', 'Magazine #4'"/>
+            <key name="language" values="'de', 'en'"/>
+            <key name="pages" generator="IntegerGenerator(min=30,max=70)"/>
+        </nestedKey>
+    </generate>
+
+<!--    name value of 'array' tag will become XML elements, and generated value will become text content;-->
+    <!--  generate simple XML with array -->
+    <generate name="array_xml" count="10" target="XML">
+        <array name="random_string" type="string" count="10"/>
+        <array name="random_number" type="int" count="10"/>
+    </generate>
+
+<!--    name value of 'list' tag will become XML elements, which cover each item;-->
+    <!--  generate simple XML with list -->
+    <generate name="list_xml" count="10" target="XML">
+        <list name="detail">
+            <item>
+                <key name="number" type="int" constant="2"/>
+            </item>
+            <item>
+                <key name="text" type="string"/>
+            </item>
+            <item>
+                <nestedKey name="employees" type="list" count="10">
+                    <key name="code" type="string"/>
+                    <key name="age" values="25, 30, 28, 45"/>
+                </nestedKey>
+            </item>
+        </list>
+    </generate>
+</setup>

--- a/datamimic_ce/demos/demo-xml/2_xml_template_1.xml
+++ b/datamimic_ce/demos/demo-xml/2_xml_template_1.xml
@@ -1,0 +1,13 @@
+<setup>
+    <!--  Get template from book.template.xml and replace data  -->
+    <!--  Element <item> from book.template.xml will be rename to <book>  -->
+    <generate name="book" source="script/book.template.xml" target="XML">
+        <!--  Text content of <author> will be replaced by random text  -->
+        <key name="author" type="string"/>
+        <!--  Add element <additionalTag>  -->
+        <key name="additionalTag" constant="extra">
+            <element name="new_key" constant="new_key_value"/>
+        </key>
+    </generate>
+
+</setup>

--- a/datamimic_ce/demos/demo-xml/3_xml_template_2.xml
+++ b/datamimic_ce/demos/demo-xml/3_xml_template_2.xml
@@ -1,0 +1,22 @@
+<setup>
+    <generate name="university" source="script/university.template.xml" target="XML">
+        <!--    Keep students element values    -->
+        <nestedKey name="students" script="students">
+            <!--    Keep student element values    -->
+            <nestedKey name="student" script="students.student">
+                <!--    Rewrite name elements    -->
+                <variable name="person" entity="Person"/>
+                <nestedKey name="name" type="dict">
+                    <key name="first" script="students.student.person.given_name"/>
+                    <key name="last" script="students.student.person.family_name"/>
+                </nestedKey>
+                <!--    Keep phone element of contact, and rewrite email element    -->
+                <nestedKey name="contact" script="students.student.contact">
+                    <key name="email" script="students.student.person.email"/>
+                </nestedKey>
+                <!--    Add new element: gender    -->
+                <key name="gender" script="students.student.person.gender"/>
+            </nestedKey>
+        </nestedKey>
+    </generate>
+</setup>

--- a/datamimic_ce/demos/demo-xml/4_xml_template_script.xml
+++ b/datamimic_ce/demos/demo-xml/4_xml_template_script.xml
@@ -1,0 +1,22 @@
+<setup>
+    <generate name="book_script" count="10" target="XML">
+        <nestedKey name="part" type="dict">
+            <key name="author" type="string"/>
+            <key name="additionalTag" constant="extra">
+                <element name="new_key" constant="new_key_value"/>
+            </key>
+            <!--            Copy simple key-->
+            <key name="copy_author" script="part.author"/>
+            <!--            Copy xml key text only-->
+            <key name="copy_additionalTag" script="part.additionalTag.get('#text')"/>
+            <!--            Copy xml attribute-->
+            <key name="copy_additionalTag2" constant="abc">
+                <element name="copy_new_key" script="part.additionalTag.get('@new_key')"/>
+            </key>
+            <!--            Copy whole xml element-->
+            <key name="copy_additionalTag3" script="part.additionalTag"/>
+
+        </nestedKey>
+    </generate>
+
+</setup>

--- a/datamimic_ce/demos/demo-xml/datamimic.xml
+++ b/datamimic_ce/demos/demo-xml/datamimic.xml
@@ -1,0 +1,13 @@
+<setup>
+
+    <!--
+    XML Demo
+    ======================================
+    DATAMIMIC XML Demo demonstrates processing of XML files.
+    -->
+
+    <include uri="1_xml_generate.xml" />
+    <include uri="2_xml_template_1.xml" />
+    <include uri="3_xml_template_2.xml" />
+    <include uri="4_xml_template_script.xml" />
+</setup>

--- a/datamimic_ce/demos/demo-xml/info.toml
+++ b/datamimic_ce/demos/demo-xml/info.toml
@@ -1,0 +1,6 @@
+title = "Basic XML"
+description = "Showcases how to generate and export XML file with DATAMIMIC."
+icon = "xml"
+tags = ["#xml"]
+id = "demo-xml"
+projectName = "demo-xml"

--- a/datamimic_ce/demos/demo-xml/script/book.template.xml
+++ b/datamimic_ce/demos/demo-xml/script/book.template.xml
@@ -1,0 +1,21 @@
+<list>
+    <item>
+        <title language="en">Introduction to Programming</title>
+        <author nationality="US">John Smith</author>
+        <publishedDate format="yyyy-mm-dd">2022-01-01</publishedDate>
+        <tags>
+            <category>programming</category>
+            <nation>us</nation>
+        </tags>
+    </item>
+    <item>
+        <title language="en">Data Science Essentials</title>
+        <author nationality="UK">Jane Doe</author>
+        <publishedDate format="yyyy-mm-dd">2021-08-15</publishedDate>
+    </item>
+    <item>
+        <title language="en">Web Development Basics</title>
+        <author nationality="CA">Michael Johnson</author>
+        <publishedDate format="yyyy-mm-dd">2023-03-20</publishedDate>
+    </item>
+</list>

--- a/datamimic_ce/demos/demo-xml/script/university.template.xml
+++ b/datamimic_ce/demos/demo-xml/script/university.template.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list>
+    <item>
+        <students>
+            <student id="1">
+                <name>
+                    <first>John</first>
+                    <last>Doe</last>
+                </name>
+                <age>20</age>
+                <grade letter="A">Excellent</grade>
+                <contact>
+                    <email>john.doe@example.com</email>
+                    <phone type="mobile">123-456-7890</phone>
+                </contact>
+            </student>
+            <student id="2">
+                <name>
+                    <first>Jane</first>
+                    <last>Smith</last>
+                </name>
+                <age>22</age>
+                <grade letter="B">Good</grade>
+                <contact>
+                    <email>jane.smith@example.com</email>
+                    <phone type="home">987-654-3210</phone>
+                </contact>
+            </student>
+        </students>
+    </item>
+</list>
+


### PR DESCRIPTION
This commit introduces demo XML files to the DATAMIMIC project, including templates for generating and transforming XML data. Additionally, a new `.gitignore` entry is added to exclude `/db/` and `/.run/` directories. These updates provide examples for processing and exporting XML.