### PR TITLE
Update workflows to use ubuntu-22.04 and simplify logger setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
           retention-days: 1
 
   install_dependencies:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: python:3.11-slim-buster
     needs: setup
     permissions:
@@ -80,7 +80,7 @@ jobs:
         shell: bash
 
   mypy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: install_dependencies
     container: python:3.11-slim-buster
     continue-on-error: true # TODO: Remove this line once all mypy errors are fixed
@@ -106,7 +106,7 @@ jobs:
         shell: bash
 
   ruff:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: install_dependencies
     container: python:3.11-slim-buster
     continue-on-error: true # TODO: Remove this line once all ruff errors are fixed
@@ -134,7 +134,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -167,7 +167,7 @@ jobs:
           path: dist/*
 
   unit_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: install_dependencies
     container: python:3.11-slim-buster
     steps:
@@ -198,7 +198,7 @@ jobs:
 
 
   functional_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: install_dependencies
     container: python:3.11-slim-buster
     services:
@@ -247,7 +247,7 @@ jobs:
 
 
   integration_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: install_dependencies
     services:
       postgres:
@@ -295,7 +295,7 @@ jobs:
           path: coverage.xml
 
   sonarcloud_analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ unit_test, functional_test, integration_test ]
     steps:
       - name: Checkout repository
@@ -335,13 +335,13 @@ jobs:
     needs: [ build, unit_test, functional_test, integration_test ]
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-22.04, macos-latest, windows-latest ]
         arch: [ x64, arm64 ]
         python-version: [ '3.11' ]
         exclude:
           - os: windows-latest
             arch: arm64  # Exclude Windows ARM64 as it's not supported
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             arch: arm64  # Ubuntu GitHub runners do not support ARM64 yet
     steps:
       - name: Set Up Python
@@ -453,7 +453,7 @@ jobs:
 
   publish_dev:
     if: github.ref == 'refs/heads/development'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ e2e_test ]
     environment:
       name: testpypi
@@ -491,7 +491,7 @@ jobs:
 
   release:
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ e2e_test ]
     environment:
       name: pypi
@@ -518,14 +518,14 @@ jobs:
       - name: List Contents of dist Directory
         run: ls -R dist
 
-#      - name: Publish distribution to PyPI
-#        uses: pypa/gh-action-pypi-publish@release/v1
-#        with:
-#          repository-url: https://pypi.org/legacy/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://pypi.org/legacy/
 
   trigger_ee_dev:
     if: github.ref == 'refs/heads/development'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ publish_dev ]
     steps:
       - name: trigger EE development pipelines

--- a/datamimic_ce/logger/__init__.py
+++ b/datamimic_ce/logger/__init__.py
@@ -45,10 +45,7 @@ def setup_logger(logger_name, task_id, level=logging.INFO):
 
     if not l.handlers:  # Avoid adding duplicate handlers
         l.setLevel(level)
-        if settings.RUNTIME_ENVIRONMENT in ["development", "production"]:
-            l.addHandler(stream_handler)
-        else:
-            l.addHandler(stream_handler)
+        l.addHandler(stream_handler)
 
     l.propagate = False  # Avoid propagation to the parent logger
 


### PR DESCRIPTION
Replaced 'ubuntu-latest' with 'ubuntu-22.04' across GitHub workflows for consistency and predictability of the environment. Simplified logger setup by removing redundant conditional logic for handler addition in non-parent logger configuration. ( fix sonarqube issue )