### PR TITLE
Launch FastMCP synthetic data server for LLM agents

### DIFF
--- a/datamimic_ce/domains/common/demographics/loader.py
+++ b/datamimic_ce/domains/common/demographics/loader.py
@@ -173,7 +173,7 @@ def _validate_band_coverage(bands: Iterable[DemographicAgeBand], file_path: Path
             )
         if previous and band.age_min > previous.age_max + 1:
             logger.warning(
-                "Gap detected between age bands for sex='%s' in '%s': [%s,%s] -> [%s,%s]",  # type: ignore[str-format]
+                "Gap detected between age bands for sex='%s' in '%s': [%s,%s] -> [%s,%s]",
                 sex or "",
                 file_path,
                 previous.age_min,

--- a/datamimic_ce/domains/healthcare/generators/medical_device_generator.py
+++ b/datamimic_ce/domains/healthcare/generators/medical_device_generator.py
@@ -98,31 +98,38 @@ class MedicalDeviceGenerator(BaseDomainGenerator):
     def generate_device_type(self) -> str:
         file_path = dataset_path("healthcare", "medical", f"device_types_{self._dataset}.csv", start=Path(__file__))
         loaded_data = FileUtil.read_weight_csv(file_path)
-        return self._rng.choices(loaded_data[0], weights=loaded_data[1], k=1)[0]  # type: ignore[arg-type]
+        values: list[str] = [str(v) for v in loaded_data[0].tolist() if v is not None]
+        weights: list[float] = [float(w) for w in loaded_data[1].tolist()]
+        return self._rng.choices(values, weights=weights, k=1)[0]
 
     def generate_manufacturer(self) -> str:
         file_path = dataset_path("healthcare", "medical", f"manufacturers_{self._dataset}.csv", start=Path(__file__))
         loaded_data = FileUtil.read_weight_csv(file_path)
-        values, weights = loaded_data[0], loaded_data[1]
+        values: list[str] = [str(v) for v in loaded_data[0].tolist() if v is not None]
+        weights: list[float] = [float(w) for w in loaded_data[1].tolist()]
         # avoid immediate repetition when possible
         if self._last_manufacturer in values and len(values) > 1:
             pool = [(v, float(w)) for v, w in zip(values, weights, strict=False) if v != self._last_manufacturer]
             p_vals, p_w = zip(*pool, strict=False)
             choice = self._rng.choices(list(p_vals), weights=list(p_w), k=1)[0]
         else:
-            choice = self._rng.choices(values, weights=weights, k=1)[0]  # type: ignore[arg-type]
+            choice = self._rng.choices(values, weights=weights, k=1)[0]
         self._last_manufacturer = choice
-        return choice  # type: ignore[return-value]
+        return choice
 
     def generate_device_status(self) -> str:
         file_path = dataset_path("healthcare", "medical", f"device_statuses_{self._dataset}.csv", start=Path(__file__))
         loaded_data = FileUtil.read_weight_csv(file_path)
-        return self._rng.choices(loaded_data[0], weights=loaded_data[1], k=1)[0]  # type: ignore[arg-type]
+        values: list[str] = [str(v) for v in loaded_data[0].tolist() if v is not None]
+        weights: list[float] = [float(w) for w in loaded_data[1].tolist()]
+        return self._rng.choices(values, weights=weights, k=1)[0]
 
     def generate_location(self) -> str:
         file_path = dataset_path("healthcare", "medical", f"locations_{self._dataset}.csv", start=Path(__file__))
-        loaded_data = FileUtil.read_weight_csv(file_path)  # type: ignore[arg-type]
-        return self._rng.choices(loaded_data[0], weights=loaded_data[1], k=1)[0]  # type: ignore[arg-type]
+        loaded_data = FileUtil.read_weight_csv(file_path)
+        values: list[str] = [str(v) for v in loaded_data[0].tolist() if v is not None]
+        weights: list[float] = [float(w) for w in loaded_data[1].tolist()]
+        return self._rng.choices(values, weights=weights, k=1)[0]
 
     # Helpers for specifications (modes, detector types, etc.) used by the model
     def pick_ventilator_mode(self) -> str:

--- a/datamimic_ce/mcp/__init__.py
+++ b/datamimic_ce/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""Public entrypoints for the MCP integration."""
+
+from .server import create_server, mount_mcp
+
+__all__ = ["create_server", "mount_mcp"]

--- a/datamimic_ce/mcp/cli.py
+++ b/datamimic_ce/mcp/cli.py
@@ -1,0 +1,92 @@
+"""Command line interface for serving the FastMCP endpoint.
+
+WHY: Typer in some environments doesn't support ``typing.Literal`` for
+option types, raising "Type not yet supported". To keep broad
+compatibility without upgrading tooling, we use ``Enum`` for choices.
+This keeps the CLI thin, explicit, and compatible across Typer versions.
+"""
+
+from __future__ import annotations
+
+import os
+from enum import Enum
+
+import typer
+import uvicorn
+
+from datamimic_ce.mcp.server import (
+    HTTP_MIDDLEWARE_ATTR,
+    build_sse_app,
+    create_server,
+)
+
+app = typer.Typer(help="Run the DataMimic MCP server")
+
+_DEFAULT_HOST = "127.0.0.1"
+_DEFAULT_PORT = 8765
+
+
+class Transport(str, Enum):
+    """Supported transport mechanisms for FastMCP.
+
+    WHY: Replaces ``Literal['sse', 'stdio']`` to avoid Typer limitations.
+    """
+
+    sse = "sse"
+    stdio = "stdio"
+
+
+class LogLevel(str, Enum):
+    """Supported log levels for uvicorn.
+
+    WHY: Replaces ``Literal[...]`` to avoid Typer limitations.
+    """
+
+    critical = "critical"
+    error = "error"
+    warning = "warning"
+    info = "info"
+    debug = "debug"
+
+
+@app.command()
+def serve(
+    host: str = typer.Option(
+        os.getenv("DATAMIMIC_MCP_HOST", _DEFAULT_HOST),
+        help="Host interface to bind for SSE transport",
+    ),
+    port: int = typer.Option(
+        int(os.getenv("DATAMIMIC_MCP_PORT", str(_DEFAULT_PORT))),
+        help="TCP port to bind for SSE transport",
+    ),
+    transport: Transport = typer.Option(
+        Transport.sse,
+        help="FastMCP transport (sse for network clients, stdio for agent runtimes)",
+    ),
+    log_level: LogLevel = typer.Option(
+        LogLevel.info,
+        help="Log level when running the SSE server",
+    ),
+) -> None:
+    """Start the FastMCP server with optional API key gating."""
+
+    api_key = os.getenv("DATAMIMIC_MCP_API_KEY")
+    server = create_server(api_key=api_key)
+    middleware = getattr(server, HTTP_MIDDLEWARE_ATTR, None)
+
+    if transport == Transport.stdio:
+        # WHY: stdio transport is typically embedded; it does not honour host/port.
+        server.run(Transport.stdio.value)
+        return
+
+    sse_app = build_sse_app(server, middleware)
+    uvicorn.run(
+        sse_app,
+        host=host,
+        port=port,
+        log_level=log_level.value,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/datamimic_ce/mcp/models.py
+++ b/datamimic_ce/mcp/models.py
@@ -1,0 +1,162 @@
+"""Pydantic models backing the MCP surface."""
+
+from __future__ import annotations
+
+import csv
+from functools import lru_cache
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+from datamimic_ce.domains.common.locale_registry import dataset_code_for_locale
+from datamimic_ce.domains.locales import SUPPORTED_DATASET_CODES
+from datamimic_ce.domains.utils.dataset_path import dataset_path
+
+MAX_COUNT = 10_000
+_DEFAULT_LOCALE = "en_US"
+_DEFAULT_CLOCK = "2025-01-01T00:00:00Z"
+
+_DATASET_LOCALE_DEFAULTS: dict[str, str] = {
+    "US": "en_US",
+    "DE": "de_DE",
+    "VN": "vi_VN",
+}
+
+
+@lru_cache(maxsize=None)
+def _default_locale_for_dataset(dataset: str) -> str | None:
+    """Infer the canonical locale for a dataset using packaged metadata."""
+
+    normalized = dataset.upper()
+    explicit = _DATASET_LOCALE_DEFAULTS.get(normalized)
+    if explicit:
+        return explicit
+
+    try:
+        path = dataset_path("common", f"country_{normalized}.csv")
+    except OSError:  # pragma: no cover - defensive fall-back for env overrides
+        return None
+
+    expected_name = f"country_{normalized}.csv"
+    if path.name != expected_name or not path.exists():
+        return None
+
+    with path.open("r", encoding="utf-8") as handle:
+        reader = csv.reader(handle)
+        for row in reader:
+            if not row:
+                continue
+            code = row[0].strip().upper()
+            if code != normalized or len(row) < 2:
+                continue
+            locale = row[1].strip().replace("-", "_")
+            if locale:
+                return locale
+    return None
+
+
+class GenerateArgs(BaseModel):
+    """Validated request arguments for the ``generate`` MCP tool."""
+
+    domain: str = Field(..., description="Target domain identifier")
+    version: str = Field("v1", description="Domain contract version")
+    count: int = Field(
+        1,
+        ge=0,
+        le=MAX_COUNT,
+        description="Number of records to generate (capped at 10k)",
+    )
+    seed: int | str = Field(
+        "0",
+        description="Seed propagated to the deterministic generators",
+    )
+    locale: str | None = Field(
+        None,
+        description="Locale identifier (e.g. en_US). Defaults to dataset derived locale",
+    )
+    dataset: str | None = Field(
+        None,
+        description=(
+            "Dataset code that implies a locale (e.g. US). "
+            "Mutually exclusive with custom locale overrides."
+        ),
+    )
+    constraints: dict[str, Any] | None = Field(
+        None,
+        description="Optional domain-specific constraint overrides",
+    )
+    profile_id: str | None = Field(
+        None,
+        description="Explicit profile selection (mutually exclusive with component_id)",
+    )
+    component_id: str | None = Field(
+        None,
+        description="Component-driven profile selection (mutually exclusive with profile_id)",
+    )
+    clock: str = Field(
+        _DEFAULT_CLOCK,
+        description="ISO8601 timestamp establishing the deterministic reference clock",
+    )
+
+    @model_validator(mode="after")
+    def _enforce_contracts(self) -> "GenerateArgs":
+        if self.profile_id and self.component_id:
+            raise ValueError("profile_id and component_id cannot be combined")
+
+        resolved_dataset = self._normalize_dataset(self.dataset)
+        resolved_locale = self._normalize_locale(self.locale, resolved_dataset)
+
+        if self.locale and resolved_dataset:
+            dataset_for_locale = dataset_code_for_locale(self.locale)
+            if dataset_for_locale.upper() != resolved_dataset:
+                raise ValueError("locale and dataset disagree on the backing data pack")
+
+        object.__setattr__(self, "dataset", resolved_dataset)
+        object.__setattr__(self, "locale", resolved_locale)
+        return self
+
+    @staticmethod
+    def _normalize_dataset(raw: str | None) -> str | None:
+        """Canonicalize dataset identifiers and enforce the supported list."""
+        if raw is None:
+            return None
+        normalized = raw.strip().upper()
+        if not normalized:
+            return None
+        if normalized not in SUPPORTED_DATASET_CODES:
+            supported = ", ".join(SUPPORTED_DATASET_CODES)
+            raise ValueError(
+                f"Unsupported dataset '{normalized}'. Expected one of [{supported}]",
+            )
+        return normalized
+
+    @staticmethod
+    def _normalize_locale(locale: str | None, dataset: str | None) -> str:
+        """Derive the locale, falling back to dataset defaults or the global default."""
+        if locale:
+            return locale
+        if dataset:
+            inferred = _default_locale_for_dataset(dataset)
+            if inferred:
+                return inferred
+        return _DEFAULT_LOCALE
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serialize the request into the facade payload shape."""
+        payload: dict[str, Any] = {
+            "domain": self.domain,
+            "version": self.version,
+            "count": self.count,
+            "seed": self.seed,
+            "locale": self.locale,
+            "constraints": self.constraints or {},
+            "clock": self.clock,
+        }
+        if self.profile_id:
+            payload["profile_id"] = self.profile_id
+        if self.component_id:
+            payload["component_id"] = self.component_id
+        return payload
+
+
+__all__ = ["GenerateArgs", "MAX_COUNT"]

--- a/datamimic_ce/mcp/models.py
+++ b/datamimic_ce/mcp/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import csv
-from functools import lru_cache
+from functools import cache
 from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
@@ -23,7 +23,7 @@ _DATASET_LOCALE_DEFAULTS: dict[str, str] = {
 }
 
 
-@lru_cache(maxsize=None)
+@cache
 def _default_locale_for_dataset(dataset: str) -> str | None:
     """Infer the canonical locale for a dataset using packaged metadata."""
 
@@ -76,10 +76,7 @@ class GenerateArgs(BaseModel):
     )
     dataset: str | None = Field(
         None,
-        description=(
-            "Dataset code that implies a locale (e.g. US). "
-            "Mutually exclusive with custom locale overrides."
-        ),
+        description=("Dataset code that implies a locale (e.g. US). Mutually exclusive with custom locale overrides."),
     )
     constraints: dict[str, Any] | None = Field(
         None,
@@ -99,7 +96,7 @@ class GenerateArgs(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _enforce_contracts(self) -> "GenerateArgs":
+    def _enforce_contracts(self) -> GenerateArgs:
         if self.profile_id and self.component_id:
             raise ValueError("profile_id and component_id cannot be combined")
 

--- a/datamimic_ce/mcp/resources.py
+++ b/datamimic_ce/mcp/resources.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterator, Literal, cast
+from typing import Any, Literal, cast
 
 from datamimic_ce.domains import facade
 

--- a/datamimic_ce/mcp/resources.py
+++ b/datamimic_ce/mcp/resources.py
@@ -1,0 +1,55 @@
+"""Expose JSON Schema resources for MCP clients."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, Literal, cast
+
+from datamimic_ce.domains import facade
+
+SchemaKind = Literal["request", "response"]
+
+
+@dataclass(frozen=True)
+class SchemaResource:
+    """Descriptor for a domain schema resource."""
+
+    domain: str
+    version: str
+    kind: SchemaKind
+
+    @property
+    def uri(self) -> str:
+        """Return the canonical MCP resource URI."""
+        return f"resource://datamimic/schemas/{self.domain}/{self.version}/{self.kind}.json"
+
+    @property
+    def path(self) -> Path:
+        """Resolve the on-disk schema path for the resource."""
+        filename = f"{self.domain}.{self.version}.{self.kind}.json"
+        return Path(__file__).resolve().parents[1] / "domains" / "schemas" / filename
+
+
+def iter_schema_resources() -> Iterator[SchemaResource]:
+    """Yield schema descriptors for each domain and version pair."""
+    for domain, version in sorted(facade.REGISTRY):
+        yield SchemaResource(domain=domain, version=version, kind="request")
+        yield SchemaResource(domain=domain, version=version, kind="response")
+
+
+def load_schema(domain: str, version: str, kind: SchemaKind) -> dict[str, Any]:
+    """Load a schema document from disk using the canonical registry layout."""
+    resource = SchemaResource(domain=domain, version=version, kind=kind)
+    path = resource.path
+    if not path.exists():
+        raise FileNotFoundError(f"Missing schema file for {resource.uri}")
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):  # Defensive guardrail for schema drift.
+        raise TypeError(f"Schema at {path} must decode into an object")
+    return cast(dict[str, Any], data)
+
+
+__all__ = ["SchemaResource", "SchemaKind", "iter_schema_resources", "load_schema"]

--- a/datamimic_ce/mcp/server.py
+++ b/datamimic_ce/mcp/server.py
@@ -1,0 +1,181 @@
+"""FastMCP server wiring for DataMimic domains."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import MISSING, fields
+from typing import Any, TYPE_CHECKING, cast
+
+from fastmcp import FastMCP
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.routing import Mount, Route
+
+from datamimic_ce.domains import facade
+from datamimic_ce.mcp import resources
+from datamimic_ce.mcp.models import GenerateArgs
+
+if TYPE_CHECKING:  # pragma: no cover - import hint for typing only
+    from typing import Protocol
+
+    class _FastAPILike(Protocol):  # pylint: disable=too-few-public-methods
+        def mount(self, path: str, app: Any) -> None:
+            """Mount an ASGI app at the provided path."""
+else:  # pragma: no cover - runtime fallback avoids optional FastAPI dependency
+    _FastAPILike = Any
+
+
+HTTP_MIDDLEWARE_ATTR = "_datamimic_http_middleware"
+
+
+class _APIKeyMiddleware(BaseHTTPMiddleware):  # pylint: disable=too-few-public-methods
+    """Reject requests that lack the configured API key."""
+
+    def __init__(self, app: Any, api_key: str) -> None:
+        super().__init__(app)
+        self._api_key = api_key
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        provided = request.headers.get("authorization")
+        token = None
+        if provided and provided.lower().startswith("bearer "):
+            token = provided.split(" ", 1)[1]
+        if token is None:
+            token = request.headers.get("x-api-key")
+        if token != self._api_key:
+            return JSONResponse(
+                status_code=HTTP_401_UNAUTHORIZED,
+                content={"error": "invalid_api_key"},
+            )
+        return await call_next(request)
+
+
+def list_domains_impl() -> list[dict[str, Any]]:
+    """Return metadata describing the registered domain generators."""
+
+    catalog: list[dict[str, Any]] = []
+    for (domain, version), (request_cls, _) in sorted(facade.REGISTRY.items()):
+        defaults: dict[str, Any] = {}
+        field_names: list[str] = []
+        for field in fields(request_cls):
+            if field.name == "request_hash":
+                continue
+            field_names.append(field.name)
+            if field.default is not MISSING:
+                defaults[field.name] = field.default
+        catalog.append(
+            {
+                "domain": domain,
+                "version": version,
+                "request_fields": field_names,
+                "defaults": defaults,
+            }
+        )
+    return catalog
+
+
+def generate_impl(args: GenerateArgs) -> dict[str, Any]:
+    """Delegate to the domain facade with deterministic payloads."""
+
+    payload = args.to_payload()
+    # WHY: The facade owns canonical hashing and RNG seeding; forwarding the payload
+    # untouched prevents duplicate hash derivations and keeps determinism obvious.
+    return cast(dict[str, Any], facade.generate_domain(payload))
+
+
+def create_server(*, api_key: str | None = None) -> FastMCP:
+    """Create a FastMCP server exposing DataMimic generators."""
+
+    server = FastMCP(
+        name="datamimic-ce",
+        version=None,
+    )
+
+    @server.tool("list_domains")
+    async def list_domains() -> list[dict[str, Any]]:
+        return list_domains_impl()
+
+    @server.tool("generate")
+    async def generate(args: GenerateArgs) -> dict[str, Any]:
+        return generate_impl(args)
+
+    http_middleware = _build_http_middleware(api_key)
+    setattr(server, HTTP_MIDDLEWARE_ATTR, http_middleware)
+
+    for schema in resources.iter_schema_resources():
+        loader = _schema_loader(schema.domain, schema.version, schema.kind)
+        server.resource(schema.uri, mime_type="application/schema+json")(loader)
+
+    return server
+
+
+def mount_mcp(
+    app: _FastAPILike,
+    *,
+    path: str = "/mcp",
+    api_key: str | None = None,
+    server: FastMCP | None = None,
+) -> FastMCP:
+    """Mount the FastMCP server onto an existing FastAPI application."""
+
+    mcp_server = server or create_server(api_key=api_key)
+    http_middleware = getattr(mcp_server, HTTP_MIDDLEWARE_ATTR, None)
+    sse_app = build_sse_app(mcp_server, http_middleware)
+    app.mount(path, sse_app)
+    return mcp_server
+
+
+def _build_http_middleware(api_key: str | None) -> list[Middleware] | None:
+    if not api_key:
+        return None
+    # WHY: Starlette middleware keeps HTTP transports gated.
+    # Avoid reimplementing FastMCP internals just for header inspection.
+    return [Middleware(_APIKeyMiddleware, api_key=api_key)]
+
+
+def _schema_loader(
+    domain: str,
+    version: str,
+    kind: resources.SchemaKind,
+) -> Callable[[], dict[str, Any]]:
+    """Build a parameterless schema loader for the FastMCP registry."""
+
+    def load() -> dict[str, Any]:
+        return resources.load_schema(domain, version, kind)
+
+    return load
+
+
+def build_sse_app(
+    server: FastMCP,
+    middleware: list[Middleware] | None,
+) -> Starlette:
+    """Create an SSE ASGI app with optional middleware layering.
+
+    Note: FastMCP's Starlette route may log a benign TypeError due to returning
+    None after streaming. This does not affect functionality; tests verify end-to-end.
+    """
+
+    sse_factory = cast(Callable[[], Starlette], getattr(server, "sse_app"))
+    sse_app = sse_factory()
+    if middleware:
+        for entry in middleware:
+            # WHY: Starlette stores middleware callables and kwargs separately; rehydrate
+            # them instead of reimplementing the wrapping logic here.
+            sse_app.add_middleware(entry.cls, *entry.args, **entry.kwargs)
+    return sse_app
+
+
+__all__ = [
+    "create_server",
+    "mount_mcp",
+    "generate_impl",
+    "list_domains_impl",
+    "build_sse_app",
+]

--- a/datamimic_ce/mcp/server.py
+++ b/datamimic_ce/mcp/server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import MISSING, fields
-from typing import Any, TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from fastmcp import FastMCP
 from starlette.applications import Starlette
@@ -13,7 +13,6 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.status import HTTP_401_UNAUTHORIZED
-from starlette.routing import Mount, Route
 
 from datamimic_ce.domains import facade
 from datamimic_ce.mcp import resources
@@ -39,9 +38,7 @@ class _APIKeyMiddleware(BaseHTTPMiddleware):  # pylint: disable=too-few-public-m
         super().__init__(app)
         self._api_key = api_key
 
-    async def dispatch(
-        self, request: Request, call_next: RequestResponseEndpoint
-    ) -> Response:
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         provided = request.headers.get("authorization")
         token = None
         if provided and provided.lower().startswith("bearer "):
@@ -86,7 +83,7 @@ def generate_impl(args: GenerateArgs) -> dict[str, Any]:
     payload = args.to_payload()
     # WHY: The facade owns canonical hashing and RNG seeding; forwarding the payload
     # untouched prevents duplicate hash derivations and keeps determinism obvious.
-    return cast(dict[str, Any], facade.generate_domain(payload))
+    return facade.generate_domain(payload)
 
 
 def create_server(*, api_key: str | None = None) -> FastMCP:
@@ -162,7 +159,7 @@ def build_sse_app(
     None after streaming. This does not affect functionality; tests verify end-to-end.
     """
 
-    sse_factory = cast(Callable[[], Starlette], getattr(server, "sse_app"))
+    sse_factory = cast(Callable[[], Starlette], server.sse_app)
     sse_app = sse_factory()
     if middleware:
         for entry in middleware:

--- a/datamimic_ce/workers/ray_generate_worker.py
+++ b/datamimic_ce/workers/ray_generate_worker.py
@@ -4,7 +4,7 @@
 # See LICENSE file for the full text of the license.
 # For questions and support, contact: info@rapiddweller.com
 
-import ray  # type: ignore[import-not-found]
+import ray
 
 from datamimic_ce.contexts.geniter_context import GenIterContext
 from datamimic_ce.contexts.setup_context import SetupContext

--- a/docs/mcp_quickstart.md
+++ b/docs/mcp_quickstart.md
@@ -1,0 +1,135 @@
+# DATAMIMIC MCP Quickstart
+
+This guide walks through installing and exercising the Model Context Protocol (MCP) surface that wraps the existing DataMimic domain facade.
+
+## Installation
+
+```bash
+pip install datamimic-ce[mcp]
+```
+
+The optional `mcp` extra pulls in `fastmcp`, `uvicorn`, and the additional runtime pieces needed for the server and tests.
+
+For local development against a checkout, install the package in editable mode so the test suite can import the optional transport client:
+
+```bash
+pip install -e .[mcp]
+```
+
+## Running the server
+
+Launch the MCP server via the dedicated CLI:
+
+```bash
+export DATAMIMIC_MCP_HOST=127.0.0.1
+export DATAMIMIC_MCP_PORT=8765
+# Optional API key gate – clients must send the same token via `Authorization: Bearer` or `X-API-Key`
+export DATAMIMIC_MCP_API_KEY=changeme
+
+datamimic-mcp
+```
+
+Environment variables override the Typer command options so deployments can be tuned without altering scripts:
+
+- `DATAMIMIC_MCP_HOST` (default `127.0.0.1`, only used for SSE transport)
+- `DATAMIMIC_MCP_PORT` (default `8765`, only used for SSE transport)
+- `DATAMIMIC_MCP_API_KEY` (unset disables authentication)
+
+## IDE configuration
+
+### Claude Desktop (YAML)
+
+```yaml
+mcpServers:
+  datamimic:
+    command: datamimic-mcp
+    args: ["--host", "127.0.0.1", "--port", "8765"]
+    env:
+      DATAMIMIC_MCP_API_KEY: changeme
+```
+
+### Cursor (JSON)
+
+```json
+{
+  "mcpServers": {
+    "datamimic": {
+      "command": "datamimic-mcp",
+      "args": ["--host", "127.0.0.1", "--port", "8765"],
+      "env": {
+        "DATAMIMIC_MCP_HOST": "127.0.0.1",
+        "DATAMIMIC_MCP_PORT": "8765"
+      }
+    }
+  }
+}
+```
+
+Both snippets assume the CLI is on `PATH`. Remove the API key entry if the server is running without authentication.
+
+## Example interactions
+
+### List domains
+
+```python
+import anyio
+from fastmcp.client import Client
+from datamimic_ce.mcp.server import create_server
+
+async def main():
+    async with Client(create_server()) as client:
+        response = await client.call_tool("list_domains")
+        print(response[0].text)
+
+anyio.run(main)
+```
+
+Sample output (truncated):
+
+```json
+[{"domain":"person","version":"v1","request_fields":["domain","version","count","seed","locale","profile_id","component_id","constraints","clock"],"defaults":{"domain":"person","version":"v1","count":1,"seed":"0","locale":"en_US"}}, ...]
+```
+
+### Generate deterministic people
+
+```python
+import anyio, json
+from fastmcp.client import Client
+from datamimic_ce.mcp.models import GenerateArgs
+from datamimic_ce.mcp.server import create_server
+
+async def main():
+    args = GenerateArgs(domain="person", locale="en_US", seed=42, count=2)
+    async with Client(create_server()) as client:
+        payload = args.model_dump(mode="python")
+        first = await client.call_tool("generate", {"args": payload})
+        second = await client.call_tool("generate", {"args": payload})
+        print(json.loads(first[0].text) == json.loads(second[0].text))  # True
+
+anyio.run(main)
+```
+
+The `determinism_proof.content_hash` field and the canonical JSON comparisons will match across identical requests, ensuring byte-identical payloads for the same seed lineage.
+
+### Payments domain example
+
+```python
+args = GenerateArgs(domain="address", locale="de_DE", seed=7, count=1)
+```
+
+Running the snippet twice with the same seed yields identical addresses. Switching `seed` alters the content hash and record values without touching structural metadata.
+
+## Security and guardrails
+
+- **Authentication** – set `DATAMIMIC_MCP_API_KEY` to require clients to present the same token via `Authorization: Bearer <token>` or the `X-API-Key` header. Requests lacking the correct key receive `401` responses.
+- **Resource caps** – the `GenerateArgs.count` field is capped at `10_000`. Larger requests fail validation before reaching domain code.
+- **Profile selectors** – `profile_id` and `component_id` are mutually exclusive. The model validator raises immediately if both are supplied.
+- **Deterministic clock** – the `clock` attribute defaults to `2025-01-01T00:00:00Z` to preserve reproducibility while still allowing overrides.
+
+## Additional resources
+
+- `examples/call_list_domains.py` – prints the registered tools and domain catalogue.
+- `examples/call_generate.py` – emits sample person records using `seed=42`.
+- `make typecheck`, `make lint`, and `make coverage` – convenience targets for the strict quality gates (mypy `--strict`, pylint ≥ 9.0, coverage ≥ 90%).
+
+Happy generating!

--- a/examples/call_generate.py
+++ b/examples/call_generate.py
@@ -1,0 +1,20 @@
+"""Minimal generate invocation showing deterministic output."""
+
+import anyio
+import json
+from fastmcp.client import Client
+
+from datamimic_ce.mcp.models import GenerateArgs
+from datamimic_ce.mcp.server import create_server
+
+
+async def _main() -> None:
+    async with Client(create_server()) as client:
+        args = GenerateArgs(domain="person", locale="en_US", seed=42)
+        payload = args.model_dump(mode="python")
+        result = await client.call_tool("generate", {"args": payload})
+        print(json.dumps(json.loads(result[0].text), indent=2))
+
+
+if __name__ == "__main__":
+    anyio.run(_main)

--- a/examples/call_list_domains.py
+++ b/examples/call_list_domains.py
@@ -1,0 +1,18 @@
+"""Quick helper to list available MCP domains."""
+
+import anyio
+from fastmcp.client import Client
+
+from datamimic_ce.mcp.server import create_server
+
+
+async def _main() -> None:
+    async with Client(create_server()) as client:
+        tools = await client.list_tools()
+        print("Tools:", ", ".join(sorted(tool.name for tool in tools)))
+        domains = await client.call_tool("list_domains")
+        print(domains[0].text)
+
+
+if __name__ == "__main__":
+    anyio.run(_main)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,18 @@ ray = [
     "ray>=2.40.0",
 ]
 
+# Optional dependency group for MCP server surface
+mcp = [
+    "fastmcp>=2.0",
+    "uvicorn>=0.30",
+]
+
 [tool.setuptools_scm]
 local_scheme = "dirty-tag"  # Includes a "dirty" tag in version if working directory is not clean
 
 [project.scripts]
 datamimic = "datamimic_ce.cli:app"  # Entry point for your CLI application
+datamimic-mcp = "datamimic_ce.mcp.cli:app"
 
 [tool.setuptools]
 include-package-data = true
@@ -83,10 +90,14 @@ dev-dependencies = [
     "types-psutil>=6.0.0",
     "types-xmltodict>=0.13.0",
     "types-lxml>=5.3.0",
+    "fastmcp>=2.0",
+    "uvicorn>=0.30",
 ]
 
 [tool.mypy]
 python_version = "3.11"
+warn_redundant_casts = true
+warn_unused_ignores = true
 
 [tool.ruff]
 line-length = 120                  # Maximum line length
@@ -124,3 +135,20 @@ addopts = "-n auto --dist=loadscope"
 
 [tool.pyright]
 typeCheckingMode="off"
+
+[tool.pylint.main]
+fail-under = 9.0
+fail-on = ["E", "F"]
+
+[tool.pylint.reports]
+output-format = "colorized"
+
+[[tool.mypy.overrides]]
+module = "datamimic_ce.*"
+follow_imports = "skip"
+
+[[tool.mypy.overrides]]
+module = "datamimic_ce.mcp.*"
+follow_imports = "normal"
+disallow_any_generics = true
+no_implicit_optional = true

--- a/tests_ce/integration_tests/test_mcp_cli_sse.py
+++ b/tests_ce/integration_tests/test_mcp_cli_sse.py
@@ -1,0 +1,140 @@
+"""Integration tests for the real MCP CLI over SSE.
+
+WHY: Complements stdio tests by exercising the CLI in network mode, including
+API key gating. Prints selected output so humans can verify behavior.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from typing import Iterable
+
+import anyio
+import pytest
+
+fastmcp_client = pytest.importorskip(
+    "fastmcp.client", reason="fastmcp extra required; install datamimic_ce[mcp]"
+)
+transports = pytest.importorskip(
+    "fastmcp.client.transports", reason="fastmcp extra required; install datamimic_ce[mcp]"
+)
+
+Client = fastmcp_client.Client
+SSETransport = transports.SSETransport
+
+from datamimic_ce.mcp.models import GenerateArgs
+
+
+def _free_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_port_open(host: str, port: int, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise TimeoutError(f"Port {host}:{port} did not open in time")
+
+
+def _spawn_cli_sse(port: int, env: dict[str, str] | None = None) -> subprocess.Popen:
+    cmd = [
+        sys.executable,
+        "-m",
+        "datamimic_ce.mcp.cli",
+        "--transport",
+        "sse",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--log-level",
+        "warning",
+    ]
+    proc = subprocess.Popen(cmd, env={**os.environ, **(env or {})})
+    _wait_port_open("127.0.0.1", port)
+    return proc
+
+
+def _kill(proc: subprocess.Popen) -> None:
+    try:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    except Exception:
+        pass
+
+
+def _print_tools(tools: Iterable) -> None:  # pragma: no cover - print helper
+    names = sorted([t.name for t in tools])
+    print("SSE MCP tools:", names)
+
+
+@pytest.fixture
+def anyio_backend() -> str:  # pragma: no cover - fixture glue
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_cli_sse_generate_roundtrip(anyio_backend) -> None:
+    port = _free_tcp_port()
+    proc = _spawn_cli_sse(port)
+    try:
+        async with Client(SSETransport(f"http://127.0.0.1:{port}/sse")) as client:
+            tools = await client.list_tools()
+            _print_tools(tools)
+
+            # Also call the catalog tool and show basic stats for human verification
+            catalog_raw = await client.call_tool("list_domains", {})
+            catalog = json.loads(catalog_raw[0].text)
+            print("Domains count:", len(catalog))
+            if catalog:
+                print("First domain entry:", json.dumps(catalog[0], sort_keys=True)[:240])
+
+            args = GenerateArgs(domain="person", locale="en_US", seed=42)
+            res = await client.call_tool("generate", {"args": args.model_dump(mode="python")})
+            data = json.loads(res[0].text)
+            assert data.get("items"), "Expected generated items from SSE CLI"
+            print("Generated sample (seed=42):", json.dumps(data["items"][0], sort_keys=True)[:240])
+            # Verify schema resource fetch via SSE transport
+            res_schema = await client.read_resource("resource://datamimic/schemas/person/v1/request.json")
+            assert res_schema and res_schema[0].text
+            print("Schema snippet:", res_schema[0].text[:120])
+    finally:
+        _kill(proc)
+
+
+@pytest.mark.anyio
+async def test_cli_sse_requires_api_key_forbidden_without_header(anyio_backend) -> None:
+    port = _free_tcp_port()
+    proc = _spawn_cli_sse(port, env={"DATAMIMIC_MCP_API_KEY": "secret"})
+    try:
+        # Attempt without header should fail with HTTP 401
+        with pytest.raises(Exception):
+            async with Client(SSETransport(f"http://127.0.0.1:{port}/sse")) as client:
+                await client.list_tools()
+
+        # With Authorization header it should succeed
+        headers = {"Authorization": "Bearer secret"}
+        async with Client(SSETransport(f"http://127.0.0.1:{port}/sse", headers=headers)) as client:
+            tools = await client.list_tools()
+            _print_tools(tools)
+            args = GenerateArgs(domain="person", seed=99)
+            res = await client.call_tool("generate", {"args": args.model_dump(mode="python")})
+            data = json.loads(res[0].text)
+            assert data.get("items"), "Expected generated items with API key"
+            print("Generated sample (seed=99, gated):", json.dumps(data["items"][0], sort_keys=True)[:240])
+    finally:
+        _kill(proc)

--- a/tests_ce/integration_tests/test_mcp_cli_stdio.py
+++ b/tests_ce/integration_tests/test_mcp_cli_stdio.py
@@ -1,0 +1,73 @@
+"""Integration test: spawn the real MCP CLI in stdio mode and call tools.
+
+WHY: Ensures our tests exercise the actual CLI process and FastMCP wiring
+without mocks. Uses stdio transport so no network is required.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import anyio
+import pytest
+
+fastmcp_client = pytest.importorskip(
+    "fastmcp.client", reason="fastmcp extra required; install datamimic_ce[mcp]"
+)
+transports = pytest.importorskip(
+    "fastmcp.client.transports", reason="fastmcp extra required; install datamimic_ce[mcp]"
+)
+
+Client = fastmcp_client.Client
+PythonStdioTransport = transports.PythonStdioTransport
+
+from datamimic_ce.mcp.models import GenerateArgs
+from datamimic_ce.domains.determinism import canonical_json, hash_bytes
+
+
+@pytest.fixture
+def anyio_backend() -> str:  # pragma: no cover - fixture glue
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_cli_stdio_generate_roundtrip() -> None:
+    # Spawn the real CLI as a subprocess with stdio transport
+    transport = PythonStdioTransport(
+        script_path="datamimic_ce/mcp/cli.py",
+        args=["--transport", "stdio"],
+        python_cmd=sys.executable,
+    )
+
+    async with Client(transport) as client:
+        # Discover tools
+        tools = await client.list_tools()
+        tool_names = {t.name for t in tools}
+        assert {"list_domains", "generate"}.issubset(tool_names)
+        # Show tool list for human verification in -s runs
+        print("MCP tools:", sorted(tool_names))
+        # Also show domain catalog size and first entry
+        catalog_raw = await client.call_tool("list_domains", {})
+        catalog = json.loads(catalog_raw[0].text)
+        print("Domains count:", len(catalog))
+        if catalog:
+            print("First domain entry:", json.dumps(catalog[0], sort_keys=True)[:240])
+
+        # Call generate with deterministic args and assert result shape
+        args = GenerateArgs(domain="person", locale="en_US", seed=7)
+        payload = args.model_dump(mode="python")
+        result = await client.call_tool("generate", {"args": payload})
+        assert result, "No content from generate tool"
+        text = result[0].text
+        assert text and text.strip(), "Empty text payload from generate tool"
+        data = json.loads(text)
+        assert isinstance(data.get("items"), list) and data["items"], "Expected non-empty generated items"
+        # Show a snippet of the generated item for human verification in -s runs
+        sample = data["items"][0]
+        print("Generated sample (seed=7):", json.dumps(sample, sort_keys=True)[:240])
+        # Determinism is covered in unit/e2e tests; stdio path validated for roundtrip.
+        # Also verify schema resource fetch via stdio transport
+        res = await client.read_resource("resource://datamimic/schemas/person/v1/request.json")
+        assert res and res[0].text
+        print("Schema snippet:", res[0].text[:120])

--- a/tests_ce/unit_tests/test_mcp/conftest.py
+++ b/tests_ce/unit_tests/test_mcp/conftest.py
@@ -1,0 +1,9 @@
+"""Ensure the project package is importable during isolated test runs."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = ROOT.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests_ce/unit_tests/test_mcp/test_cli.py
+++ b/tests_ce/unit_tests/test_mcp/test_cli.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+# WHY: These tests prove CLI option parsing works without relying on Typer's
+# Literal support. We validate behavior using Enums and avoid I/O by mocking.
+
+from importlib import import_module
+from types import ModuleType
+from typer.testing import CliRunner
+
+
+runner = CliRunner()
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.runs: list[str] = []
+
+    def run(self, mode: str) -> None:
+        self.runs.append(mode)
+
+
+def test_cli_transport_stdio_invokes_server_run(monkeypatch) -> None:
+    fake = _FakeServer()
+
+    # Install a fake server module before importing the CLI to avoid optional deps
+    fake_server = ModuleType("datamimic_ce.mcp.server")
+    fake_server.HTTP_MIDDLEWARE_ATTR = "_datamimic_http_middleware"  # type: ignore[attr-defined]
+
+    def _fake_create_server(api_key=None):  # noqa: ANN001
+        return fake
+
+    def _fake_build_sse_app(server, middleware):  # noqa: ANN001
+        return object()
+
+    fake_server.create_server = _fake_create_server  # type: ignore[attr-defined]
+    fake_server.build_sse_app = _fake_build_sse_app  # type: ignore[attr-defined]
+    fake_server.mount_mcp = lambda *a, **k: None  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "datamimic_ce.mcp.server",
+        fake_server,
+    )
+
+    cli_mod = import_module("datamimic_ce.mcp.cli")
+
+    # Ensure uvicorn.run isn't called in stdio mode
+    uvicorn_called = {"count": 0}
+
+    def _fake_uvicorn_run(*args, **kwargs):  # noqa: ANN001
+        uvicorn_called["count"] += 1
+
+    monkeypatch.setattr(cli_mod.uvicorn, "run", _fake_uvicorn_run)
+
+    result = runner.invoke(cli_mod.app, ["--transport", "stdio"])
+
+    assert result.exit_code == 0, result.output
+    assert fake.runs == ["stdio"]
+    assert uvicorn_called["count"] == 0
+
+
+def test_cli_transport_sse_invokes_uvicorn_with_params(monkeypatch) -> None:
+    fake = _FakeServer()
+
+    # Install a fake server module before importing the CLI to avoid optional deps
+    fake_server = ModuleType("datamimic_ce.mcp.server")
+    fake_server.HTTP_MIDDLEWARE_ATTR = "_datamimic_http_middleware"  # type: ignore[attr-defined]
+
+    def _fake_create_server(api_key=None):  # noqa: ANN001
+        return fake
+
+    def _fake_build_sse_app(server, middleware):  # noqa: ANN001
+        return object()
+
+    fake_server.create_server = _fake_create_server  # type: ignore[attr-defined]
+    fake_server.build_sse_app = _fake_build_sse_app  # type: ignore[attr-defined]
+    fake_server.mount_mcp = lambda *a, **k: None  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "datamimic_ce.mcp.server",
+        fake_server,
+    )
+
+    cli_mod = import_module("datamimic_ce.mcp.cli")
+
+    captured = {}
+
+    def _fake_uvicorn_run(app, host, port, log_level):  # noqa: ANN001
+        captured.update({
+            "app": app,
+            "host": host,
+            "port": port,
+            "log_level": log_level,
+        })
+
+    monkeypatch.setattr(cli_mod.uvicorn, "run", _fake_uvicorn_run)
+
+    result = runner.invoke(
+        cli_mod.app,
+        [
+            "--transport",
+            "sse",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "1234",
+            "--log-level",
+            "debug",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    # server.run should not be used for SSE
+    assert fake.runs == []
+    # uvicorn.run should receive our params, including mapped log level
+    assert captured["host"] == "0.0.0.0"
+    assert captured["port"] == 1234
+    assert captured["log_level"] == "debug"

--- a/tests_ce/unit_tests/test_mcp/test_e2e.py
+++ b/tests_ce/unit_tests/test_mcp/test_e2e.py
@@ -1,0 +1,103 @@
+"""End-to-end tests exercising the FastMCP server."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections.abc import Callable
+
+import anyio
+import pytest
+
+fastmcp_client = pytest.importorskip(
+    "fastmcp.client", reason="fastmcp extra required; install datamimic_ce[mcp]"
+)
+uvicorn = pytest.importorskip("uvicorn", reason="uvicorn required for SSE transport tests")
+
+Client = fastmcp_client.Client
+
+from datamimic_ce.domains.determinism import canonical_json, hash_bytes
+from datamimic_ce.mcp.models import GenerateArgs
+from datamimic_ce.mcp.server import (
+    HTTP_MIDDLEWARE_ATTR,
+    build_sse_app,
+    create_server,
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:  # pragma: no cover - fixture glue
+    return "asyncio"
+
+
+async def _call_generate(client: Client, args: GenerateArgs) -> dict:
+    payload = args.model_dump(mode="python")
+    result = await client.call_tool("generate", {"args": payload})
+    assert result, "FastMCP generate tool returned no content"
+    text_payload = result[0].text
+    assert text_payload, "FastMCP generate tool returned empty text"
+    return dict(json.loads(text_payload))
+
+
+@pytest.mark.anyio
+async def test_generate_is_deterministic(anyio_backend) -> None:
+    server = create_server()
+    async with Client(server) as client:
+        args = GenerateArgs(domain="person", locale="en_US", seed=42)
+        first = await _call_generate(client, args)
+        second = await _call_generate(client, args)
+        assert canonical_json(first) == canonical_json(second)
+        assert hash_bytes(canonical_json(first)) == hash_bytes(canonical_json(second))
+
+
+@pytest.mark.anyio
+async def test_schema_resource_available(anyio_backend) -> None:
+    server = create_server()
+    async with Client(server) as client:
+        listing = await client.list_tools()
+        assert {tool.name for tool in listing} == {"list_domains", "generate"}
+        resources = await client.read_resource("resource://datamimic/schemas/person/v1/request.json")
+        assert resources and "\"$schema\"" in resources[0].text
+
+
+@pytest.mark.anyio
+async def test_sse_transport_roundtrip(anyio_backend, free_tcp_port_factory) -> None:
+    server = create_server()
+    middleware = getattr(server, HTTP_MIDDLEWARE_ATTR, None)
+    sse_app = build_sse_app(server, middleware)
+
+    port = free_tcp_port_factory()
+    config = uvicorn.Config(
+        sse_app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        loop="asyncio",
+        lifespan="on",
+    )
+    uvicorn_server = uvicorn.Server(config)
+
+    thread = threading.Thread(target=uvicorn_server.run, daemon=True)
+    thread.start()
+
+    await _wait_for(lambda: uvicorn_server.started)
+
+    try:
+        async with Client(f"http://127.0.0.1:{port}/sse") as client:
+            args = GenerateArgs(domain="person", seed=99)
+            payload = await _call_generate(client, args)
+            assert payload["items"], "Expected generated items from SSE transport"
+    finally:
+        uvicorn_server.should_exit = True
+        uvicorn_server.force_exit = True
+        await anyio.to_thread.run_sync(thread.join, 5)
+
+
+async def _wait_for(condition: Callable[[], bool], timeout: float = 3.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return
+        await anyio.sleep(0.05)
+    raise TimeoutError("Timed out waiting for condition")

--- a/tests_ce/unit_tests/test_mcp/test_models.py
+++ b/tests_ce/unit_tests/test_mcp/test_models.py
@@ -1,0 +1,46 @@
+"""Unit tests for MCP argument models."""
+
+import pytest
+
+from datamimic_ce.mcp import models
+from datamimic_ce.mcp.models import GenerateArgs, MAX_COUNT
+
+
+def test_mutually_exclusive_profile_and_component() -> None:
+    with pytest.raises(ValueError):
+        GenerateArgs(domain="person", profile_id="p", component_id="c")
+
+
+def test_count_upper_bound() -> None:
+    with pytest.raises(ValueError):
+        GenerateArgs(domain="person", count=MAX_COUNT + 1)
+
+
+def test_dataset_resolves_locale() -> None:
+    args = GenerateArgs(domain="person", dataset="us")
+    assert args.dataset == "US"
+    assert args.locale == "en_US"
+
+
+def test_dataset_locale_inferred_from_metadata(monkeypatch) -> None:
+    models._default_locale_for_dataset.cache_clear()
+    monkeypatch.setattr(
+        models,
+        "_DATASET_LOCALE_DEFAULTS",
+        {"US": "en_US", "VN": "vi_VN"},
+        raising=False,
+    )
+    args = GenerateArgs(domain="person", dataset="DE")
+    assert args.locale == "de_DE"
+
+
+def test_dataset_locale_mismatch() -> None:
+    with pytest.raises(ValueError):
+        GenerateArgs(domain="person", dataset="US", locale="de_DE")
+
+
+def test_to_payload_expands_defaults() -> None:
+    args = GenerateArgs(domain="person", locale="en_US", constraints={"age": {"min": 18}})
+    payload = args.to_payload()
+    assert payload["constraints"] == {"age": {"min": 18}}
+    assert payload["clock"] == args.clock

--- a/tests_ce/unit_tests/test_mcp/test_server_unit.py
+++ b/tests_ce/unit_tests/test_mcp/test_server_unit.py
@@ -1,0 +1,107 @@
+"""Unit coverage for the MCP server wiring."""
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import Response
+
+from datamimic_ce.domains import facade
+from datamimic_ce.mcp import resources
+from datamimic_ce.mcp.models import GenerateArgs
+from datamimic_ce.mcp.server import (
+    HTTP_MIDDLEWARE_ATTR,
+    build_sse_app,
+    create_server,
+    generate_impl,
+    list_domains_impl,
+    _APIKeyMiddleware,
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:  # pragma: no cover - fixture glue
+    return "asyncio"
+
+
+async def _receive() -> dict:
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+async def _noop_app(scope, receive, send):  # pragma: no cover - helper
+    return None
+
+
+def test_list_domains_matches_registry() -> None:
+    listing = list_domains_impl()
+    registry_keys = set(facade.REGISTRY.keys())
+    reported_keys = {(item["domain"], item["version"]) for item in listing}
+    assert reported_keys == registry_keys
+
+
+def test_generate_impl_forwards_payload(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_generate(payload):
+        captured["payload"] = payload
+        return {"ok": True}
+
+    monkeypatch.setattr(facade, "generate_domain", fake_generate)
+
+    args = GenerateArgs(domain="person", locale="en_US", seed=123, count=2)
+    result = generate_impl(args)
+
+    assert result == {"ok": True}
+    forwarded = captured["payload"]
+    assert forwarded["domain"] == "person"
+    assert forwarded["seed"] == 123
+    assert forwarded["count"] == 2
+    assert forwarded["locale"] == "en_US"
+
+
+@pytest.mark.anyio
+async def test_api_key_middleware_rejects_invalid_token(anyio_backend) -> None:
+    middleware = _APIKeyMiddleware(_noop_app, "secret")
+    scope = {"type": "http", "method": "GET", "path": "/", "headers": []}
+    request = Request(scope, _receive)
+
+    async def call_next(_: Request) -> Response:  # pragma: no cover - defensive
+        return Response("ok")
+
+    response = await middleware.dispatch(request, call_next)
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_api_key_middleware_allows_matching_bearer(anyio_backend) -> None:
+    middleware = _APIKeyMiddleware(_noop_app, "secret")
+    headers = [(b"authorization", b"Bearer secret")]
+    scope = {"type": "http", "method": "GET", "path": "/", "headers": headers}
+    request = Request(scope, _receive)
+
+    async def call_next(_: Request) -> Response:
+        return Response("ok", status_code=200)
+
+    response = await middleware.dispatch(request, call_next)
+    assert response.status_code == 200
+
+
+def test_missing_schema_raises() -> None:
+    with pytest.raises(FileNotFoundError):
+        resources.load_schema("unknown", "v1", "request")
+
+
+def test_build_sse_app_applies_middleware() -> None:
+    server = create_server(api_key="secret")
+    middleware = getattr(server, HTTP_MIDDLEWARE_ATTR)
+    assert middleware is not None
+    sse_app = build_sse_app(server, middleware)
+    assert any(entry.cls is _APIKeyMiddleware for entry in sse_app.user_middleware)
+
+
+def test_schema_resources_loadable() -> None:
+    discovered: list[str] = []
+    for entry in resources.iter_schema_resources():
+        discovered.append(entry.uri)
+        loaded = resources.load_schema(entry.domain, entry.version, entry.kind)
+        assert isinstance(loaded, dict)
+        assert loaded, "Schema should not be empty"
+    assert discovered, "Expected packaged schema resources"


### PR DESCRIPTION
Summary:
- Deliver a production-ready FastMCP server with SSE mounting, optional API-key middleware, and resource registration so LLM agents can stream deterministic synthetic data from the existing DataMimic facade without duplicating business logic.
- Harden the GenerateArgs contract with dataset-to-locale inference, mutual-exclusion guardrails, and deterministic payload serialization to keep Model Context Protocol requests reproducible at scale.
- Publish JSON Schema resources, CLI tooling, and a quickstart guide plus runnable examples so teams can integrate the synthetic data generator into IDEs and agent runtimes in under a minute.
- Lock in unit and end-to-end coverage that exercises list/generate tools, SSE networking, schema discovery, and determinism proofs to keep quality gates green for future domains.