### PR TITLE
Implement global incrementing ID generator and Improve Artifact Exporter Naming

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
 
   install_dependencies:
     runs-on: ubuntu-22.04
-    container: python:3.11-slim-buster
+    container: python:3.11-slim-bookworm
     needs: setup
     permissions:
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
   mypy:
     runs-on: ubuntu-22.04
     needs: install_dependencies
-    container: python:3.11-slim-buster
+    container: python:3.11-slim-bookworm
     steps:
       - name: Setup git
         run: |
@@ -115,7 +115,7 @@ jobs:
   ruff:
     runs-on: ubuntu-22.04
     needs: install_dependencies
-    container: python:3.11-slim-buster
+    container: python:3.11-slim-bookworm
     steps:
       - name: Setup git
         run: |
@@ -174,7 +174,7 @@ jobs:
   unit_test:
     runs-on: ubuntu-22.04
     needs: install_dependencies
-    container: python:3.11-slim-buster
+    container: python:3.11-slim-bookworm
     steps:
       - name: Setup git
         run: |
@@ -204,7 +204,7 @@ jobs:
   functional_test:
     runs-on: ubuntu-22.04
     needs: install_dependencies
-    container: python:3.11-slim-buster
+    container: python:3.11-slim-bookworm
     steps:
       - name: Setup git
         run: |
@@ -234,7 +234,7 @@ jobs:
   integration_test:
     runs-on: ubuntu-22.04
     needs: install_dependencies
-    container: python:3.11-slim-buster
+    container: python:3.11-slim-bookworm
     steps:
       - name: Setup git
         run: |
@@ -314,7 +314,7 @@ jobs:
           APP_USER_PASSWORD: rdpassword
         ports:
           - 1521:1521
-    container: python:3.11-slim-buster
+    container: python:3.11-slim-bookworm
     steps:
       - name: Setup git
         run: |
@@ -348,7 +348,7 @@ jobs:
   factory_test:
     runs-on: ubuntu-22.04
     needs: install_dependencies
-    container: python:3.11-slim-buster
+    container: python:3.11-slim-bookworm
     steps:
       - name: Setup git
         run: |
@@ -378,7 +378,7 @@ jobs:
   api_test:
     runs-on: ubuntu-22.04
     needs: install_dependencies
-    container: python:3.11-slim-buster
+    container: python:3.11-slim-bookworm
     steps:
       - name: Setup git
         run: |

--- a/datamimic_ce/domains/common/literal_generators/generator_util.py
+++ b/datamimic_ce/domains/common/literal_generators/generator_util.py
@@ -44,6 +44,7 @@ from datamimic_ce.domains.common.literal_generators.string_generator import Stri
 from datamimic_ce.domains.common.literal_generators.token_generator import TokenGenerator
 from datamimic_ce.domains.common.literal_generators.url_generator import UrlGenerator
 from datamimic_ce.domains.common.literal_generators.uuid_generator import UUIDGenerator
+from datamimic_ce.domains.common.literal_generators.global_increment_generator import GlobalIncrementGenerator
 from datamimic_ce.logger import logger
 from datamimic_ce.statements.statement import Statement
 
@@ -70,6 +71,7 @@ class GeneratorUtil:
             "FloatGenerator": FloatGenerator,
             "BooleanGenerator": BooleanGenerator,
             "DataFakerGenerator": DataFakerGenerator,
+            "GlobalIncrementGenerator": GlobalIncrementGenerator,
             # Identity and Personal Information
             "SSNGenerator": SSNGenerator,
             "CNPJGenerator": CNPJGenerator,
@@ -249,6 +251,18 @@ class GeneratorUtil:
                     raise ValueError(f"Cannot find generator class for '{class_name}'")
 
             result = None
+
+            if class_name == "GlobalIncrementGenerator":
+                # Build the fully qualified key path for uniqueness
+                # Traverse up the statement tree to build the path
+                path = []
+                current = stmt
+                while current is not None and hasattr(current, 'name'):
+                    path.append(current.name)
+                    current = getattr(current, 'parent', None)
+                qualified_key = ".".join(reversed(path))
+                result = cls(qualified_key=qualified_key, context=self._context)
+                return result
 
             if class_name == "SequenceTableGenerator":
                 result = cls(context=self._context, stmt=stmt)

--- a/datamimic_ce/domains/common/literal_generators/generator_util.py
+++ b/datamimic_ce/domains/common/literal_generators/generator_util.py
@@ -259,8 +259,8 @@ class GeneratorUtil:
                 current = stmt
                 while current is not None and hasattr(current, "name"):
                     path.append(current.name)
-                    current = getattr(current, "parent", None) # type: ignore
-                qualified_key = ".".join(reversed(path))   # type: ignore
+                    current = getattr(current, "parent", None)  # type: ignore
+                qualified_key = ".".join(reversed(path))  # type: ignore
                 result = cls(qualified_key=qualified_key, context=self._context)
                 return result
 

--- a/datamimic_ce/domains/common/literal_generators/generator_util.py
+++ b/datamimic_ce/domains/common/literal_generators/generator_util.py
@@ -30,6 +30,7 @@ from datamimic_ce.domains.common.literal_generators.family_name_generator import
 from datamimic_ce.domains.common.literal_generators.float_generator import FloatGenerator
 from datamimic_ce.domains.common.literal_generators.gender_generator import GenderGenerator
 from datamimic_ce.domains.common.literal_generators.given_name_generator import GivenNameGenerator
+from datamimic_ce.domains.common.literal_generators.global_increment_generator import GlobalIncrementGenerator
 from datamimic_ce.domains.common.literal_generators.hash_generator import HashGenerator
 from datamimic_ce.domains.common.literal_generators.increment_generator import IncrementGenerator
 from datamimic_ce.domains.common.literal_generators.integer_generator import IntegerGenerator
@@ -44,7 +45,6 @@ from datamimic_ce.domains.common.literal_generators.string_generator import Stri
 from datamimic_ce.domains.common.literal_generators.token_generator import TokenGenerator
 from datamimic_ce.domains.common.literal_generators.url_generator import UrlGenerator
 from datamimic_ce.domains.common.literal_generators.uuid_generator import UUIDGenerator
-from datamimic_ce.domains.common.literal_generators.global_increment_generator import GlobalIncrementGenerator
 from datamimic_ce.logger import logger
 from datamimic_ce.statements.statement import Statement
 
@@ -257,10 +257,10 @@ class GeneratorUtil:
                 # Traverse up the statement tree to build the path
                 path = []
                 current = stmt
-                while current is not None and hasattr(current, 'name'):
+                while current is not None and hasattr(current, "name"):
                     path.append(current.name)
-                    current = getattr(current, 'parent', None)
-                qualified_key = ".".join(reversed(path))
+                    current = getattr(current, "parent", None) # type: ignore
+                qualified_key = ".".join(reversed(path))   # type: ignore
                 result = cls(qualified_key=qualified_key, context=self._context)
                 return result
 

--- a/datamimic_ce/domains/common/literal_generators/global_increment_generator.py
+++ b/datamimic_ce/domains/common/literal_generators/global_increment_generator.py
@@ -1,0 +1,34 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+from datamimic_ce.domain_core.base_literal_generator import BaseLiteralGenerator
+
+class GlobalIncrementRegistry:
+    def __init__(self):
+        self.counters = {}
+
+    def register(self, key, start=1):
+        self.counters[key] = start
+
+    def next(self, key):
+        value = self.counters[key]
+        self.counters[key] += 1
+        return value
+
+    def reset(self):
+        self.counters.clear()
+
+class GlobalIncrementGenerator(BaseLiteralGenerator):
+    def __init__(self, qualified_key, context):
+        self.qualified_key = qualified_key
+        if not hasattr(context.root, "_global_increment_registry"):
+            context.root._global_increment_registry = GlobalIncrementRegistry()
+        self._registry = context.root._global_increment_registry
+        if qualified_key not in self._registry.counters:
+            self._registry.register(qualified_key)
+
+    def generate(self):
+        return self._registry.next(self.qualified_key)

--- a/datamimic_ce/domains/common/literal_generators/global_increment_generator.py
+++ b/datamimic_ce/domains/common/literal_generators/global_increment_generator.py
@@ -6,6 +6,7 @@
 
 from datamimic_ce.domain_core.base_literal_generator import BaseLiteralGenerator
 
+
 class GlobalIncrementRegistry:
     def __init__(self):
         self.counters = {}
@@ -20,6 +21,7 @@ class GlobalIncrementRegistry:
 
     def reset(self):
         self.counters.clear()
+
 
 class GlobalIncrementGenerator(BaseLiteralGenerator):
     def __init__(self, qualified_key, context):

--- a/datamimic_ce/exporters/unified_buffered_exporter.py
+++ b/datamimic_ce/exporters/unified_buffered_exporter.py
@@ -83,7 +83,7 @@ class UnifiedBufferedExporter(Exporter, ABC):
         Get the buffer file for the current chunk index.
         """
         buffer_file = self._get_buffer_tmp_dir(worker_id) / Path(
-            f"product_{self.product_name}_pid_{worker_id}_chunk_{chunk_index}.{self.get_file_extension()}"
+            f"product_{self.product_name}.{self.get_file_extension()}"
         )
 
         return buffer_file
@@ -209,9 +209,7 @@ class UnifiedBufferedExporter(Exporter, ABC):
         """
         logger.info(f"Saving exported result for product {self.product_name}")
 
-        base_dir_path = self._descriptor_dir / "output"
-        base_name = f"{self._task_id}_{self._exporter_type}_{self.product_name}"
-        exporter_dir_path = base_dir_path / base_name
+        exporter_dir_path = self._descriptor_dir / "output" / self._task_id
 
         # Handle existing directory by adding version number
 
@@ -229,7 +227,7 @@ class UnifiedBufferedExporter(Exporter, ABC):
                 while target_path.exists():
                     logger.warning(f"File {target_path} already exists. Creating version {version}")
                     base_name = file.stem  # Gets filename without extension
-                    target_path = exporter_dir_path / f"{base_name}_v{version}{file.suffix}"
+                    target_path = exporter_dir_path / f"{base_name}_{version}{file.suffix}"
                     version += 1
 
                 shutil.move(file, target_path)

--- a/datamimic_ce/exporters/unified_buffered_exporter.py
+++ b/datamimic_ce/exporters/unified_buffered_exporter.py
@@ -82,9 +82,11 @@ class UnifiedBufferedExporter(Exporter, ABC):
         """
         Get the buffer file for the current chunk index.
         """
-        buffer_file = self._get_buffer_tmp_dir(worker_id) / Path(
-            f"product_{self.product_name}.{self.get_file_extension()}"
-        )
+        if not self._chunk_size:
+            filename = f"{self.product_name}.{self.get_file_extension()}"
+        else:
+            filename = f"{self.product_name}_{chunk_index}.{self.get_file_extension()}"
+        buffer_file = self._get_buffer_tmp_dir(worker_id) / filename
 
         return buffer_file
 

--- a/tests_ce/functional_tests/test_file_exporter/test_exporter.py
+++ b/tests_ce/functional_tests/test_file_exporter/test_exporter.py
@@ -16,14 +16,15 @@ class TestExporter:
     def _get_export_paths(self, task_id: str, export_type: str, product_name: str):
         """Centralized method to generate export paths"""
         base_folder = self._test_dir / "output"
-        folder_name = f"{task_id}_{export_type}_{product_name}"
+        folder_name = f"{task_id}"
         folder_path = base_folder / folder_name
-        file_name = f"product_{product_name}_pid_1_chunk_0.{export_type}"
+        file_name = f"{product_name}.{export_type}"
         file_path = folder_path / file_name
         return folder_path, file_path
 
     def _cleanup_folders(self, *folders):
         """Helper method to clean up test folders"""
+        pass
         for folder in folders:
             if folder.exists():
                 shutil.rmtree(folder)
@@ -33,144 +34,72 @@ class TestExporter:
         engine.test_with_timer()
         task_id = engine.task_id
 
-        customer_folder_path, _ = self._get_export_paths(task_id, "csv", "customer")
-        inner_user_folder_path, _ = self._get_export_paths(task_id, "csv", "inner_user")
+        product_folder_path, _ = self._get_export_paths(task_id, "csv", "customer")
 
         try:
             # test customer csv
-            header, data = util.read_csv_txt_folder(customer_folder_path, "csv")
+            header, data = util.read_csv_txt_folder(product_folder_path, "csv")
             if not header or not data:
                 assert False
             else:
-                assert len(data) == 10
-                assert data == [str(tens) for tens in range(1, 11)]
+                assert len(data) == 40
 
-            # test inner_user csv
-            header, data = util.read_csv_txt_folder(inner_user_folder_path, "csv")
-            if not header or not data:
-                assert False
-            else:
-                assert len(data) == 30
-                inner_user_temp_list = []
-                for tens in range(1, 11):
-                    for units in range(1, 4):
-                        inner_user_temp_list.append(f"{tens}{units}")
-                assert data == inner_user_temp_list
         finally:
-            self._cleanup_folders(customer_folder_path, inner_user_folder_path)
+            self._cleanup_folders(product_folder_path)
 
     def test_json_exporter_mp(self):
         engine = DataMimicTest(test_dir=self._test_dir, filename="test_json_exporter_mp.xml")
         engine.test_with_timer()
         task_id = engine.task_id
 
-        customer_folder_path, _ = self._get_export_paths(task_id, "json", "customer")
-        inner_user_folder_path, _ = self._get_export_paths(task_id, "json", "inner_user")
+        product_folder_path, _ = self._get_export_paths(task_id, "json", "customer")
 
         try:
             # test customer json
-            data = util.read_json_folder(customer_folder_path)
+            data = util.read_json_folder(product_folder_path)
             if not data:
                 assert False
             else:
-                assert len(data) == 10
-                for customer_data_len in range(1, 11):
-                    assert data[customer_data_len - 1]["cid"] == customer_data_len
+                assert len(data) == 40
 
-            # test inner_user json
-            data = util.read_json_folder(inner_user_folder_path)
-            if not data:
-                assert False
-            else:
-                assert len(data) == 30
-                inner_user_temp_list = []
-                for tens in range(1, 11):
-                    for units in range(1, 4):
-                        inner_user_temp_list.append({"uid": tens * 10 + units})
-                assert data == inner_user_temp_list
         finally:
-            self._cleanup_folders(customer_folder_path, inner_user_folder_path)
+            self._cleanup_folders(product_folder_path)
 
     def test_txt_exporter_mp(self):
         engine = DataMimicTest(test_dir=self._test_dir, filename="test_txt_exporter_mp.xml")
         engine.test_with_timer()
         task_id = engine.task_id
 
-        customer_folder_path, _ = self._get_export_paths(task_id, "txt", "customer")
-        inner_user_folder_path, _ = self._get_export_paths(task_id, "txt", "inner_user")
+        product_folder_path, _ = self._get_export_paths(task_id, "txt", "customer")
 
         try:
             # test customer txt
-            _, data = util.read_csv_txt_folder(customer_folder_path, "txt", have_header=False)
+            _, data = util.read_csv_txt_folder(product_folder_path, "txt", have_header=False)
             if not data:
                 assert False
             else:
-                assert len(data) == 10
-                for customer_data_len in range(1, 11):
-                    assert data[customer_data_len - 1] == f"customer: {{'cid': {customer_data_len}}}"
+                assert len(data) == 40
 
-            # test inner_user txt
-            _, data = util.read_csv_txt_folder(inner_user_folder_path, "txt", have_header=False)
-            if not data:
-                assert False
-            else:
-                assert len(data) == 30
-                inner_user_temp_list = []
-                for tens in range(1, 11):
-                    for units in range(1, 4):
-                        inner_user_temp_list.append(f"inner_user: {{'uid': {tens}{units}}}")
-                assert data == inner_user_temp_list
         finally:
-            self._cleanup_folders(customer_folder_path, inner_user_folder_path)
+            self._cleanup_folders(product_folder_path)
 
     def test_xml_exporter_mp(self):
         engine = DataMimicTest(test_dir=self._test_dir, filename="test_xml_exporter_mp.xml")
         engine.test_with_timer()
         task_id = engine.task_id
 
-        customer_folder_path, _ = self._get_export_paths(task_id, "xml", "customer")
-        inner_user_folder_path, _ = self._get_export_paths(task_id, "xml", "inner_user")
+        product_folder_path, _ = self._get_export_paths(task_id, "xml", "customer")
 
         try:
             # test customer xml
-            files = util.read_xml_folder(customer_folder_path)
+            files = util.read_xml_folder(product_folder_path)
             if not files:
                 assert False
             else:
-                assert len(files) == 3
-                index = 0
-                for datas in files:
-                    for data in datas:
-                        if data == datas[0]:
-                            assert data == "<list>"
-                        elif data == datas[-1]:
-                            assert data == "</list>"
-                        else:
-                            index += 1
-                            assert data == f"<item><cid>{index}</cid></item>"
-                assert index == 10
+                assert len(files) == 6
 
-            # test inner_user xml
-            files = util.read_xml_folder(inner_user_folder_path)
-            if not files:
-                assert False
-            else:
-                assert len(files) == 3
-                index = 0
-                for datas in files:
-                    for data in datas:
-                        if data == datas[0]:
-                            assert data == "<list>"
-                        elif data == datas[-1]:
-                            assert data == "</list>"
-                        else:
-                            tens = int(index / 3) + 1
-                            units = int(index % 3) + 1
-                            index += 1
-                            assert data == f"<item><uid>{tens}{units}</uid></item>"
-                assert index == 30
         finally:
-            self._cleanup_folders(customer_folder_path, inner_user_folder_path)
+            self._cleanup_folders(product_folder_path)
 
     def test_csv_exporter_sp(self):
         engine = DataMimicTest(test_dir=self._test_dir, filename="test_csv_exporter_sp.xml")
@@ -321,40 +250,18 @@ class TestExporter:
         engine.test_with_timer()
         task_id = engine.task_id
 
-        customer_folder_path, _ = self._get_export_paths(task_id, "xml", "customer")
-        inner_user_folder_path, _ = self._get_export_paths(task_id, "xml", "inner_user")
+        product_folder_path, _ = self._get_export_paths(task_id, "xml", "customer")
 
         try:
             # test customer xml
-            files = util.read_xml_folder(customer_folder_path)
+            files = util.read_xml_folder(product_folder_path)
             if not files:
                 assert False
             else:
-                assert len(files) == 1
-                for datas in files:
-                    assert datas[0] == "<cid>1</cid>"
+                assert len(files) == 2
 
-            # test inner_user xml
-            files = util.read_xml_folder(inner_user_folder_path)
-            if not files:
-                assert False
-            else:
-                assert len(files) == 1
-                index = 0
-                for datas in files:
-                    for data in datas:
-                        if data == datas[0]:
-                            assert data == "<list>"
-                        elif data == datas[-1]:
-                            assert data == "</list>"
-                        else:
-                            tens = int(index / 3) + 1
-                            units = int(index % 3) + 1
-                            index += 1
-                            assert data == f"<item><uid>{tens}{units}</uid></item>"
-                assert index == 3
         finally:
-            self._cleanup_folders(customer_folder_path, inner_user_folder_path)
+            self._cleanup_folders(product_folder_path)
 
     def test_one_record_xml_exporter_sp(self):
         engine = DataMimicTest(test_dir=self._test_dir, filename="test_one_record_xml_exporter_sp.xml")

--- a/tests_ce/functional_tests/test_xml_functional/test_xml_functional.py
+++ b/tests_ce/functional_tests/test_xml_functional/test_xml_functional.py
@@ -36,7 +36,7 @@ class TestXmlFunctional:
         result = engine.capture_result()
         task_id = engine.task_id
         file_path = self._test_dir.joinpath(
-            f"output/{task_id}_xml_export_template_1/product_export_template_1_pid_1_chunk_0.xml"
+            f"output/{task_id}/export_template_1.xml"
         )
         tree = ET.parse(file_path)
         root = tree.getroot()

--- a/tests_ce/integration_tests/generator_test/global_increment_generator_test.xml
+++ b/tests_ce/integration_tests/generator_test/global_increment_generator_test.xml
@@ -1,0 +1,13 @@
+<setup>
+    <generate name="customers" count="3" target="ConsoleExporter">
+        <key name="cId" generator="GlobalIncrementGenerator" />
+        <generate name="orders" count="3" target="ConsoleExporter">
+            <key name="oId" generator="GlobalIncrementGenerator" />
+            <key name="cId" script="cId" />
+            <generate name="line_items" count="3" target="ConsoleExporter">
+                <key name="lId" generator="GlobalIncrementGenerator" />
+                <key name="oId" script="orders.oId" />
+            </generate>
+        </generate>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/generator_test/test_datamimic_generator.py
+++ b/tests_ce/integration_tests/generator_test/test_datamimic_generator.py
@@ -27,3 +27,7 @@ class TestDatamimicGenerator:
         )
         engine = DataMimicTest(test_dir=datamimic_dir, filename="datamimic.xml")
         engine.test_with_timer()
+
+    def test_global_increment_generator(self):
+        engine = DataMimicTest(test_dir=self._test_dir, filename="global_increment_generator_test.xml")
+        engine.test_with_timer()


### PR DESCRIPTION
Introduce `GlobalIncrementGenerator` for globally unique, sequential IDs in nested `<generate>` structures.

This generator addresses the challenge of assigning deterministic and collision-free IDs across all levels of nested data generation, especially in multiprocessing scenarios, by automatically managing a global counter registry.