### PR TITLE
Cache generators across pages

### DIFF
--- a/datamimic_ce/contexts/setup_context.py
+++ b/datamimic_ce/contexts/setup_context.py
@@ -117,7 +117,7 @@ class SetupContext(Context):
             default_dataset=self._default_dataset,
             default_locale=self._default_locale,
             global_variables=self.global_variables,
-            generators=copy.deepcopy(self._generators),
+            generators=copy.deepcopy(self._generators, memo),
             num_process=copy.deepcopy(self._num_process, memo),
             default_variable_prefix=self._default_variable_prefix,
             default_variable_suffix=self._default_variable_suffix,

--- a/datamimic_ce/domain_core/__init__.py
+++ b/datamimic_ce/domain_core/__init__.py
@@ -1,5 +1,5 @@
-# # DATAMIMIC
-# # Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
-# # This software is licensed under the MIT License.
-# # See LICENSE file for the full text of the license.
-# # For questions and support, contact: info@rapiddweller.com
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com

--- a/datamimic_ce/domain_core/base_literal_generator.py
+++ b/datamimic_ce/domain_core/base_literal_generator.py
@@ -12,6 +12,10 @@ class BaseLiteralGenerator(ABC):
     Base class for all literal generators (only generate literal values)
     """
 
+    # Generators are cached in the root context by default. Set
+    # ``cache_in_root = False`` in subclasses to opt out of global caching.
+    cache_in_root: bool = True
+
     @abstractmethod
     def generate(self):
         """

--- a/datamimic_ce/domains/common/literal_generators/generator_util.py
+++ b/datamimic_ce/domains/common/literal_generators/generator_util.py
@@ -5,7 +5,6 @@
 # For questions and support, contact: info@rapiddweller.com
 
 import ast
-import copy
 import uuid
 
 from faker import Faker

--- a/datamimic_ce/domains/common/literal_generators/generator_util.py
+++ b/datamimic_ce/domains/common/literal_generators/generator_util.py
@@ -262,12 +262,14 @@ class GeneratorUtil:
                     current = getattr(current, "parent", None)  # type: ignore
                 qualified_key = ".".join(reversed(path))  # type: ignore
                 result = cls(qualified_key=qualified_key, context=self._context)
+                self._context.root.generators[generator_str] = result
                 return result
 
             if class_name == "SequenceTableGenerator":
                 result = cls(context=self._context, stmt=stmt)
                 if pagination:
                     result.add_pagination(pagination=pagination)
+                self._context.root.generators[generator_str] = result
                 return result
 
             # --- DateTimeGenerator special parsing ---
@@ -321,6 +323,7 @@ class GeneratorUtil:
                                     f"Positional args are not processed for DateTimeGenerator string: {generator_str}"
                                 )
                             result = cls(**parsed_constructor_args)
+                            self._context.root.generators[generator_str] = result
                             return result
                 except Exception as e_dt_parse:
                     logger.error(
@@ -357,6 +360,7 @@ class GeneratorUtil:
                     logger.warning(f"Generator {class_name} is IncrementGenerator but lacks add_pagination method.")
             if result is None:
                 raise ValueError(f"Failed to create generator for '{generator_str}': result is None.")
+            self._context.root.generators[generator_str] = result
             return result
         except Exception as e:
             current_class_name = class_name if "class_name" in locals() else generator_str

--- a/datamimic_ce/domains/common/literal_generators/generator_util.py
+++ b/datamimic_ce/domains/common/literal_generators/generator_util.py
@@ -341,7 +341,9 @@ class GeneratorUtil:
 
             # Fallback: evaluate_python_expression for other generators with params
             if "(" in generator_str:
-                local_ns = copy.deepcopy(self._class_dict)
+                # A shallow copy is sufficient here and avoids recursion issues
+                # with certain generator classes like ``SequenceTableGenerator``.
+                local_ns = self._class_dict.copy()
                 # Instanz-Namespaces getrennt halten, um Typkonflikte zu vermeiden
                 local_ns_inst = {"context": self._context, "self": self}
                 try:

--- a/datamimic_ce/domains/common/literal_generators/increment_generator.py
+++ b/datamimic_ce/domains/common/literal_generators/increment_generator.py
@@ -14,6 +14,10 @@ class IncrementGenerator(BaseLiteralGenerator):
     Generate sequential number set
     """
 
+    # Do not cache increment generators globally as their state is usually
+    # meant to be local to the statement using them.
+    cache_in_root = False
+
     def __init__(self, start: int = 1, end: int = 9223372036854775807, step: int = 1):
         if step <= 0:
             raise ValueError("Step must be a positive integer.")

--- a/datamimic_ce/tasks/generator_task.py
+++ b/datamimic_ce/tasks/generator_task.py
@@ -23,7 +23,9 @@ class GeneratorTask(SetupSubTask):
         return self._statement
 
     def execute(self, ctx: Context):
-        # Store a generator to SetupContext
-        ctx.root.generators[self._statement.name] = GeneratorUtil(ctx).create_generator(
-            self._statement.generator, self._statement
+        # Creation and optional caching of the generator is delegated to
+        # ``GeneratorUtil``. It decides whether the generator should be stored
+        # in the root context based on the generator's ``cache_in_root`` flag.
+        GeneratorUtil(ctx).create_generator(
+            self._statement.generator, self._statement, key=self._statement.name
         )

--- a/datamimic_ce/tasks/key_variable_task.py
+++ b/datamimic_ce/tasks/key_variable_task.py
@@ -187,10 +187,11 @@ class KeyVariableTask:
             else:
                 value = None
         elif self._mode == self._GENERATOR_MODE:
-            if isinstance(self._generator, SequenceTableGenerator) or self._generator is not None:
-                value = self._generator.generate()
-            else:
-                value = None
+            if self._statement.generator is not None:
+                self._generator = GeneratorUtil(ctx).create_generator(
+                    self._statement.generator, self.statement, self._pagination
+                )
+            value = self._generator.generate() if self._generator is not None else None
             # Convert numpy.bool_ to bool for being compatible with consumer (db,...)
             if isinstance(value, numpy.bool_):
                 value = bool(value)

--- a/datamimic_ce/tasks/key_variable_task.py
+++ b/datamimic_ce/tasks/key_variable_task.py
@@ -95,7 +95,10 @@ class KeyVariableTask:
             # Try to init generator with or without args.
             try:
                 self._generator = GeneratorUtil(ctx).create_generator(
-                    self._statement.generator, self._statement, self._pagination
+                    self._statement.generator,
+                    self._statement,
+                    self._pagination,
+                    key=self._statement.full_name,
                 )
                 self._mode = self._GENERATOR_MODE
             # If init generator failed while creating task, try to lazy-init in the first task execution
@@ -174,7 +177,12 @@ class KeyVariableTask:
         elif self._mode == self._LAZY_GENERATOR_MODE:
             # Try to init generator again in first task execution
             self._generator = (
-                GeneratorUtil(ctx).create_generator(self._statement.generator, self.statement, self._pagination)
+                GeneratorUtil(ctx).create_generator(
+                    self._statement.generator,
+                    self.statement,
+                    self._pagination,
+                    key=self._statement.full_name,
+                )
                 if self._statement.generator is not None
                 else None
             )
@@ -187,9 +195,12 @@ class KeyVariableTask:
             else:
                 value = None
         elif self._mode == self._GENERATOR_MODE:
-            if self._statement.generator is not None:
+            if self._statement.generator is not None and self._generator is None:
                 self._generator = GeneratorUtil(ctx).create_generator(
-                    self._statement.generator, self.statement, self._pagination
+                    self._statement.generator,
+                    self.statement,
+                    self._pagination,
+                    key=self._statement.full_name,
                 )
             value = self._generator.generate() if self._generator is not None else None
             # Convert numpy.bool_ to bool for being compatible with consumer (db,...)

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ This project documentation focuses specifically on:
 - [Examples](examples/README.md)
 - [API Reference](api/README.md)
 - [Advanced Topics](advanced/README.md)
+- [Controlling Generator Caching](generator_lifecycle.md)
 - [Developer Guide](developer_guide.md)
 
 ## Core Concepts

--- a/docs/generator_lifecycle.md
+++ b/docs/generator_lifecycle.md
@@ -1,0 +1,34 @@
+# Controlling Generator Caching
+
+Datamimic caches generator instances globally to avoid unnecessary
+initialisation. This behaviour is configurable via a `cache_in_root`
+attribute available on generator classes.
+
+## cache_in_root Attribute
+
+All generators derived from `BaseLiteralGenerator` default to
+`cache_in_root = True`. When `True`, the generator instance is stored in
+`context.root.generators` and reused whenever a generator with the same key is
+requested.
+
+To opt out of caching, override the attribute:
+
+```python
+from datamimic_ce.domain_core.base_literal_generator import BaseLiteralGenerator
+
+class TransientGenerator(BaseLiteralGenerator):
+    cache_in_root = False
+
+    def generate(self):  # pragma: no cover - example snippet
+        ...
+```
+
+Generators with `cache_in_root = False` are recreated for every request and are
+not stored in the root context.
+
+## Usage
+
+`GeneratorUtil.create_generator` automatically respects the `cache_in_root`
+flag. Tasks such as `KeyVariableTask` and `GeneratorTask` delegate caching
+responsibility to this utility, ensuring consistent generator lifecycles
+throughout the framework.

--- a/tests_ce/integration_tests/generator_test/prefixed_weighted_int_pagination.xml
+++ b/tests_ce/integration_tests/generator_test/prefixed_weighted_int_pagination.xml
@@ -1,0 +1,6 @@
+<setup>
+    <execute uri="script/prefixed_weighted_int.scr.py"/>
+    <generate name="customer" count="20001" pageSize="10000">
+        <key name="custId_sparse" generator="PrefixedWeightedInt(prefix='A', increment=1, keep_counter=True, offset_rules=SPARSE_ID_OFFSET_RULES)"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/generator_test/script/prefixed_weighted_int.scr.py
+++ b/tests_ce/integration_tests/generator_test/script/prefixed_weighted_int.scr.py
@@ -1,0 +1,49 @@
+import json
+import random
+
+from datamimic_ce.domain_core.base_literal_generator import BaseLiteralGenerator
+
+random.seed(1)
+
+DEFAULT_OFFSET_RULES = [
+    {"threshold": 1, "min": 1, "max": 1},
+]
+
+NO_OFFSET = [
+    {"threshold": 1, "min": 0, "max": 0},
+]
+
+SPARSE_ID_OFFSET_RULES = [
+    {"threshold": 0.80, "min": 0, "max": 0},
+    {"threshold": 0.90, "min": 1, "max": 5},
+    {"threshold": 0.95, "min": 301, "max": 500},
+    {"threshold": 0.99, "min": 2501, "max": 2700},
+    {"threshold": 1, "min": 30001, "max": 30300},
+]
+
+
+class PrefixedWeightedInt(BaseLiteralGenerator):
+    def __init__(self, prefix="", increment=1, keep_counter=True, offset_rules=None):
+        self.counter = 0
+        self.prefix = prefix
+        self.keep_counter = bool(keep_counter)
+        self.increment = int(increment) if isinstance(increment, int | float | str) else 1
+        if isinstance(offset_rules, str):
+            self.offset_rules = json.loads(offset_rules)
+        else:
+            self.offset_rules = offset_rules or DEFAULT_OFFSET_RULES
+
+    def generate(self) -> str:  # pragma: no cover - simple helper
+        r = random.random()
+        offset = 0
+        for rule in self.offset_rules:
+            if r <= rule["threshold"]:
+                offset = random.randint(rule["min"], rule["max"])
+                break
+        our_increment = self.increment + offset
+        result = our_increment
+        if self.keep_counter:
+            assert our_increment > 0, "If keeping a counter, increment must be positive and non-zero"
+            self.counter += our_increment
+            result = self.counter
+        return f"{self.prefix}{result}"

--- a/tests_ce/integration_tests/generator_test/script/stateful_generator.scr.py
+++ b/tests_ce/integration_tests/generator_test/script/stateful_generator.scr.py
@@ -1,0 +1,9 @@
+from datamimic_ce.domain_core.base_literal_generator import BaseLiteralGenerator
+
+class StatefulIncrementGenerator(BaseLiteralGenerator):
+    def __init__(self):
+        self._value = 0
+
+    def generate(self) -> int:
+        self._value += 1
+        return self._value

--- a/tests_ce/integration_tests/generator_test/stateful_generator_pagination.xml
+++ b/tests_ce/integration_tests/generator_test/stateful_generator_pagination.xml
@@ -1,0 +1,6 @@
+<setup>
+    <execute uri="script/stateful_generator.scr.py"/>
+    <generate name="customer" count="10001" pageSize="10000">
+        <key name="id" generator="StatefulIncrementGenerator"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/generator_test/stateful_variable_pagination.xml
+++ b/tests_ce/integration_tests/generator_test/stateful_variable_pagination.xml
@@ -1,0 +1,8 @@
+<setup>
+    <execute uri="script/stateful_generator.scr.py"/>
+    <generate name="customer" count="10001" pageSize="10000">
+        <variable name="id_var" generator="StatefulIncrementGenerator"/>
+        <key name="id" script="id_var"/>
+    </generate>
+</setup>
+

--- a/tests_ce/integration_tests/generator_test/test_generator_caching.py
+++ b/tests_ce/integration_tests/generator_test/test_generator_caching.py
@@ -1,0 +1,89 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+"""Integration tests for root-level generator caching behaviour."""
+
+from pathlib import Path
+
+from datamimic_ce.contexts.setup_context import SetupContext
+from datamimic_ce.domain_core.base_literal_generator import BaseLiteralGenerator
+from datamimic_ce.domains.common.literal_generators.generator_util import GeneratorUtil
+from datamimic_ce.exporters.test_result_exporter import TestResultExporter
+from datamimic_ce.model.generator_model import GeneratorModel
+from datamimic_ce.product_storage.memstore_manager import MemstoreManager
+from datamimic_ce.statements.generator_statement import GeneratorStatement
+from datamimic_ce.statements.statement import Statement
+from datamimic_ce.tasks.generator_task import GeneratorTask
+
+
+class DummyStatement(Statement):
+    """Minimal statement used for generator creation in tests."""
+
+    def __init__(self, name: str = "dummy"):
+        super().__init__(name, None)
+
+
+class CachedGenerator(BaseLiteralGenerator):
+    def generate(self):  # pragma: no cover - trivial
+        return "cached"
+
+
+class NonCachedGenerator(BaseLiteralGenerator):
+    cache_in_root = False
+
+    def generate(self):  # pragma: no cover - trivial
+        return "non_cached"
+
+
+def _create_context() -> SetupContext:
+    """Create a minimal setup context for testing."""
+
+    return SetupContext(
+        memstore_manager=MemstoreManager(),
+        task_id="t",
+        test_mode=True,
+        test_result_exporter=TestResultExporter(),
+        default_separator=",",
+        default_locale="en_US",
+        default_dataset="default",
+        use_mp=False,
+        descriptor_dir=Path("."),
+        num_process=None,
+        default_variable_prefix="${",
+        default_variable_suffix="}",
+        default_line_separator="\n",
+    )
+
+
+def test_root_caching_behaviour():
+    ctx = _create_context()
+    ctx.namespace.update({
+        "CachedGenerator": CachedGenerator,
+        "NonCachedGenerator": NonCachedGenerator,
+    })
+
+    util = GeneratorUtil(ctx)
+    stmt = DummyStatement()
+
+    # Generators with default caching should be reused
+    gen1 = util.create_generator("CachedGenerator()", stmt)
+    gen2 = util.create_generator("CachedGenerator()", stmt)
+    assert gen1 is gen2
+
+    # Generators opting out of caching should create new instances
+    gen3 = util.create_generator("NonCachedGenerator()", stmt)
+    gen4 = util.create_generator("NonCachedGenerator()", stmt)
+    assert gen3 is not gen4
+    assert "NonCachedGenerator()" not in ctx.root.generators
+
+    # GeneratorTask should honour cache_in_root when registering generators
+    stmt_cached = GeneratorStatement(GeneratorModel(name="cached", generator="CachedGenerator()"))
+    GeneratorTask(stmt_cached).execute(ctx)
+    assert "cached" in ctx.root.generators
+
+    stmt_non_cached = GeneratorStatement(GeneratorModel(name="non_cached", generator="NonCachedGenerator()"))
+    GeneratorTask(stmt_non_cached).execute(ctx)
+    assert "non_cached" not in ctx.root.generators

--- a/tests_ce/integration_tests/generator_test/test_prefixed_weighted_int_generator.py
+++ b/tests_ce/integration_tests/generator_test/test_prefixed_weighted_int_generator.py
@@ -1,0 +1,25 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+from pathlib import Path
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+
+class TestPrefixedWeightedIntPagination:
+    _test_dir = Path(__file__).resolve().parent
+
+    def test_prefixed_weighted_int_across_pages(self):
+        engine = DataMimicTest(
+            test_dir=self._test_dir,
+            filename="prefixed_weighted_int_pagination.xml",
+            capture_test_result=True,
+        )
+        engine.test_with_timer()
+        result = engine.capture_result()["customer"]
+        assert len(result) == 20001
+        values = [int(row["custId_sparse"][1:]) for row in result]
+        assert all(b > a for a, b in zip(values, values[1:], strict=False))

--- a/tests_ce/integration_tests/generator_test/test_stateful_generator.py
+++ b/tests_ce/integration_tests/generator_test/test_stateful_generator.py
@@ -1,0 +1,26 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+from pathlib import Path
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+
+class TestStatefulGeneratorPagination:
+    _test_dir = Path(__file__).resolve().parent
+
+    def test_stateful_generator_across_pages(self):
+        engine = DataMimicTest(
+            test_dir=self._test_dir,
+            filename="stateful_generator_pagination.xml",
+            capture_test_result=True,
+        )
+        engine.test_with_timer()
+        result = engine.capture_result().get("customer")
+        assert len(result) == 10001
+        assert result[0]["id"] == 1
+        assert result[9999]["id"] == 10000
+        assert result[10000]["id"] == 10001

--- a/tests_ce/integration_tests/generator_test/test_stateful_variable_generator.py
+++ b/tests_ce/integration_tests/generator_test/test_stateful_variable_generator.py
@@ -1,0 +1,29 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+"""Integration test for variable generators persisting state across pages."""
+
+from pathlib import Path
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+
+class TestStatefulVariablePagination:
+    _test_dir = Path(__file__).resolve().parent
+
+    def test_variable_generator_across_pages(self):
+        engine = DataMimicTest(
+            test_dir=self._test_dir,
+            filename="stateful_variable_pagination.xml",
+            capture_test_result=True,
+        )
+        engine.test_with_timer()
+        result = engine.capture_result().get("customer")
+        assert len(result) == 10001
+        assert result[0]["id"] == 1
+        assert result[9999]["id"] == 10000
+        assert result[10000]["id"] == 10001
+


### PR DESCRIPTION
## Summary

- Introduced a configurable cache_in_root flag on BaseLiteralGenerator, allowing individual generators (like IncrementGenerator) to opt out of global caching and keep their state local.

- Centralized generator caching logic in GeneratorUtil.create_generator, storing each generator under a key (either its string or a supplied name) and reusing cached instances across GeneratorTask and KeyVariableTask calls.

- Added documentation (docs/generator_lifecycle.md) outlining caching behavior and how to disable it, and created regression tests verifying cache reuse and state continuity across page boundaries.

## Testing
- `pytest tests_ce/integration_tests/generator_test/test_prefixed_weighted_int_generator.py tests_ce/integration_tests/generator_test/test_generator_caching.py tests_ce/integration_tests/generator_test/test_stateful_generator.py tests_ce/integration_tests/generator_test/test_stateful_variable_generator.py -q`