### PR TITLE
Update documentation to standardize branding to DATAMIMIC

### DIFF
--- a/docs/data-domains/README.md
+++ b/docs/data-domains/README.md
@@ -11,7 +11,6 @@ Welcome to the documentation for the Domain-Driven Framework component of DATAMI
 - [Using Domain Services](domain_services.md) - Guide to using the domain service APIs
 - [Weighted Distributions System](weighted_distributions.md) - How DATAMIMIC's distribution system works
 - [Testing with DATAMIMIC](testing_with_datamimic.md) - Using synthetic data for testing
-- [DATAMIMIC vs Other Libraries](comparison.md) - Comparison with other data generation tools
 
 > For more detailed information on domain models, exporters, importers, and platform integration, please refer to our [official online documentation](https://docs.datamimic.io/).
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -1,14 +1,14 @@
-# DataMimic Developer Guide
+# DATAMIMIC Developer Guide
 
 ## Introduction
 
-DataMimic is a powerful synthetic data generation framework built on a domain-driven architecture that produces high-quality, weighted dataset-driven synthetic data for various industries. Unlike generic data generation libraries, DataMimic focuses on creating data that accurately mimics real-world distributions and relationships, making it ideal for testing, training, and demonstration purposes.
+DATAMIMIC is a powerful synthetic data generation framework built on a domain-driven architecture that produces high-quality, weighted dataset-driven synthetic data for various industries. Unlike generic data generation libraries, DATAMIMIC focuses on creating data that accurately mimics real-world distributions and relationships, making it ideal for testing, training, and demonstration purposes.
 
 > **Note**: For comprehensive documentation including detailed model descriptions, exporters, importers, platform UI, and more, please visit our official online documentation at [https://docs.datamimic.io/](https://docs.datamimic.io/)
 
 ## Installation
 
-To install DataMimic Community Edition:
+To install DATAMIMIC Community Edition:
 
 ```bash
 pip install datamimic-ce
@@ -16,7 +16,7 @@ pip install datamimic-ce
 
 ## Core Architecture
 
-DataMimic is built on three main architectural components:
+DATAMIMIC is built on three main architectural components:
 
 1. **Domain Core** - Provides the foundational classes and interfaces for all domain models
 2. **Domains** - Industry-specific implementations of entities and business logic
@@ -94,7 +94,7 @@ people_json = json.dumps([p.to_dict() for p in people], cls=DatetimeEncoder)
 
 ## Domain Models
 
-DataMimic includes specialized models for various industry domains:
+DATAMIMIC includes specialized models for various industry domains:
 
 ### Healthcare Domain
 
@@ -126,7 +126,7 @@ DataMimic includes specialized models for various industry domains:
 
 ## Weighted Distributions
 
-A key advantage of DataMimic is its use of weighted distributions based on real-world data patterns:
+A key advantage of DATAMIMIC is its use of weighted distributions based on real-world data patterns:
 
 ```python
 from datamimic_ce.domains.healthcare.services import PatientService
@@ -146,7 +146,7 @@ patients = patient_service.generate_batch(count=100)
 
 ## Unit Testing with DataMimic
 
-DataMimic excels at creating test data for unit and integration tests:
+DATAMIMIC excels at creating test data for unit and integration tests:
 
 ```python
 import unittest
@@ -183,7 +183,7 @@ class TestTransactionProcessor(unittest.TestCase):
 
 ## Comparison with Other Libraries
 
-| Feature | DataMimic | Faker | Mimesis |
+| Feature | DATAMIMIC | Faker | Mimesis |
 |---------|-----------|-------|---------|
 | Domain-specific models | ✓ | ✗ | Partial |
 | Realistic distributions | ✓ | ✗ | ✗ |
@@ -237,6 +237,6 @@ class CustomEntity(BaseEntity):
 
 ## Conclusion
 
-DataMimic's domain-driven architecture provides a powerful framework for generating synthetic data that accurately reflects real-world patterns and relationships. By leveraging weighted distributions and domain-specific models, DataMimic enables developers to create high-quality test data, training datasets, and demonstration data that closely mimics production systems.
+DataMimic's domain-driven architecture provides a powerful framework for generating synthetic data that accurately reflects real-world patterns and relationships. By leveraging weighted distributions and domain-specific models, DATAMIMIC enables developers to create high-quality test data, training datasets, and demonstration data that closely mimics production systems.
 
 For further assistance or to contribute to the project, visit our GitHub repository or contact the development team.

--- a/docs/examples/healthcare_generation.md
+++ b/docs/examples/healthcare_generation.md
@@ -1,6 +1,6 @@
 # Healthcare Data Generation with DataMimic
 
-This example demonstrates how to generate synthetic healthcare data using the DataMimic framework.
+This example demonstrates how to generate synthetic healthcare data using the DATAMIMIC framework.
 
 ## Basic Patient Generation
 
@@ -284,4 +284,4 @@ Patients:
 - Mary Johnson, 29 years old, Conditions: []
 ```
 
-This demonstrates how DataMimic can generate realistic, related healthcare entities for testing and development. 
+This demonstrates how DATAMIMIC can generate realistic, related healthcare entities for testing and development. 

--- a/docs/examples/person_generation.md
+++ b/docs/examples/person_generation.md
@@ -1,6 +1,6 @@
 # Person Generation with DataMimic
 
-This example demonstrates how to generate synthetic person data using the DataMimic framework.
+This example demonstrates how to generate synthetic person data using the DATAMIMIC framework.
 
 ## Basic Person Generation
 
@@ -77,7 +77,7 @@ Person 5: Susan Johnson, 31 years old
 
 ## Working with Different Locales
 
-DataMimic supports generating data for different regions by specifying the dataset:
+DATAMIMIC supports generating data for different regions by specifying the dataset:
 
 ```python
 # Create services for different regions


### PR DESCRIPTION
- Changed all instances of "DataMimic" to "DATAMIMIC" in the developer guide, examples, and domain documentation for consistency.
- Removed the "DATAMIMIC vs Other Libraries" section from the domain documentation README to streamline content.