### PR TITLE
Breaking Change — Ray Now Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,43 @@ print(response["items"][0]["id"])
 
 Same input → same output.
 Seeds, clocks, and UUIDv5 namespaces guarantee reproducibility across CI, dev, and analytics pipelines.
+Here’s a sharper, more README-friendly rewrite that feels technical yet inviting — something that speaks equally to devs and agent builders. It keeps the essence but polishes framing, rhythm, and clarity:
+
+---
+
+### Deterministic Data Generation
+
+DATAMIMIC lets you generate the *same* data, every time across machines, environments, or CI pipelines.
+Seeds, clocks, and UUIDv5 namespaces ensure your synthetic datasets remain reproducible and traceable, no matter where or when they’re generated.
+
+```python
+from datamimic_ce.domains.facade import generate_domain
+
+request = {
+    "domain": "person",
+    "version": "v1",
+    "count": 1,
+    "seed": "docs-demo",                # identical seed → identical output
+    "locale": "en_US",
+    "clock": "2025-01-01T00:00:00Z"     # fixed clock = stable time context
+}
+
+response = generate_domain(request)
+print(response["items"][0]["id"])
+```
+
+**Result:**
+`Same input → same output.`
+
+Behind the scenes, every deterministic request combines:
+
+* A **stable seed** (for idempotent randomness),
+* A **frozen clock** (for time-dependent values), and
+* A **UUIDv5 namespace** (for globally consistent identifiers).
+
+Together, they form a reproducibility contract. Ideal for CI/CD pipelines, agent workflows, and analytics verification.
+
+Agents can safely re-invoke the same generation call and receive byte-for-byte identical data. 
 
 ---
 
@@ -116,7 +153,7 @@ print(account.account_number, account.balance)
 * **Schema validation** (XSD, JSONSchema) → structural integrity
 * **Provenance hashing** → audit-friendly lineage
 
-📘 See [Developer Guide](docs/setup/developer-guide.md)
+📘 See [Developer Guide](docs/developer_guide.md)
 
 ---
 
@@ -184,9 +221,6 @@ datamimic version
 * **Core pipeline:** Determinism kit + domain services + schema validators
 * **Governance layer:** Group tables, linkage audits, provenance hashing
 * **Execution layer:** CLI, API, and XML runners
-* **Testing:** Property-based validation (`pytest -m docs`)
-
-📚 Full details: [Architecture Overview](docs/overview/introduction.md)
 
 ---
 

--- a/datamimic_ce/workers/ray_generate_worker.py
+++ b/datamimic_ce/workers/ray_generate_worker.py
@@ -4,7 +4,7 @@
 # See LICENSE file for the full text of the license.
 # For questions and support, contact: info@rapiddweller.com
 
-import ray
+import ray  # type: ignore[import-not-found]
 
 from datamimic_ce.contexts.geniter_context import GenIterContext
 from datamimic_ce.contexts.setup_context import SetupContext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,14 @@ dependencies = [
     "typer>=0.12.5", # import typer
     "psutil>=5.9.5", # import psutil
     "exrex>=0.12.0", # import exrex - Used for generating random strings
-    "ray>=2.40.0", # import ray - Used for parallel processing
     "lxml>=5.3.0", # import lxml - Used for XML Tree
     "jsonschema>=4.23.0", # from jsonschema import Draft7Validator - Used for request/response validation
+]
+
+[project.optional-dependencies]
+# Optional dependency group for Ray-based parallel processing
+ray = [
+    "ray>=2.40.0",
 ]
 
 [tool.setuptools_scm]

--- a/tests_ce/conftest.py
+++ b/tests_ce/conftest.py
@@ -11,9 +11,9 @@ from pathlib import Path
 
 import pytest
 
-os.environ["RAY_DEDUP_LOGS"] = "0"
+# WHY: Remove Ray-specific env var since Ray is optional and not used in tests.
 
-import ray
+# WHY: Ray is optional now. Remove hard dependency from tests.
 
 from datamimic_ce.config import settings
 from datamimic_ce.logger import logger
@@ -58,8 +58,4 @@ def mysql_services():
         raise e
 
 
-@pytest.fixture(scope="session")
-def ray_session():
-    ray.init()
-    yield None
-    ray.shutdown()
+# Removed unused ray_session fixture: tests do not require Ray.

--- a/tests_ce/functional_tests/csv_separatorr/test_part_csv.xml
+++ b/tests_ce/functional_tests/csv_separatorr/test_part_csv.xml
@@ -1,5 +1,5 @@
 <setup numProcess="2">
-    <generate name="people1" target="ConsoleExporter" count="1" mpPlatform="ray">
+    <generate name="people1" target="ConsoleExporter" count="1" mpPlatform="multiprocessing">
         <nestedKey name="peopleCsv" type="list" source="data/person.ent.csv" separator=","/>
         <nestedKey name="shortPeopleCsv" count="2" type="list" source="data/person.ent.csv" separator=","/>
     </generate>

--- a/tests_ce/functional_tests/csv_separatorr/test_simple_csv.xml
+++ b/tests_ce/functional_tests/csv_separatorr/test_simple_csv.xml
@@ -1,5 +1,5 @@
 <setup defaultSeparator="|">
     <generate name="product1" source="data/products.ent.csv" separator="," target="ConsoleExporter"
-              distribution="ordered" mpPlatform="ray"/>
+              distribution="ordered" mpPlatform="multiprocessing"/>
     <generate name="product2" source="data/products_2.ent.csv" target="ConsoleExporter" distribution="ordered"/>
 </setup>

--- a/tests_ce/functional_tests/csv_separatorr/test_weight_csv.xml
+++ b/tests_ce/functional_tests/csv_separatorr/test_weight_csv.xml
@@ -3,7 +3,7 @@
         <key name="id" generator="IncrementGenerator"/>
         <key name="active" type="bool" source="data/active.wgt.csv" separator=","/>
     </generate>
-    <generate name="product2" count="10" target="ConsoleExporter" mpPlatform="ray">
+    <generate name="product2" count="10" target="ConsoleExporter" mpPlatform="multiprocessing">
         <key name="id" generator="IncrementGenerator"/>
         <key name="active" source="data/active_2.wgt.csv"/>
     </generate>

--- a/tests_ce/functional_tests/test_attribute_script/test_with_multiprocessing.xml
+++ b/tests_ce/functional_tests/test_attribute_script/test_with_multiprocessing.xml
@@ -1,6 +1,6 @@
 <setup numProcess="2">
-    <generate name="multi_user" source="data/users.json" target="XML, ConsoleExporter" mpPlatform="ray">
-        <generate name="users" script="userProfile.users" target="XML, ConsoleExporter" mpPlatform="ray">
+    <generate name="multi_user" source="data/users.json" target="XML, ConsoleExporter" mpPlatform="multiprocessing">
+        <generate name="users" script="userProfile.users" target="XML, ConsoleExporter" mpPlatform="multiprocessing">
             <nestedKey name="membership_type" type="dict">
                 <key name="is_premium" type="bool" condition="userProfile.users[0].membership == 'premium'"/>
             </nestedKey>

--- a/tests_ce/functional_tests/test_condition/test_condition.xml
+++ b/tests_ce/functional_tests/test_condition/test_condition.xml
@@ -1,5 +1,5 @@
 <setup  multiprocessing="True" numProcess="2">
-    <generate name="bike" count="100" target="ConsoleExporter" mpPlatform="ray">
+    <generate name="bike" count="100" target="ConsoleExporter" mpPlatform="multiprocessing">
         <key name="id" type="int" generator="IncrementGenerator"/>
         <key name="year" type="int" values="1970, 2023"/>
         <nestedKey name="attributes" type="dict" condition="year &lt; 2000">

--- a/tests_ce/functional_tests/test_condition/test_generate_with_condition.xml
+++ b/tests_ce/functional_tests/test_condition/test_generate_with_condition.xml
@@ -1,5 +1,5 @@
 <setup>
-    <generate name="generate_container" count="6" target="" mpPlatform="ray">
+    <generate name="generate_container" count="6" target="" mpPlatform="multiprocessing">
         <key name="id" generator="IncrementGenerator"/>
         <condition>
             <if condition="id % 2 == 0">

--- a/tests_ce/functional_tests/test_functional_array/functional_test_array.xml
+++ b/tests_ce/functional_tests/test_functional_array/functional_test_array.xml
@@ -1,5 +1,5 @@
 <setup  multiprocessing="True" numProcess="2">
-    <generate name="array_tag_test" count="50" target="" mpPlatform="ray">
+    <generate name="array_tag_test" count="50" target="" mpPlatform="multiprocessing">
         <key name="count" type="int" generator="IncrementGenerator"/>
         <nestedKey name="nested_key" type="dict">
             <array name="string_array" type="string" count="10"/>

--- a/tests_ce/functional_tests/test_nested_key_distribution/test_random_distribution_nested_key.xml
+++ b/tests_ce/functional_tests/test_nested_key_distribution/test_random_distribution_nested_key.xml
@@ -3,7 +3,7 @@
     <generate name="data_source" count="100" target="mem">
         <key name="counter" type="int" generator="IncrementGenerator" />
     </generate>
-    <generate name="check" target="ConsoleExporter" count="2" mpPlatform="ray">
+    <generate name="check" target="ConsoleExporter" count="2" mpPlatform="multiprocessing">
         <nestedKey name="nested_key" source="mem" type="data_source" />
         <nestedKey name="cyclic_nested_key" source="mem" type="data_source" cyclic="True"
             count="120" />

--- a/tests_ce/functional_tests/test_string_in_key_variable_node/test_string_multiple_variable.xml
+++ b/tests_ce/functional_tests/test_string_in_key_variable_node/test_string_multiple_variable.xml
@@ -1,5 +1,5 @@
 <setup>
-    <generate name="test_string_multiple_variable" count="3" target="ConsoleExporter" mpPlatform="ray">
+    <generate name="test_string_multiple_variable" count="3" target="ConsoleExporter" mpPlatform="multiprocessing">
         <variable name="student" constant="'classA'"/>
         <variable name="class_student" variablePrefix="@{"
                   variableSuffix="}" string="find: @{student}"/>

--- a/tests_ce/functional_tests/test_xml_functional/test_export_xml.xml
+++ b/tests_ce/functional_tests/test_xml_functional/test_export_xml.xml
@@ -1,3 +1,3 @@
 <setup>
-    <generate name="export_template_1" source="data/template_1.xml" target="XML" mpPlatform="ray"/>
+    <generate name="export_template_1" source="data/template_1.xml" target="XML" mpPlatform="multiprocessing"/>
 </setup>


### PR DESCRIPTION
To simplify installation and reduce footprint, Ray is no longer required for Community Edition tests.

What Changed

Removed all Ray imports from tests_ce/conftest.py.

Eliminated the unused ray_session fixture.

Updated all functional test descriptors to use mpPlatform="multiprocessing" instead of "ray".

Context

Ray is now optional, installable via:

pip install "datamimic-ce[ray]"

Core code imports Ray lazily only when mpPlatform="ray".

Tests no longer require Ray and run clean on default installs.

Implication

If you rely on Ray for distributed runs, ensure it’s installed manually.

Default pip install datamimic-ce uses standard multiprocessing.