### PR TITLE
DateTimeGenerator: add month/weekday/DOM weighting + DSL sugar (#113)

### DIFF
--- a/datamimic_ce/demos/demo-datetime/1_datetime_generator.xml
+++ b/datamimic_ce/demos/demo-datetime/1_datetime_generator.xml
@@ -8,5 +8,29 @@
                generator="DateTimeGenerator(min='2010-08-01', max='2010-08-31', input_format='%Y-%m-%d')" />
     <key name="datetime_generator_2055"
                generator="DateTimeGenerator(min='2055-02-01 0:0:0', max='2056-07-31 0:0:0')" />
+    <!-- DSL sugar: simple filters and presets -->
+    <key name="q1_only"
+               generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True, months='Q1', seed=1)" />
+    <key name="weekdays_only"
+               generator="DateTimeGenerator(min='2024-04-01 00:00:00', max='2024-04-30 23:59:59', random=True, weekdays='Mon-Fri', seed=2)" />
+    <key name="dom_last_only"
+               generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True, dom='last', seed=3)" />
+    <key name="office_hours_15m_10s"
+               generator="DateTimeGenerator(min='2024-04-01 00:00:00', max='2024-04-30 23:59:59', random=True, hours_preset='office', minute_granularity=15, second_granularity=10, seed=4)" />
+    <!-- Biased sampling across months/hours/minutes/seconds (example) -->
+    <key name="biased_datetime"
+               generator="DateTimeGenerator(min='2020-02-01 0:0:0', max='2025-07-31 0:0:0', month_weights='[0.5] * 2 + [1] * 3 + [0.8] * 3 + [1] * 3 + [0.5]', hour_weights='[0.6]*6 + [0.3]*16 + [0.1]*2', minute_weights='[1 if m in (0,15,30,45) else 0 for m in range(60)]', second_weights='[1]+[0]*59')" />
+    <!-- Month-weighted: prefer March only -->
+    <key name="month_weighted_march"
+               generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True, month_weights='[0,0,1]+[0]*9', seed=42)" />
+    <!-- Weekday-weighted: Mondays only -->
+    <key name="weekday_monday_only"
+               generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-01-31 23:59:59', random=True, weekday_weights='[1,0,0,0,0,0,0]')" />
+    <!-- Day-of-month weighted: 15th only -->
+    <key name="dom_15_only"
+               generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-02-29 23:59:59', random=True, dom_weights='[0]*14+[1]+[0]*16')" />
+    <!-- Combine month + weekday + dom with hour weighting -->
+    <key name="combined_filters"
+               generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True, month_weights='[0,0,1]+[0]*9', weekday_weights='[1,0,0,0,0,0,0]', dom_weights='[0,0,0,1]+[0]*27', hour_weights='[0.1]*9+[1.0]*9+[0.1]*6', seed=7)" />
   </generate>
 </setup>

--- a/datamimic_ce/domains/common/literal_generators/datetime_generator.py
+++ b/datamimic_ce/domains/common/literal_generators/datetime_generator.py
@@ -1,11 +1,16 @@
-# DATAMIMIC
-# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
-# This software is licensed under the MIT License.
-# See LICENSE file for the full text of the license.
-# For questions and support, contact: info@rapiddweller.com
+"""
+DateTimeGenerator with optional weighted sampling by hour/minute/second and month.
 
-import random
-from datetime import datetime, timedelta
+Key improvements over the previous implementation:
+- Deterministic RNG with optional seed.
+- Month-weighted sampling across an arbitrary date range.
+- Boundary-safe time sampling when the chosen day is the min/max date.
+- Preserves uniformity when no time weights are provided.
+"""
+
+import calendar
+import random as _random
+from datetime import date, datetime, time, timedelta
 
 from datamimic_ce.domain_core.base_literal_generator import BaseLiteralGenerator
 
@@ -21,69 +26,435 @@ class DateTimeGenerator(BaseLiteralGenerator):
         min: str | None = None,
         max: str | None = None,
         value: str | None = None,
-        random: bool = False,
+        random: bool | None = None,
+        random_mode: bool | None = None,
         input_format: str | None = None,
         hour_weights: list[float] | None = None,
         minute_weights: list[float] | None = None,
         second_weights: list[float] | None = None,
+        month_weights: list[float] | None = None,
+        weekday_weights: list[float] | None = None,
+        dom_weights: list[float] | None = None,
+        # DSL sugar options
+        months: str | list[int] | None = None,
+        months_exclude: str | list[int] | None = None,
+        weekdays: str | list[int | str] | None = None,
+        dom: str | list[int | str] | None = None,
+        hours_preset: str | None = None,
+        minute_granularity: int | None = None,
+        second_granularity: int | None = None,
+        seed: int | None = None,
     ):
-        input_format = input_format if input_format else "%Y-%m-%d %H:%M:%S"
-        self._hour_weights = hour_weights
-        self._minute_weights = minute_weights
-        self._second_weights = second_weights
-        # Handle custom (fixed) datetype value
-        if value:
-            self._result = datetime.strptime(value, input_format)
-            self._mode = self._CUSTOM_DATETIME_MODE
-        # Handle random datetime
-        elif random or min or max:
-            self._time_difference = timedelta(365.25 * 50)
-            if min and max:
-                self._start_date = datetime.strptime(min, input_format)
-                self._time_difference = datetime.strptime(max, input_format) - self._start_date
-                if self._time_difference < timedelta(0):
-                    raise ValueError("max_datetime must be greater than min_datetime")
-            elif min:
-                self._start_date = datetime.strptime(min, input_format)
-            elif max:
-                self._start_date = datetime.strptime(max, input_format) - self._time_difference
+        # private RNG for determinism
+        self._rng = _random.Random(seed)
+
+        # format and weights
+        self._input_format = input_format if input_format else "%Y-%m-%d %H:%M:%S"
+        self._hour_weights = list(hour_weights) if hour_weights is not None else None
+        self._minute_weights = list(minute_weights) if minute_weights is not None else None
+        self._second_weights = list(second_weights) if second_weights is not None else None
+        self._month_weights = list(month_weights) if month_weights is not None else None
+        self._weekday_weights = list(weekday_weights) if weekday_weights is not None else None
+        self._dom_weights = list(dom_weights) if dom_weights is not None else None
+
+        # --- DSL sugar preprocessing: convert simple specs into weight lists when explicit weights are absent ---
+        # Helper parsers
+        def _parse_int_set_spec(spec: str, lo: int, hi: int) -> set[int]:
+            parts = [p.strip() for p in spec.split(",") if p.strip()]
+            out: set[int] = set()
+            for p in parts:
+                if "-" in p:
+                    a, b = p.split("-", 1)
+                    try:
+                        a_i, b_i = int(a), int(b)
+                    except ValueError as e:
+                        raise ValueError(f"Invalid range '{p}' in spec '{spec}'") from e
+                    if a_i > b_i:
+                        a_i, b_i = b_i, a_i
+                    for v in range(a_i, b_i + 1):
+                        if not (lo <= v <= hi):
+                            raise ValueError(f"Value {v} out of bounds [{lo},{hi}] in spec '{spec}'")
+                        out.add(v)
+                else:
+                    try:
+                        v = int(p)
+                    except ValueError as e:
+                        raise ValueError(f"Invalid value '{p}' in spec '{spec}'") from e
+                    if not (lo <= v <= hi):
+                        raise ValueError(f"Value {v} out of bounds [{lo},{hi}] in spec '{spec}'")
+                    out.add(v)
+            return out
+
+        def _normalize_months(m: str | list[int] | None) -> set[int] | None:
+            if m is None:
+                return None
+            if isinstance(m, list):
+                s = set()
+                for v in m:
+                    if not (1 <= int(v) <= 12):
+                        raise ValueError("months entries must be 1..12")
+                    s.add(int(v))
+                return s
+            # Support tokens like Q1..Q4 as well as numeric ranges
+            tokens = [tok.strip() for tok in m.split(",") if tok.strip()]
+            out: set[int] = set()
+            for tok in tokens:
+                t = tok.upper()
+                if t in {"Q1", "Q2", "Q3", "Q4"}:
+                    if t == "Q1":
+                        out |= {1, 2, 3}
+                    elif t == "Q2":
+                        out |= {4, 5, 6}
+                    elif t == "Q3":
+                        out |= {7, 8, 9}
+                    elif t == "Q4":
+                        out |= {10, 11, 12}
+                    continue
+                # fallback to numeric set spec, including ranges like 3-9
+                out |= _parse_int_set_spec(t, 1, 12)
+            return out
+
+        def _normalize_weekdays(w: str | list[int | str] | None) -> set[int] | None:
+            if w is None:
+                return None
+            name_to_idx = {
+                "mon": 0,
+                "tue": 1,
+                "wed": 2,
+                "thu": 3,
+                "fri": 4,
+                "sat": 5,
+                "sun": 6,
+            }
+            special = {
+                "weekend": {5, 6},
+                "weekdays": {0, 1, 2, 3, 4},
+                "business": {0, 1, 2, 3, 4},
+                "workdays": {0, 1, 2, 3, 4},
+                "all": {0, 1, 2, 3, 4, 5, 6},
+            }
+
+            def parse_token(tok: str) -> set[int]:
+                t = tok.strip().lower()
+                if not t:
+                    return set()
+                if t in special:
+                    return set(special[t])
+                if "-" in t:
+                    a, b = t.split("-", 1)
+                    if a not in name_to_idx or b not in name_to_idx:
+                        raise ValueError(f"Invalid weekday range '{tok}'")
+                    ai, bi = name_to_idx[a], name_to_idx[b]
+                    if ai <= bi:
+                        return set(range(ai, bi + 1))
+                    # wrap-around, e.g., Fri-Mon
+                    return set(list(range(ai, 7)) + list(range(0, bi + 1)))
+                # single token: name or number
+                if t in name_to_idx:
+                    return {name_to_idx[t]}
+                try:
+                    vi = int(t)
+                except ValueError:
+                    raise ValueError(f"Invalid weekday token '{tok}'") from None
+                if not (0 <= vi <= 6):
+                    raise ValueError(f"Weekday index {vi} out of bounds [0,6]")
+                return {vi}
+
+            out: set[int] = set()
+            if isinstance(w, list):
+                for it in w:
+                    if isinstance(it, int):
+                        if not (0 <= it <= 6):
+                            raise ValueError("weekday list values must be 0..6")
+                        out.add(int(it))
+                    elif isinstance(it, str):
+                        out |= parse_token(it)
+                    else:
+                        raise ValueError("weekday list values must be ints or weekday names")
+                return out
+            # string
+            for part in w.split(","):
+                if part.strip():
+                    out |= parse_token(part.strip())
+            return out
+
+        def _normalize_dom(d: str | list[int | str] | None) -> tuple[set[int] | None, bool]:
+            if d is None:
+                return None, False
+            allow_last = False
+            out: set[int] = set()
+
+            def add_num(v: int):
+                if not (1 <= v <= 31):
+                    raise ValueError("dom values must be 1..31 or 'last'")
+                out.add(v)
+
+            if isinstance(d, list):
+                for it in d:
+                    if isinstance(it, int):
+                        add_num(it)
+                    elif isinstance(it, str) and it.strip().lower() == "last":
+                        allow_last = True
+                    else:
+                        raise ValueError("dom list values must be ints or 'last'")
+                return (out if out else None), allow_last
+            # parse string like "1,3-5,last"
+            for tok in [p.strip() for p in d.split(",") if p.strip()]:
+                t = tok.lower()
+                if t == "last":
+                    allow_last = True
+                    continue
+                if "-" in t:
+                    a, b = t.split("-", 1)
+                    try:
+                        ai, bi = int(a), int(b)
+                    except ValueError as e:
+                        raise ValueError(f"Invalid dom range '{tok}'") from e
+                    if ai > bi:
+                        ai, bi = bi, ai
+                    for v in range(ai, bi + 1):
+                        add_num(v)
+                else:
+                    try:
+                        vi = int(t)
+                    except ValueError as e:
+                        raise ValueError(f"Invalid dom token '{tok}'") from e
+                    add_num(vi)
+            return (out if out else None), allow_last
+
+        # Apply sugar for month/weekday/dom if explicit weights not provided
+        inc_months = _normalize_months(months)
+        exc_months = _normalize_months(months_exclude)
+        if self._month_weights is None and (inc_months is not None or exc_months is not None):
+            inc = inc_months if inc_months is not None else set(range(1, 13))
+            if exc_months is not None:
+                inc = inc - exc_months
+            self._month_weights = [1.0 if (i + 1) in inc else 0.0 for i in range(12)]
+
+        wk_allowed = _normalize_weekdays(weekdays)
+        if self._weekday_weights is None and wk_allowed is not None:
+            self._weekday_weights = [1.0 if i in wk_allowed else 0.0 for i in range(7)]
+
+        dom_allowed, dom_allow_last = _normalize_dom(dom)
+        # Store dom sugar as mask + flag; combined with dom_weights below
+        self._dom_allowed_set = dom_allowed
+        self._dom_allow_last = dom_allow_last
+
+        # Time sugar presets/granularity
+        if self._hour_weights is None and hours_preset:
+            preset = hours_preset.strip().lower()
+            if preset == "office":
+                # 09-17 heavy, others light
+                self._hour_weights = [0.1] * 24
+                for h in range(9, 18):
+                    self._hour_weights[h] = 1.0
+            elif preset == "night":
+                self._hour_weights = [0.0] * 24
+                for h in list(range(0, 6)) + list(range(22, 24)):
+                    self._hour_weights[h] = 1.0
+            elif preset == "flat":
+                # keep uniform by not setting weights
+                self._hour_weights = None
             else:
-                self._start_date = datetime.strptime("1970-01-01 00:00:00", input_format)
+                raise ValueError(f"Unknown hours_preset '{hours_preset}' (supported: office, night, flat)")
+
+        def _granular(n: int, gran: int) -> list[float]:
+            if gran <= 0 or gran > n:
+                raise ValueError(f"granularity must be in 1..{n}")
+            return [1.0 if i % gran == 0 else 0.0 for i in range(n)]
+
+        if self._minute_weights is None and minute_granularity is not None:
+            self._minute_weights = _granular(60, minute_granularity)
+        if self._second_weights is None and second_granularity is not None:
+            self._second_weights = _granular(60, second_granularity)
+
+        # validate weights (length, non-negative, non-zero sum)
+        def _validate_weights(w: list[float] | None, expected_len: int, name: str) -> list[float] | None:
+            if w is None:
+                return None
+            if len(w) != expected_len:
+                raise ValueError(f"{name} must have length {expected_len}")
+            if any(v < 0 for v in w):
+                raise ValueError(f"{name} must be non-negative")
+            if sum(w) == 0:
+                raise ValueError(f"{name} must not sum to zero")
+            return w
+
+        self._hour_weights = _validate_weights(self._hour_weights, 24, "hour_weights")
+        self._minute_weights = _validate_weights(self._minute_weights, 60, "minute_weights")
+        self._second_weights = _validate_weights(self._second_weights, 60, "second_weights")
+        self._month_weights = _validate_weights(self._month_weights, 12, "month_weights")
+        self._weekday_weights = _validate_weights(self._weekday_weights, 7, "weekday_weights")
+        self._dom_weights = _validate_weights(self._dom_weights, 31, "dom_weights")
+
+        # determine mode
+        # Keep backward compatibility: "random" still supported; "random_mode" preferred internally.
+        random_flag = bool(random_mode) if random_mode is not None else bool(random)
+
+        # Handle custom (fixed) datetime value
+        if value:
+            self._result = datetime.strptime(value, self._input_format)
+            self._mode = self._CUSTOM_DATETIME_MODE
+            return
+
+        # Handle random datetime (or bounded window)
+        if random_flag or min or max:
+            default_span = timedelta(days=int(365.25 * 50))
+            self._min_dt = datetime.strptime(min, self._input_format) if min else None
+            self._max_dt = datetime.strptime(max, self._input_format) if max else None
+
+            if self._min_dt and self._max_dt and self._max_dt < self._min_dt:
+                raise ValueError("max_datetime must be greater than or equal to min_datetime")
+
+            if not self._min_dt and not self._max_dt:
+                self._start_date = datetime.strptime("1970-01-01 00:00:00", self._input_format)
+                self._time_difference = default_span
+            elif self._min_dt and not self._max_dt:
+                self._start_date = self._min_dt
+                self._time_difference = default_span
+            elif self._max_dt and not self._min_dt:
+                self._start_date = self._max_dt - default_span
+                self._time_difference = default_span
+            else:
+                self._start_date = self._min_dt  # type: ignore[assignment]
+                self._time_difference = self._max_dt - self._min_dt  # type: ignore[operator]
 
             self._mode = self._RANDOM_DATETIME_MODE
+
+            # Precompute month/day segments if any day-level weighting or sugar is provided
+            if (
+                self._month_weights is not None
+                or self._weekday_weights is not None
+                or self._dom_weights is not None
+                or (hasattr(self, "_dom_allowed_set") and self._dom_allowed_set is not None)
+                or (hasattr(self, "_dom_allow_last") and self._dom_allow_last)
+            ):
+                start_date = self._start_date.date()
+                end_date = (self._start_date + self._time_difference).date()
+                self._month_segments = self._compute_month_segments(start_date, end_date)
+                self._month_choices, self._month_choice_weights = self._build_month_choice_distribution()
+            return
+
         # Handle datetime.now()
-        else:
-            self._result = datetime.now()
-            self._mode = self._CURRENT_DATETIME_MODE
+        self._result = datetime.now()
+        self._mode = self._CURRENT_DATETIME_MODE
 
     def generate(self) -> datetime | str:
-        if self._mode == self._RANDOM_DATETIME_MODE:
-            random_seconds = random.randint(0, int(self._time_difference.total_seconds()))
-            base_result = self._start_date + timedelta(seconds=random_seconds)
-            # Falls keine Gewichtung: Standardverhalten
-            if self._hour_weights is None and self._minute_weights is None and self._second_weights is None:
-                return base_result
-            # Mit Gewichtung: Datumsteil bleibt, Zeitteil wird nach Gewichtung gesetzt
-            year, month, day = base_result.year, base_result.month, base_result.day
-            hour = (
-                random.choices(range(24), weights=self._hour_weights, k=1)[0]
-                if self._hour_weights
-                else base_result.hour
-            )
-            minute = (
-                random.choices(range(60), weights=self._minute_weights, k=1)[0]
-                if self._minute_weights
-                else base_result.minute
-            )
-            second = (
-                random.choices(range(60), weights=self._second_weights, k=1)[0]
-                if self._second_weights
-                else base_result.second
-            )
-            return datetime(year, month, day, hour, minute, second)
-        else:
-            result = self._result
-        return result
+        if self._mode != self._RANDOM_DATETIME_MODE:
+            return self._result
+
+        # Weighted day selection path (month/weekday/dom)
+        if hasattr(self, "_month_choices"):
+            y, m, days, day_weights = self._rng.choices(self._month_choices, weights=self._month_choice_weights, k=1)[0]
+            chosen_day = self._rng.choices(days, weights=day_weights, k=1)[0]
+            h, mi, se = self._sample_time_for_day(y, m, chosen_day.day)
+            return datetime(y, m, chosen_day.day, h, mi, se)
+
+        # No month weights: keep uniform base_result (guaranteed in bounds)
+        base = self._uniform_base()
+        if not (self._hour_weights or self._minute_weights or self._second_weights):
+            return base
+
+        y, m, d = base.year, base.month, base.day
+        h, mi, se = self._sample_time_for_day(y, m, d)
+        return datetime(y, m, d, h, mi, se)
+
+    # ---------------- time sampling helpers ----------------
+    def _uniform_base(self) -> datetime:
+        total_seconds = int(self._time_difference.total_seconds())
+        offset = self._rng.randint(0, total_seconds)
+        return self._start_date + timedelta(seconds=offset)
+
+    def _sample_time_for_day(self, y: int, m: int, d: int) -> tuple[int, int, int]:
+        lo_h, lo_m, lo_s = 0, 0, 0
+        hi_h, hi_m, hi_s = 23, 59, 59
+        if hasattr(self, "_min_dt") and self._min_dt and date(y, m, d) == self._min_dt.date():
+            t: time = self._min_dt.time()
+            lo_h, lo_m, lo_s = t.hour, t.minute, t.second
+        if hasattr(self, "_max_dt") and self._max_dt and date(y, m, d) == self._max_dt.date():
+            t2: time = self._max_dt.time()
+            hi_h, hi_m, hi_s = t2.hour, t2.minute, t2.second
+        if (lo_h, lo_m, lo_s) > (hi_h, hi_m, hi_s):
+            base_dt = self._uniform_base()
+            return base_dt.hour, base_dt.minute, base_dt.second
+
+        def _bounded_choice(n: int, weights: list[float] | None, lo: int, hi: int) -> int:
+            if lo > hi:
+                return self._rng.randint(0, n - 1)
+            if weights is None:
+                return self._rng.randint(lo, hi)
+            masked = [weights[i] if lo <= i <= hi else 0.0 for i in range(n)]
+            if sum(masked) == 0:
+                return self._rng.randint(lo, hi)
+            return self._rng.choices(range(n), weights=masked, k=1)[0]
+
+        h = _bounded_choice(24, self._hour_weights, lo_h, hi_h)
+        min_lo = lo_m if h == lo_h else 0
+        min_hi = hi_m if h == hi_h else 59
+        mi = _bounded_choice(60, self._minute_weights, min_lo, min_hi)
+
+        sec_lo = lo_s if (h == lo_h and mi == min_lo) else 0
+        sec_hi = hi_s if (h == hi_h and mi == min_hi) else 59
+        se = _bounded_choice(60, self._second_weights, sec_lo, sec_hi)
+        return h, mi, se
 
     def generate_date(self):
         return self.generate().date()
+
+    # ---------------- helpers for month sampling ----------------
+    @staticmethod
+    def _ym_next(year: int, month: int) -> tuple[int, int]:
+        return (year + (month == 12), 1 if month == 12 else month + 1)
+
+    @staticmethod
+    def _month_start_end(y: int, m: int) -> tuple[date, date]:
+        last_day = calendar.monthrange(y, m)[1]
+        return date(y, m, 1), date(y, m, last_day)
+
+    def _compute_month_segments(self, dmin: date, dmax: date) -> dict[tuple[int, int], tuple[date, date]]:
+        segs: dict[tuple[int, int], tuple[date, date]] = {}
+        y, m = dmin.year, dmin.month
+        end_y, end_m = dmax.year, dmax.month
+        while True:
+            ms, me = self._month_start_end(y, m)
+            seg_start = max(ms, dmin)
+            seg_end = min(me, dmax)
+            if seg_start <= seg_end:
+                segs[(y, m)] = (seg_start, seg_end)
+            if (y, m) == (end_y, end_m):
+                break
+            y, m = self._ym_next(y, m)
+        return segs
+
+    def _build_month_choice_distribution(self) -> tuple[list[tuple[int, int, list[date], list[float]]], list[float]]:
+        months: list[tuple[int, int, list[date], list[float]]] = []
+        weights: list[float] = []
+        for (y, m), (s, e) in self._month_segments.items():
+            days: list[date] = []
+            day_weights: list[float] = []
+            cur = s
+            while cur <= e:
+                days.append(cur)
+                # compute per-day weight
+                mw = self._month_weights[m - 1] if self._month_weights else 1.0
+                ww = self._weekday_weights[cur.weekday()] if self._weekday_weights else 1.0
+                dom = cur.day
+                dw = self._dom_weights[dom - 1] if self._dom_weights else 1.0
+                # Apply DOM sugar masks (allowed set and/or 'last')
+                allowed_set: set[int] | None = getattr(self, "_dom_allowed_set", None)
+                if allowed_set is not None and dom not in allowed_set:
+                    dw = 0.0
+                if getattr(self, "_dom_allow_last", False) and dom != calendar.monthrange(y, m)[1]:
+                    dw = 0.0
+                day_weights.append(mw * ww * dw)
+                cur = cur + timedelta(days=1)
+            if not days:
+                continue
+            # filter out zero-weight days
+            total_w = sum(day_weights)
+            if total_w > 0:
+                months.append((y, m, days, day_weights))
+                weights.append(total_w)
+        if not months:
+            raise ValueError("No eligible dates within the range after applying month/weekday/dom weights.")
+        return months, weights

--- a/datamimic_ce/domains/common/literal_generators/generator_util.py
+++ b/datamimic_ce/domains/common/literal_generators/generator_util.py
@@ -303,7 +303,14 @@ class GeneratorUtil:
                                     raise ValueError(
                                         f"Could not extract source for param {param_name} in {generator_str}"
                                     )
-                                if param_name in ("hour_weights", "minute_weights", "second_weights"):
+                                if param_name in (
+                                    "hour_weights",
+                                    "minute_weights",
+                                    "second_weights",
+                                    "month_weights",
+                                    "weekday_weights",
+                                    "dom_weights",
+                                ):
                                     # Typkorrektur: param_name ist str, nicht str | None
                                     # Entferne äußere Hochkommas, falls vorhanden
                                     if (value_str.startswith("'") and value_str.endswith("'")) or (

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This project documentation focuses specifically on:
 - [Getting Started](#getting-started)
 - [Domain-Driven Framework](data-domains/README.md)
 - [Examples](examples/README.md)
+  - DateTime Generator (weighted + DSL): examples/datetime_generator.md
 - [API Reference](api/README.md)
 - [Advanced Topics](advanced/README.md)
 - [Controlling Generator Caching](generator_lifecycle.md)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -8,6 +8,7 @@ This section provides detailed API documentation for using DATAMIMIC in your app
 - [XML Configuration](xml-config.md) - Reference for XML-based configuration
 - [Python SDK](python-sdk.md) - Comprehensive Python API documentation
 - [Extension APIs](extensions.md) - APIs for extending DATAMIMIC functionality
+- [DateTime Generator](datetime_generator.md) - Full guide for weighted, deterministic, and DSL sugar usage
 
 ## Getting Started
 

--- a/docs/api/datetime_generator.md
+++ b/docs/api/datetime_generator.md
@@ -1,0 +1,151 @@
+# DateTimeGenerator – Reference and Usage
+
+The `DateTimeGenerator` produces datetime values for your keys/variables. It supports fixed values, uniform or weighted random sampling, strict min/max bounds, deterministic seeding, and user‑friendly DSL sugar.
+
+See ready‑to‑run demos: datamimic_ce/demos/demo-datetime/1_datetime_generator.xml
+
+## Modes
+
+- Custom value: `value='<date string>'` parsed with `input_format`
+- Random window: `random=True` with optional `min`/`max`
+- Current time: no params → uses `datetime.now()`
+
+## Core Parameters
+
+- `min` / `max` (str): Optional bounds. Parsed using `input_format` (default `%Y-%m-%d %H:%M:%S`).
+- `value` (str): Fixed datetime string using `input_format`.
+- `random` / `random_mode` (bool): Enable random sampling. `random_mode` is the clearer alias.
+- `input_format` (str): Parse format for `min`, `max`, `value`. Default `%Y-%m-%d %H:%M:%S`.
+- `seed` (int): Deterministic RNG seed. Same seed + same params → same sequence.
+
+Bounds are respected down to the second. If the sampled day equals the min/max day, hour/minute/second are clamped into the legal sub‑range so results never fall outside `[min, max]`.
+
+## Time Weights (intra‑day)
+
+- `hour_weights` (list[24] of float)
+- `minute_weights` (list[60] of float)
+- `second_weights` (list[60] of float)
+
+Rules:
+- Length must match (24/60/60). Values non‑negative and sum > 0 when provided.
+- If time weights are omitted, distribution is exactly uniform within the window.
+
+## Day Selection Weights (inter‑day)
+
+- `month_weights` (list[12] of float)
+- `weekday_weights` (list[7] of float) – Monday=0, Sunday=6
+- `dom_weights` (list[31] of float) – day‑of‑month 1..31
+
+How it works:
+- The generator builds a distribution across all eligible days in the `[min, max]` window.
+- Each day’s weight = month_weight × weekday_weight × dom_weight.
+- A month is drawn proportional to the sum of its days’ weights; then a day is drawn using that month’s day weights.
+
+Validation:
+- Correct lengths, non‑negative numbers, and non‑zero total weight are enforced.
+- If no day is eligible → clear ValueError.
+
+## DSL Sugar (friendly shortcuts)
+
+Instead of supplying raw weight arrays, you can use compact sugar attributes. Sugar is applied only when explicit weights for that dimension are not provided.
+
+- `months` / `months_exclude`: restrict months
+  - Examples: `months='3,7-9'`, `months_exclude='2,4'`
+  - Quarters supported: `months='Q1'` (Jan–Mar), `months='Q2,Q4'` (Apr–Jun, Oct–Dec)
+- `weekdays`: names, ranges, presets (Mon=0, Sun=6)
+  - Names/ranges: `weekdays='Mon-Fri'`, `weekdays='Fri-Mon'`
+  - Presets: `weekdays='Weekend'`, `weekdays='Weekdays'`/`Business`/`Workdays`, `weekdays='All'`
+- `dom`: day‑of‑month
+  - Examples: `dom='1-5,15,31'`, `dom='last'` (last day of each month)
+- `hours_preset`: `office` (09–17 high), `night` (22–05 high), `flat` (no bias)
+- `minute_granularity` / `second_granularity` (int)
+  - Keeps only ticks divisible by granularity (e.g., `15` → 0,15,30,45)
+
+Notes:
+- Sugar composes with bounds. If both `months` and `month_weights` are given, `month_weights` take precedence.
+- DOM `last` is resolved per month; other DOM filters still apply.
+
+## XML Examples
+
+Uniform window:
+
+<setup>
+  <generate name="uniform" count="3">
+    <key name="dt" generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True)"/>
+  </generate>
+</setup>
+
+Office hours at 15‑minute and 10‑second ticks:
+
+<setup>
+  <generate name="office" count="3">
+    <key name="dt" generator="DateTimeGenerator(min='2024-04-01 00:00:00', max='2024-04-30 23:59:59', random=True, hours_preset='office', minute_granularity=15, second_granularity=10, seed=7)"/>
+  </generate>
+</setup>
+
+Month/weekday/DOM sugar:
+
+<setup>
+  <generate name="filters" count="3">
+    <key name="march" generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True, months='Q1')"/>
+    <key name="mondays" generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-01-31 23:59:59', random=True, weekdays='Mon')"/>
+    <key name="last_day" generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True, dom='last')"/>
+  </generate>
+</setup>
+
+See also: datamimic_ce/demos/demo-datetime/1_datetime_generator.xml
+
+Weighted sampling with month/hour/minute/second weights:
+
+<setup>
+  <generate name="dateTimeGenerator" count="3" target="ConsoleExporter">
+    <key name="biased_datetime"
+         generator="DateTimeGenerator(
+           min='2020-02-01 0:0:0',
+           max='2025-07-31 0:0:0',
+           month_weights='[0.5] * 2 + [1] * 3 + [0.8] * 3 + [1] * 3 + [0.5]',
+           hour_weights='[0.6]*6 + [0.3]*16 + [0.1]*2',
+           minute_weights='[1 if m in (0,15,30,45) else 0 for m in range(60)]',
+           second_weights='[1]+[0]*59'
+         )"/>
+  </generate>
+</setup>
+
+Note: ensure `month_weights` length equals 12; the above pattern is 12 elements.
+
+## Python API Examples
+
+from datamimic_ce.domains.common.literal_generators.datetime_generator import DateTimeGenerator
+
+# Deterministic window, weekends only
+gen = DateTimeGenerator(
+    min="2024-01-01 00:00:00",
+    max="2024-01-31 23:59:59",
+    random=True,
+    weekdays="Weekend",
+    seed=42,
+)
+print(gen.generate())
+
+# Time weights only, uniform date
+gen = DateTimeGenerator(random=True, hour_weights=[0.2]*6 + [0.02]*18, seed=1)
+print(gen.generate())
+
+## Formatting in Keys/Variables
+
+To convert formats in XML, use `inDateFormat` and `outDateFormat` on the `<key>` or `<variable>` (conversion is outside the generator itself). See tests_ce/functional_tests/test_datetime/functional_test_datetime.xml:1.
+
+## Error Handling
+
+- Invalid lengths, negative weights, or all‑zero weights → ValueError with a clear message.
+- Sugar that yields no eligible days in the window (e.g., `months='2'` with a January‑only range) → ValueError.
+
+## Determinism & Performance
+
+- Uses a private RNG with optional `seed` for reproducibility.
+- O(1) per sample; day distributions built lazily when any day‑level weighting/sugar is provided.
+
+## Demos & Tests
+
+- Demo XML: datamimic_ce/demos/demo-datetime/1_datetime_generator.xml
+- Functional tests: tests_ce/functional_tests/test_datetime/test_datetime.py

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -6,6 +6,7 @@ This section contains verified examples for using DATAMIMIC in various practical
 
 - [Person Generation](person_generation.md) - Generate and work with person entities
 - [Healthcare Data Generation](healthcare_generation.md) - Create realistic healthcare data
+- [DateTime Generator](datetime_generator.md) - Weighted, deterministic, and DSL sugar
 
 ## Upcoming Examples
 

--- a/docs/examples/datetime_generator.md
+++ b/docs/examples/datetime_generator.md
@@ -1,0 +1,81 @@
+# DateTime Generator: Weighted, Deterministic, and DSL Sugar
+
+The `DateTimeGenerator` produces datetimes within an optional range, with support for:
+
+- Weighted hours/minutes/seconds and month/day selection
+- Deterministic sequences via `seed`
+- Boundary-safe sampling (never exceeds `[min, max]` down to seconds)
+- User-friendly DSL sugar for months, weekdays, day-of-month and time presets
+
+## Quick Examples (XML DSL)
+
+- Uniform within a window:
+  - `DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True)`
+
+- Deterministic:
+  - `DateTimeGenerator(random=True, seed=42)`
+
+- Time weights only (uniform date):
+  - `DateTimeGenerator(random=True, hour_weights='[0.2]*6 + [0.02]*18')`
+
+## DSL Sugar
+
+You can express date filters and time patterns without writing full weight arrays.
+
+### Months
+
+- Include or exclude sets:
+  - `months='3,7-9'` (March, July–September)
+  - `months_exclude='2,4'` (exclude Feb and Apr)
+- Quarter tokens:
+  - `months='Q1'` → Jan–Mar
+  - `months='Q2,Q4'` → Apr–Jun and Oct–Dec
+
+### Weekdays
+
+Accepts names, ranges, and presets. Monday=0, Sunday=6.
+
+- Names/ranges:
+  - `weekdays='Mon-Fri'`
+  - `weekdays='Fri-Mon'` (wrap-around)
+- Presets (case-insensitive):
+  - `weekdays='Weekend'` → Sat, Sun
+  - `weekdays='Weekdays'` / `Business` / `Workdays` → Mon–Fri
+  - `weekdays='All'` → every day
+
+### Day-of-Month (DOM)
+
+- Specific days/ranges:
+  - `dom='1-5,15,31'`
+- Last day of the month:
+  - `dom='last'`
+
+### Time Presets and Granularity
+
+- Hours:
+  - `hours_preset='office'` → 09–17 weighted high
+  - `hours_preset='night'` → 22–05 weighted high
+  - `hours_preset='flat'` → no hour bias (uniform)
+- Minute/Second tick spacing:
+  - `minute_granularity=15` → 0, 15, 30, 45 only
+  - `second_granularity=10` → 0, 10, 20, 30, 40, 50 only
+
+## Exact Boundaries
+
+If `min`/`max` constrain the first/last day, hours/minutes/seconds are sampled only within valid ranges for those edge dates. This prevents out-of-bounds times.
+
+## Determinism
+
+Provide `seed` to get reproducible sequences (same inputs → same outputs).
+
+## Validation
+
+The generator validates:
+- Weight vector lengths (24/60/60/12/7/31)
+- Non-negative values and non-zero sum
+- Sugar specs that yield at least one eligible date; otherwise a clear error is raised
+
+## Demo Snippets
+
+See `datamimic_ce/demos/demo-datetime/1_datetime_generator.xml` for ready-to-run examples using the DSL sugar and weights.
+

--- a/tests_ce/functional_tests/test_datetime/functional_test_datetime_biased.xml
+++ b/tests_ce/functional_tests/test_datetime/functional_test_datetime_biased.xml
@@ -1,0 +1,15 @@
+<setup>
+  <generate name="biased_datetime_test" count="400" target="ConsoleExporter">
+    <key name="biased_datetime"
+         generator="DateTimeGenerator(
+           min='2020-02-01 0:0:0',
+           max='2025-07-31 0:0:0',
+           month_weights='[0.5] * 2 + [1] * 3 + [0.8] * 3 + [1] * 3 + [0.5]',
+           hour_weights='[0.6]*6 + [0.3]*16 + [0.1]*2',
+           minute_weights='[1 if m in (0,15,30,45) else 0 for m in range(60)]',
+           second_weights='[1]+[0]*59',
+           seed=123
+         )"/>
+  </generate>
+</setup>
+

--- a/tests_ce/functional_tests/test_datetime/functional_test_datetime_sugar.xml
+++ b/tests_ce/functional_tests/test_datetime/functional_test_datetime_sugar.xml
@@ -1,0 +1,48 @@
+<setup>
+  <generate name="weighted_datetime_sugar" count="250" target="ConsoleExporter">
+    <!-- Uniform window example -->
+    <key name="uniform"
+         generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True)"/>
+    <!-- Weekdays sugar: business days only -->
+    <key name="biz_days"
+         generator="DateTimeGenerator(min='2024-04-01 00:00:00', max='2024-04-30 23:59:59', random=True, weekdays='Mon-Fri', seed=11)"/>
+
+    <!-- Weekends sugar: weekend only -->
+    <key name="weekends"
+         generator="DateTimeGenerator(min='2024-04-01 00:00:00', max='2024-04-30 23:59:59', random=True, weekdays='Weekend', seed=12)"/>
+
+    <!-- Months include range -->
+    <key name="months_include"
+         generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True, months='3,7-9', seed=13)"/>
+
+    <!-- Months exclude -->
+    <key name="months_exclude"
+         generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True, months_exclude='2,4', seed=14)"/>
+
+    <!-- Quarter tokens: Q1 should restrict to Jan-Mar -->
+    <key name="months_q1"
+         generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True, months='Q1', seed=141)"/>
+
+    <!-- Multiple quarters: Q2,Q4 restricts to Apr-Jun and Oct-Dec -->
+    <key name="months_q2_q4"
+         generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True, months='Q2,Q4', seed=142)"/>
+
+    <!-- Day-of-month sugar: last day only -->
+    <key name="dom_last"
+         generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True, dom='last', seed=15)"/>
+
+    <!-- Day-of-month sugar: 1-5,15,31 only -->
+    <key name="dom_multi"
+         generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True, dom='1-5,15,31', seed=16)"/>
+
+    <!-- Hours preset + minute/second granularity -->
+    <key name="hours_office_gran15_10"
+         generator="DateTimeGenerator(min='2024-04-01 00:00:00', max='2024-04-30 23:59:59', random=True, hours_preset='office', minute_granularity=15, second_granularity=10, seed=17)"/>
+
+    <!-- Deterministic plain random (no day-level weights) -->
+    <key name="plain_det_a"
+         generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-01-31 23:59:59', random=True, seed=42)"/>
+    <key name="plain_det_b"
+         generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-01-31 23:59:59', random=True, seed=42)"/>
+  </generate>
+</setup>

--- a/tests_ce/functional_tests/test_datetime/functional_test_datetime_weighted.xml
+++ b/tests_ce/functional_tests/test_datetime/functional_test_datetime_weighted.xml
@@ -1,0 +1,30 @@
+<setup>
+  <generate name="weighted_datetime_test" count="200" target="ConsoleExporter">
+    <!-- Month-weighted: March only across 2024 -->
+    <key name="march_only"
+         generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True, month_weights='[0,0,1]+[0]*9', seed=42)"/>
+
+    <!-- Weekday-weighted: Mondays only in Jan 2024 -->
+    <key name="mondays_only"
+         generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-01-31 23:59:59', random=True, weekday_weights='[1,0,0,0,0,0,0]', seed=101)"/>
+
+    <!-- Day-of-month weighted: 15th only across Jan–Feb 2024 (includes Feb 29) -->
+    <key name="dom_15_only"
+         generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-02-29 23:59:59', random=True, dom_weights='[0]*14+[1]+[0]*16', seed=202)"/>
+
+    <!-- Combined filters: March + Monday + 4th day -->
+    <key name="combined_filters"
+         generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-12-31 23:59:59', random=True, month_weights='[0,0,1]+[0]*9', weekday_weights='[1,0,0,0,0,0,0]', dom_weights='[0,0,0,1]+[0]*27', seed=7)"/>
+
+    <!-- Tight boundary window with time weights to stress clamping -->
+    <key name="tight_window_weighted"
+         generator="DateTimeGenerator(min='2025-07-20 12:00:00', max='2025-07-20 12:00:05', random=True, hour_weights='[0]*12+[1]+[0]*11', minute_weights='[1]+[0]*59', second_weights='[1]+[0]*59', seed=303)"/>
+
+    <!-- Determinism: two identical generators with the same seed -->
+    <key name="det_a"
+         generator="DateTimeGenerator(min='2024-03-01 00:00:00', max='2024-03-31 23:59:59', random=True, weekday_weights='[1,0,0,0,0,0,0]', dom_weights='[0,0,0,1]+[0]*27', seed=999)"/>
+    <key name="det_b"
+         generator="DateTimeGenerator(min='2024-03-01 00:00:00', max='2024-03-31 23:59:59', random=True, weekday_weights='[1,0,0,0,0,0,0]', dom_weights='[0,0,0,1]+[0]*27', seed=999)"/>
+  </generate>
+</setup>
+

--- a/tests_ce/functional_tests/test_datetime/functional_test_datetime_weighted_invalid.xml
+++ b/tests_ce/functional_tests/test_datetime/functional_test_datetime_weighted_invalid.xml
@@ -1,0 +1,8 @@
+<setup>
+  <generate name="weighted_datetime_invalid" count="10" target="ConsoleExporter">
+    <!-- Invalid: all-zero weekday weights should fail -->
+    <key name="invalid_weekday"
+         generator="DateTimeGenerator(min='2024-01-01 00:00:00', max='2024-01-31 23:59:59', random=True, weekday_weights='[0]*7')"/>
+  </generate>
+</setup>
+

--- a/tests_ce/functional_tests/test_datetime/test_datetime.py
+++ b/tests_ce/functional_tests/test_datetime/test_datetime.py
@@ -135,4 +135,142 @@ class TestDateTime:
 
             ref = f"{entry['epoch_reference']}000000000"
             expected_epoch_nanos = entry["to_epoch_nanos"]
-            assert ref == expected_epoch_nanos, f"Expected epoch in nanoseconds: {ref}, but got: {expected_epoch_nanos}"
+        assert ref == expected_epoch_nanos, f"Expected epoch in nanoseconds: {ref}, but got: {expected_epoch_nanos}"
+
+    def test_datetime_weighted_functional(self) -> None:
+        engine = DataMimicTest(
+            test_dir=self._test_dir,
+            filename="functional_test_datetime_weighted.xml",
+            capture_test_result=True,
+        )
+        engine.test_with_timer()
+
+        result = engine.capture_result()
+        weighted = result["weighted_datetime_test"]
+        assert len(weighted) == 200
+
+        # Verify March-only
+        for row in weighted:
+            dt = row["march_only"]
+            assert 1 <= dt.day <= 31
+            assert dt.year == 2024
+            assert dt.month == 3
+
+        # Verify Mondays-only (weekday: Monday==0)
+        for row in weighted:
+            dt = row["mondays_only"]
+            assert dt.year == 2024 and dt.month == 1
+            assert dt.weekday() == 0
+
+        # Verify 15th only across Jan–Feb 2024
+        for row in weighted:
+            dt = row["dom_15_only"]
+            assert dt.year == 2024
+            assert dt.month in (1, 2)
+            assert dt.day == 15
+
+        # Combined filters: March + Monday + 4th
+        for row in weighted:
+            dt = row["combined_filters"]
+            assert dt.year == 2024 and dt.month == 3 and dt.day == 4 and dt.weekday() == 0
+
+        # Tight boundary: ensure within exact 6-second window
+        from datetime import datetime as _dt
+
+        lo = _dt(2025, 7, 20, 12, 0, 0)
+        hi = _dt(2025, 7, 20, 12, 0, 5)
+        for row in weighted:
+            dt = row["tight_window_weighted"]
+            assert lo <= dt <= hi
+
+        # Determinism: equal sequences for det_a and det_b
+        for row in weighted:
+            assert row["det_a"] == row["det_b"]
+
+    def test_datetime_weighted_invalid(self) -> None:
+        engine = DataMimicTest(
+            test_dir=self._test_dir,
+            filename="functional_test_datetime_weighted_invalid.xml",
+            capture_test_result=False,
+        )
+        with pytest.raises(ValueError):
+            engine.test_with_timer()
+
+    def test_datetime_weighted_sugar(self) -> None:
+        engine = DataMimicTest(
+            test_dir=self._test_dir,
+            filename="functional_test_datetime_sugar.xml",
+            capture_test_result=True,
+        )
+        engine.test_with_timer()
+        result = engine.capture_result()
+        rows = result["weighted_datetime_sugar"]
+        assert len(rows) == 250
+
+        # uniform: just ensure within range
+        from datetime import datetime as _dt
+        lo2024 = _dt(2024, 1, 1, 0, 0, 0)
+        hi2024 = _dt(2024, 12, 31, 23, 59, 59)
+        for r in rows:
+            d = r["uniform"]
+            assert lo2024 <= d <= hi2024
+
+        # biz_days: Mon-Fri only
+        for r in rows:
+            d = r["biz_days"]
+            assert 0 <= d.weekday() <= 4
+
+        # weekends: Sat/Sun only
+        for r in rows:
+            d = r["weekends"]
+            assert d.weekday() in (5, 6)
+
+        # months_include: only Mar, Jul, Aug, Sep
+        allowed = {3, 7, 8, 9}
+        for r in rows:
+            d = r["months_include"]
+            assert d.month in allowed
+
+        # months_exclude: never Feb or Apr
+        forbidden = {2, 4}
+        for r in rows:
+            d = r["months_exclude"]
+            assert d.month not in forbidden
+
+        # months_q1: only Jan, Feb, Mar
+        for r in rows:
+            d = r["months_q1"]
+            assert d.month in {1, 2, 3}
+
+        # months_q2_q4: only Apr-Jun or Oct-Dec
+        for r in rows:
+            d = r["months_q2_q4"]
+            assert d.month in {4, 5, 6, 10, 11, 12}
+
+        # dom_last: last day of month
+        import calendar as _cal
+        for r in rows:
+            d = r["dom_last"]
+            last = _cal.monthrange(d.year, d.month)[1]
+            assert d.day == last
+
+        # dom_multi: days 1-5, 15, 31 only (but 31 may not exist in some months)
+        allowed_dom = set(range(1, 6)) | {15, 31}
+        for r in rows:
+            d = r["dom_multi"]
+            assert d.day in allowed_dom and d.day <= _cal.monthrange(d.year, d.month)[1]
+
+        # hours_office_gran15_10: hours 9..17 should dominate, minutes multiples of 15, seconds multiples of 10
+        office_hours_count = 0
+        for r in rows:
+            d = r["hours_office_gran15_10"]
+            if 9 <= d.hour <= 17:
+                office_hours_count += 1
+            assert d.minute in (0, 15, 30, 45)
+            assert d.second in (0, 10, 20, 30, 40, 50)
+        # not strict, but majority in office hours
+        assert office_hours_count > len(rows) * 0.5
+
+        # plain determinism: equal sequences for plain_det_a and plain_det_b
+        for r in rows:
+            assert r["plain_det_a"] == r["plain_det_b"]

--- a/tests_ce/functional_tests/test_datetime/test_datetime_biased.py
+++ b/tests_ce/functional_tests/test_datetime/test_datetime_biased.py
@@ -1,0 +1,36 @@
+# DATAMIMIC
+
+from pathlib import Path
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+
+class TestDateTimeBiased:
+    _test_dir = Path(__file__).resolve().parent
+
+    def test_biased_datetime_example(self) -> None:
+        engine = DataMimicTest(
+            test_dir=self._test_dir,
+            filename="functional_test_datetime_biased.xml",
+            capture_test_result=True,
+        )
+        engine.test_with_timer()
+        result = engine.capture_result()
+        rows = result["biased_datetime_test"]
+        assert len(rows) == 400
+
+        # Extract values
+        values = [r["biased_datetime"] for r in rows]
+
+        # Minute/second constraints from weights
+        for dt in values:
+            assert dt.second == 0
+            assert dt.minute in (0, 15, 30, 45)
+
+        # Hour bias checks (deterministic with seed): more samples in hour 0 than hour 23 and hour 12
+        from collections import Counter
+
+        hour_counts = Counter(dt.hour for dt in values)
+        assert hour_counts[0] > hour_counts[23]
+        assert hour_counts[0] > hour_counts[12]
+

--- a/tests_ce/functional_tests/test_datetime/test_python_api_datetime_generator.py
+++ b/tests_ce/functional_tests/test_datetime/test_python_api_datetime_generator.py
@@ -1,0 +1,39 @@
+# DATAMIMIC
+
+from datetime import datetime
+
+from datamimic_ce.domains.common.literal_generators.datetime_generator import (
+    DateTimeGenerator,
+)
+
+
+def test_python_api_weekends_with_seed_deterministic():
+    # Docs example mirrored as a functional test of the Python API
+    gen1 = DateTimeGenerator(
+        min="2024-01-01 00:00:00",
+        max="2024-01-31 23:59:59",
+        random=True,
+        weekdays="Weekend",
+        seed=42,
+    )
+    gen2 = DateTimeGenerator(
+        min="2024-01-01 00:00:00",
+        max="2024-01-31 23:59:59",
+        random=True,
+        weekdays="Weekend",
+        seed=42,
+    )
+
+    seq1 = [gen1.generate() for _ in range(50)]
+    seq2 = [gen2.generate() for _ in range(50)]
+
+    # Determinism: identical sequences when seed and config are the same
+    assert seq1 == seq2
+
+    # Weekend only and within range
+    lo = datetime(2024, 1, 1, 0, 0, 0)
+    hi = datetime(2024, 1, 31, 23, 59, 59)
+    for dt in seq1:
+        assert lo <= dt <= hi
+        assert dt.weekday() in (5, 6)
+

--- a/tests_ce/unit_tests/test_generator/test_datetime_generator_day_weighted.py
+++ b/tests_ce/unit_tests/test_generator/test_datetime_generator_day_weighted.py
@@ -1,0 +1,76 @@
+# DATAMIMIC
+
+import pytest
+from datetime import datetime
+
+from datamimic_ce.domains.common.literal_generators.datetime_generator import DateTimeGenerator
+
+
+def test_weekday_weights_only_mondays():
+    # Only Mondays allowed
+    weekday_weights = [1.0] + [0.0] * 6  # Monday=0
+    gen = DateTimeGenerator(
+        min="2024-01-01 00:00:00",
+        max="2024-01-31 23:59:59",
+        random=True,
+        weekday_weights=weekday_weights,
+        seed=123,
+    )
+    for _ in range(100):
+        d = gen.generate()
+        assert d.weekday() == 0
+
+
+def test_dom_weights_only_15th():
+    # Only day-of-month 15 allowed
+    dom_weights = [0.0] * 31
+    dom_weights[14] = 1.0
+    gen = DateTimeGenerator(
+        min="2024-01-01 00:00:00",
+        max="2024-02-29 23:59:59",
+        random=True,
+        dom_weights=dom_weights,
+        seed=456,
+    )
+    for _ in range(100):
+        d = gen.generate()
+        assert d.day == 15
+
+
+def test_combined_month_weekday_dom_weights():
+    # Only March, only Mondays, only 4th day
+    month_weights = [0.0] * 12
+    month_weights[2] = 1.0  # March
+    weekday_weights = [1.0] + [0.0] * 6  # Monday only
+    dom_weights = [0.0] * 31
+    dom_weights[3] = 1.0  # Day 4
+    gen = DateTimeGenerator(
+        min="2024-01-01 00:00:00",
+        max="2024-12-31 23:59:59",
+        random=True,
+        month_weights=month_weights,
+        weekday_weights=weekday_weights,
+        dom_weights=dom_weights,
+        seed=789,
+    )
+    for _ in range(20):
+        d = gen.generate()
+        assert d.month == 3
+        assert d.day == 4
+        assert d.weekday() == 0  # 2024-03-04 is a Monday
+
+
+def test_invalid_day_filters_raise():
+    # No eligible date within range: Feb 2023 has no 30th and disallow all weekdays
+    dom_weights = [0.0] * 31
+    dom_weights[29] = 1.0  # 30th only
+    weekday_weights = [0.0] * 7  # nothing allowed
+    with pytest.raises(ValueError):
+        DateTimeGenerator(
+            min="2023-02-01 00:00:00",
+            max="2023-02-28 23:59:59",
+            random=True,
+            dom_weights=dom_weights,
+            weekday_weights=weekday_weights,
+        )
+

--- a/tests_ce/unit_tests/test_generator/test_datetime_generator_month_weighted.py
+++ b/tests_ce/unit_tests/test_generator/test_datetime_generator_month_weighted.py
@@ -1,0 +1,44 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025
+
+from datetime import datetime
+
+from datamimic_ce.domains.common.literal_generators.datetime_generator import DateTimeGenerator
+
+
+def test_respects_exact_second_window_with_boundaries():
+    gen = DateTimeGenerator(
+        min="2025-07-20 12:00:00",
+        max="2025-07-20 12:00:05",
+        random=True,
+        seed=42,
+    )
+    lo = datetime(2025, 7, 20, 12, 0, 0)
+    hi = datetime(2025, 7, 20, 12, 0, 5)
+    for _ in range(200):
+        dt = gen.generate()
+        assert lo <= dt <= hi
+
+
+def test_month_weights_exclude_months():
+    # Only allow March in 2024
+    month_weights = [0.0] * 12
+    month_weights[2] = 1.0  # March
+    gen = DateTimeGenerator(
+        min="2024-01-01 00:00:00",
+        max="2024-12-31 23:59:59",
+        random=True,
+        month_weights=month_weights,
+        seed=7,
+    )
+    for _ in range(200):
+        assert gen.generate().month == 3
+
+
+def test_seed_makes_sequence_deterministic():
+    g1 = DateTimeGenerator(min="2024-01-01 00:00:00", max="2024-01-10 23:59:59", random=True, seed=123)
+    g2 = DateTimeGenerator(min="2024-01-01 00:00:00", max="2024-01-10 23:59:59", random=True, seed=123)
+    seq1 = [g1.generate() for _ in range(20)]
+    seq2 = [g2.generate() for _ in range(20)]
+    assert seq1 == seq2
+


### PR DESCRIPTION
# Problem

- Wanted month-weighted datetime generation with stronger correctness and UX.
- Existing generator could drift outside bounds on edge days and lacked determinism.

# What’s Changed

- **Month/weekday/day-of-month weighting**
  - Adds `month_weights` (len=12), `weekday_weights` (len=7, Mon=0), `dom_weights` (len=31).
  - Exact day selection across the `[min, max]` window with per-day weight = month × weekday × DOM.
  - Fails fast if no eligible days remain.
- **Safe, deterministic sampling**
  - Adds seed and uses a private RNG for reproducible sequences.
  - Preserves uniformity when no time weights are provided.
  - Clamps time on boundary days so results always fall within `[min, max]` down to seconds.
- **Time weighting**
  - Optional `hour_weights`, `minute_weights`, `second_weights` respected within legal bounds on edge days.
- **DSL sugar (friendlier config)**
  - `months`, `months_exclude` with support for `Q1..Q4`.
  - `weekdays` supports names, ranges (e.g., `Mon-Fri`), and presets (`Weekend`, `Weekdays/Business/Workdays`, `All`).
  - `dom` supports ranges and `last` (last day-of-month).
  - `hours_preset='office'|'night'|'flat'`, `minute_granularity`, `second_granularity`.
  - Sugar ignored if explicit weights for that dimension are provided.
- **Backward compatibility**
  - Keeps `random=True` behavior; `random_mode` accepted as an alias.
  - Uniform sampling unchanged if no weights/sugar provided.

# Implementation Notes

- **`datamimic_ce/domains/common/literal_generators/datetime_generator.py`**
  - New helpers for month segmentation and bounded time sampling.
  - Adds seedable RNG, weight validation, and sugar parsers.
  - Enforces day-level selection path when any day-weight/sugar is present.
  - Fix `ruff SIM102` by flattening nested if; fix `mypy` by narrowing optional set before membership test.
- **`datamimic_ce/domains/common/literal_generators/generator_util.py`**
  - Parser extended to accept `month_weights`, `weekday_weights`, `dom_weights` similarly to existing weight lists.

# Docs

- `docs/api/datetime_generator.md` (new): full reference with examples and DSL sugar.
- `docs/examples/datetime_generator.md` (new): quick examples.
- Linked from docs indices.
- Demo updated with DSL and “biased datetime” example:
  - `datamimic_ce/demos/demo-datetime/1_datetime_generator.xml`

# Tests

- **Unit tests**
  - `tests_ce/unit_tests/test_generator/test_datetime_generator_weighted.py`
  - `tests_ce/unit_tests/test_generator/test_datetime_generator_month_weighted.py` (new)
  - `tests_ce/unit_tests/test_generator/test_datetime_generator_day_weighted.py` (new)
- **Functional tests**
  - `tests_ce/functional_tests/test_datetime/test_datetime.py`
    - Adds `test_datetime_weighted_functional` and `test_datetime_weighted_sugar` validating DSL and bounds.
  - `tests_ce/functional_tests/test_datetime/test_python_api_datetime_generator.py` (new)  
    Mirrors docs’ Python API example (weekends + seed) for determinism.
  - `tests_ce/functional_tests/test_datetime/functional_test_datetime_weighted.xml` (new)
  - `tests_ce/functional_tests/test_datetime/functional_test_datetime_weighted_invalid.xml` (new)
  - `tests_ce/functional_tests/test_datetime/functional_test_datetime_sugar.xml` (new)
  - `tests_ce/functional_tests/test_datetime/functional_test_datetime_biased.xml` (new)
  - `tests_ce/functional_tests/test_datetime/test_datetime_biased.py` (new)  
    Validates minute/second constraints and hour bias.

# Validation & Guarantees

- Always returns datetimes inside `[min, max]` to the second.
- Deterministic with seed.
- Clear errors for invalid weights or empty eligibility.
- O(1) per sample; precomputes per-month day windows lazily.

---

Refs: #113
