### PR TITLE
docs: tighten compliance claims, expand CE value, sharpen CE/EE separ…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The Enterprise Platform adds the governed workflows, scanners, dashboards, and e
 **The Enterprise Platform adds:**
 
 - **PII scanner** — probability-scored field detection with configurable thresholds via DataWorkbench
-- **Multi-system execution** — Oracle / MongoDB / Kafka / EDIFACT / SWIFT MT / HL7 in coordinated workflows with referential integrity
+- **Multi-system execution** — Oracle / MongoDB / Kafka / EDIFACT / SWIFT MT / HL7 v2.x / HL7 FHIR in coordinated workflows with referential integrity
 - **Governance layer** — role-based dashboards, audit trails, approval flows, reusable enterprise templates, scheduler
 - **Performance core** — Rust fastpath, ML/auto-regressive engine for complex distributions, keyset and manifest building, optimised distributed execution
 - **On-premise / air-gapped deployment** — podman-compose or Helm, with consulting-led rollout
@@ -83,7 +83,7 @@ CE and EE are **not the same engine with a feature flag**. They share the DSL an
 | Scheduled execution + task runner | ✅ |
 | CI/CD pipeline integration (Tosca, Jenkins, GitLab) | ✅ |
 | Multi-system execution: Oracle, MongoDB, Kafka | ✅ |
-| **Template engine: schema-aware editor for EDIFACT, SWIFT MT, HL7, and further industry formats — customer-uploadable specs, additional editors deliverable in days on the same framework** | ✅ |
+| **Template engine: schema-aware editors for EDIFACT, SWIFT MT, HL7 v2.x, and HL7 FHIR — customer-uploadable specs, further industry formats deliverable in days on the same framework** | ✅ |
 | Audit-evidence artefacts for GDPR Art. 30 records, PCI DSS 4.0 Req. 6.5.5 (test data) reviews, and — for US Covered Entities / Business Associates — HIPAA §164.312 evidence packs | ✅ |
 | On-premise deployment + air-gapped environments | ✅ |
 | LSP-powered IDE tooling for DSL authoring | ✅ |
@@ -126,10 +126,11 @@ The EE template engine generates industry-standard financial messages from DATAM
 |---|---|
 | **UN/EDIFACT** | Schema-aware form editor; spec versions and subsets per engagement |
 | **SWIFT MT** | Schema-aware form editor; categories and SR versions per engagement |
-| **HL7** | Engine-supported; editor deliverable in days on the same framework |
-| **Further industry formats** (ISO 20022 / MX, FHIR, vertical dialects) | Built into the editor catalogue as part of POC and 1-year engagement scopes |
+| **HL7 v2.x** | Schema-aware form editor; versions per engagement |
+| **HL7 FHIR** | Schema-aware form editor for FHIR resources (Patient, Observation, Encounter, …); profiles per engagement |
+| **Further industry formats** (ISO 20022 / MX, vertical dialects) | Built into the editor catalogue as part of POC and 1-year engagement scopes — typically delivered in days on the same framework |
 
-Because every editor sits on the same framework, additional standards are typically delivered in days, not release cycles. Customers can also download, adjust, and upload their own specs directly — DATAMIMIC's spec library expands with customer needs, not with quarterly vendor release notes.
+Customers can also download, adjust, and upload their own specs directly — DATAMIMIC's spec library expands with customer needs, not with quarterly vendor release notes.
 
 Generated messages are deterministic and traceable to their source model, and syntactically valid against the registered spec. They are intended for **test and training environments only** — they are not network-validated and must not be transmitted on production SWIFTNet or EDI networks. See the [SWIFT CSP note](#supported-systems) below.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The Enterprise Platform adds the governed workflows, scanners, dashboards, and e
 **The Enterprise Platform adds:**
 
 - **PII scanner** — probability-scored field detection with configurable thresholds via DataWorkbench
-- **Multi-system execution** — Oracle / MongoDB / Kafka / EDIFACT / SWIFT MT / HL7 in coordinated workflows with referential integrity
+- **Multi-system execution** — Oracle / MongoDB / Kafka / EDIFACT / SWIFT MT in coordinated workflows with referential integrity
 - **Governance layer** — role-based dashboards, audit trails, approval flows, reusable enterprise templates, scheduler
 - **Performance core** — Rust fastpath, ML/auto-regressive engine for complex distributions, keyset and manifest building, optimised distributed execution
 - **On-premise / air-gapped deployment** — podman-compose or Helm, with consulting-led rollout
@@ -83,7 +83,7 @@ CE and EE are **not the same engine with a feature flag**. They share the DSL an
 | Scheduled execution + task runner | ✅ |
 | CI/CD pipeline integration (Tosca, Jenkins, GitLab) | ✅ |
 | Multi-system execution: Oracle, MongoDB, Kafka | ✅ |
-| **Template engine: EDIFACT, SWIFT MT, HL7 + spec-specific editors** | ✅ |
+| **Template engine: schema-aware editor for EDIFACT and SWIFT MT (additional formats built per engagement; customer-uploadable specs)** | ✅ |
 | Audit-evidence artefacts for GDPR Art. 30 records, PCI DSS 4.0 Req. 6.5.5 (test data) reviews, and — for US Covered Entities / Business Associates — HIPAA §164.312 evidence packs | ✅ |
 | On-premise deployment + air-gapped environments | ✅ |
 | LSP-powered IDE tooling for DSL authoring | ✅ |
@@ -108,15 +108,28 @@ Logging depth is independently configurable per profile — from minimal (throug
 
 ## EE template engine
 
-The EE template engine generates industry-standard financial and healthcare message formats from DATAMIMIC models, with spec-specific editors for each format:
+The EE template engine generates industry-standard financial messages from DATAMIMIC models. The workbench parses uploaded message samples, auto-detects the message type, and validates edits against the registered spec version in real time.
 
-| Format | Standard | Spec-specific editor |
-|---|---|---|
-| EDIFACT | UN/EDIFACT | ✅ |
-| SWIFT MT | SWIFT MT | ✅ |
-| HL7 | HL7 v2.x | ✅ |
+### Capabilities
 
-Templates are versioned, reusable across scenarios, and fully integrated with the DATAMIMIC DSL and audit layer. Generated messages are deterministic and traceable to their source model.
+- **Spec-aware form editing** — segments and elements rendered as structured forms with mandatory/optional indicators, per-field value suggestions, and inline custom-extension support
+- **Strict validation** against baked spec versions, with segment- and element-level error reporting
+- **Advisory mode** when a spec is unregistered or in draft — editing stays enabled, validation continues as guidance
+- **Round-trip** between the structured form view and the authoritative template text — no fidelity loss
+- **Download / adjust / upload your own spec** — customers can extend or override the baked spec catalogue without waiting for a release
+- **Live structure tree + preview** for every edit
+- **File auto-detection** — upload an existing message, the editor identifies the type and loads the matching spec
+
+### Formats with shipped editor support
+
+| Format | Coverage |
+|---|---|
+| **UN/EDIFACT** | Schema-aware form editor; spec versions and subsets per customer engagement |
+| **SWIFT MT** | Schema-aware form editor; categories and SR versions per customer engagement |
+
+Additional formats (ISO 20022 / MX, HL7, FHIR, industry-specific dialects) are built into the editor catalogue as part of POC and 1-year engagement scopes — DATAMIMIC's spec library expands with customer needs, not with quarterly vendor release notes.
+
+Generated messages are deterministic and traceable to their source model, and syntactically valid against the registered spec. They are intended for **test and training environments only** — they are not network-validated and must not be transmitted on production SWIFTNet or EDI networks. See the [SWIFT CSP note](#supported-systems) below.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The Enterprise Platform adds the governed workflows, scanners, dashboards, and e
 **The Enterprise Platform adds:**
 
 - **PII scanner** — probability-scored field detection with configurable thresholds via DataWorkbench
-- **Multi-system execution** — Oracle / MongoDB / Kafka / EDIFACT / SWIFT MT in coordinated workflows with referential integrity
+- **Multi-system execution** — Oracle / MongoDB / Kafka / EDIFACT / SWIFT MT / HL7 in coordinated workflows with referential integrity
 - **Governance layer** — role-based dashboards, audit trails, approval flows, reusable enterprise templates, scheduler
 - **Performance core** — Rust fastpath, ML/auto-regressive engine for complex distributions, keyset and manifest building, optimised distributed execution
 - **On-premise / air-gapped deployment** — podman-compose or Helm, with consulting-led rollout
@@ -83,7 +83,7 @@ CE and EE are **not the same engine with a feature flag**. They share the DSL an
 | Scheduled execution + task runner | ✅ |
 | CI/CD pipeline integration (Tosca, Jenkins, GitLab) | ✅ |
 | Multi-system execution: Oracle, MongoDB, Kafka | ✅ |
-| **Template engine: schema-aware editor for EDIFACT and SWIFT MT (additional formats built per engagement; customer-uploadable specs)** | ✅ |
+| **Template engine: schema-aware editor for EDIFACT, SWIFT MT, HL7, and further industry formats — customer-uploadable specs, additional editors deliverable in days on the same framework** | ✅ |
 | Audit-evidence artefacts for GDPR Art. 30 records, PCI DSS 4.0 Req. 6.5.5 (test data) reviews, and — for US Covered Entities / Business Associates — HIPAA §164.312 evidence packs | ✅ |
 | On-premise deployment + air-gapped environments | ✅ |
 | LSP-powered IDE tooling for DSL authoring | ✅ |
@@ -120,14 +120,16 @@ The EE template engine generates industry-standard financial messages from DATAM
 - **Live structure tree + preview** for every edit
 - **File auto-detection** — upload an existing message, the editor identifies the type and loads the matching spec
 
-### Formats with shipped editor support
+### Format coverage
 
 | Format | Coverage |
 |---|---|
-| **UN/EDIFACT** | Schema-aware form editor; spec versions and subsets per customer engagement |
-| **SWIFT MT** | Schema-aware form editor; categories and SR versions per customer engagement |
+| **UN/EDIFACT** | Schema-aware form editor; spec versions and subsets per engagement |
+| **SWIFT MT** | Schema-aware form editor; categories and SR versions per engagement |
+| **HL7** | Engine-supported; editor deliverable in days on the same framework |
+| **Further industry formats** (ISO 20022 / MX, FHIR, vertical dialects) | Built into the editor catalogue as part of POC and 1-year engagement scopes |
 
-Additional formats (ISO 20022 / MX, HL7, FHIR, industry-specific dialects) are built into the editor catalogue as part of POC and 1-year engagement scopes — DATAMIMIC's spec library expands with customer needs, not with quarterly vendor release notes.
+Because every editor sits on the same framework, additional standards are typically delivered in days, not release cycles. Customers can also download, adjust, and upload their own specs directly — DATAMIMIC's spec library expands with customer needs, not with quarterly vendor release notes.
 
 Generated messages are deterministic and traceable to their source model, and syntactically valid against the registered spec. They are intended for **test and training environments only** — they are not network-validated and must not be transmitted on production SWIFTNet or EDI networks. See the [SWIFT CSP note](#supported-systems) below.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DATAMIMIC — Governed Test Data for Regulated Enterprises
 
-> **This repository contains the DATAMIMIC Community Edition (CE)** — the open-source deterministic data engine at the core of the **DATAMIMIC Enterprise Platform**.
+> **This repository contains the DATAMIMIC Community Edition (CE).** MIT-licensed, Python-native, MCP-ready.
 >
 > CE is fully usable standalone for deterministic synthetic data generation and PII-aware pseudonymization. The Enterprise Platform adds governed workflows, PII scanning, role-based access, audit logging, scheduling, multi-system execution, and the full operational layer that regulated enterprises require.
 >
@@ -58,7 +58,7 @@ CE and EE are **not the same engine with a feature flag**. They share the DSL an
 | Domain models: Finance, Healthcare, Demographics | ✅ | ✅ |
 | MCP server for AI agent integration | ✅ | ✅ |
 | CLI + local execution | ✅ | ✅ |
-| **Scale** | millions of records | **designed for billion-record workloads** via isolated multiprocessing and Ray-based distributed execution |
+| **Scale** | millions of records via Python multiprocessing (and optional Ray) | **designed for billion-record workloads** — Rust fastpath, optimised multi-process execution, and keyset/manifest building on top of the shared Ray distribution layer |
 | **PII scanner** | ❌ | ✅ probability-scored field detection, configurable threshold, DataWorkbench integration |
 | **Runtime configuration profiles** | ❌ | ✅ Performance · Balanced · Flexibility |
 | **Memory management** | standard | optimised for high-volume batch and streaming |
@@ -66,7 +66,9 @@ CE and EE are **not the same engine with a feature flag**. They share the DSL an
 | **Nested structure evaluation** | basic | deep nested generation with extended condition + ruleset evaluation |
 | **Importer / exporter logging** | ❌ | per-stage logging for importers and exporters |
 | **Error handling** | standard exceptions | structured error catalog with recovery strategies |
-| **ML engine integration** | ❌ | combine statistical models with conditions, rulesets, validators |
+| **Rust fastpath** | ❌ | performance-critical paths in Rust |
+| **Keyset and manifest building** | ❌ | reads live DB schemas to build coordinated multi-table generation plans |
+| **ML / auto-regressive engine** | ❌ | combine statistical models with conditions, rulesets, validators for complex distributions |
 
 ### Platform capabilities (EE only)
 
@@ -96,7 +98,7 @@ The EE core supports three runtime configuration profiles, selectable per execut
 
 | Profile | Optimises for | Typical use case |
 |---|---|---|
-| **Performance** | Maximum throughput via isolated multiprocessing + Ray-based distributed execution | Bulk generation at nine-figure record volumes to PostgreSQL, Oracle, Kafka |
+| **Performance** | Maximum throughput via Rust fastpath, optimised multi-process execution, and Ray-based distribution | Bulk generation at billion-record volumes to PostgreSQL, Oracle, Kafka |
 | **Balanced** | Throughput + full audit logging | Standard enterprise pipeline runs with compliance requirements |
 | **Flexibility** | Deep nested evaluation, extended condition and ruleset processing | Complex domain models with ML engine combinations, multi-level referential structures |
 
@@ -143,7 +145,7 @@ Most test data tools produce random output. That breaks regression tests, audit 
 - Same seed + same model = byte-identical output, every run, every machine
 - Frozen clocks + canonical hashing = stable temporal context
 - UUIDv5 namespaces = reproducible entity identifiers
-- Provenance hash on every output = audit-ready lineage
+- Provenance hash on every output = re-executable lineage
 
 ```python
 from datamimic_ce.domains.facade import generate_domain
@@ -170,13 +172,13 @@ response = generate_domain(request)
 | Reproducible output | ❌ | ✅ | ✅ |
 | Domain-aware relationships | ❌ | ✅ | ✅ |
 | Business logic constraints | ❌ | ✅ | ✅ |
-| Audit-ready provenance | ❌ | ✅ | ✅ |
+| Per-output provenance hash | ❌ | ✅ | ✅ |
 | Source data pseudonymization | ❌ | ✅ manual | ✅ automated |
 | PII field detection | ❌ | ❌ | ✅ probability-scored |
 | Enterprise governance layer | ❌ | ❌ | ✅ |
 | Multi-system execution | ❌ | ❌ | ✅ |
 | Role-based workflows | ❌ | ❌ | ✅ |
-| Regulated industry compliance | ❌ | ❌ | ✅ |
+| Designed for regulated-industry deployment (governance, audit, RBAC) | ❌ | ❌ | ✅ |
 
 ```python
 # Faker — broken relationships
@@ -227,7 +229,7 @@ DATAMIMIC supports two pseudonymization modes with different privacy postures:
 
 | Mode | How | Legal classification | Use case |
 |---|---|---|---|
-| **Seeded** (`rngSeed` set) | Deterministic, reproducible | Pseudonymization — GDPR Art. 25 | Regression testing, stable CI/CD pipelines |
+| **Seeded** (`rngSeed` set) | Deterministic, reproducible | Pseudonymization (GDPR Art. 4(5)) | Regression testing, stable CI/CD pipelines |
 | **Non-seeded** (no `rngSeed`) | Non-deterministic, no reversible mapping at field level | Privacy-maximized transformation | One-time data delivery, higher privacy posture |
 
 > **Note on GDPR anonymization:** Full anonymization status under GDPR depends on complete field coverage across all quasi-identifiers and a re-identification risk assessment on the complete record — not on individual field transformation alone. DATAMIMIC does not make anonymization claims on behalf of the customer. Non-seeded mode maximizes privacy at the transformation level; the customer is responsible for assessing re-identification risk across the full dataset.
@@ -353,7 +355,7 @@ DATAMIMIC produces evidence and reproducible artifacts that support compliance w
 
 ## Architecture
 
-CE and EE share the DATAMIMIC DSL and the determinism contract. The execution layer is separate: CE is a single-machine engine built on Python; EE is an independently-optimised execution engine with a Rust fastpath, ML/auto-regressive generation, keyset and manifest building from live schemas, and distributed execution at billion-record scale.
+CE and EE share the DATAMIMIC DSL and the determinism contract. The execution layer is separate: CE is a Python execution engine using multiprocessing (with optional Ray for distribution); EE is an independently-optimised execution engine with a Rust fastpath, ML/auto-regressive generation, keyset and manifest building from live schemas, and optimised distributed execution at billion-record scale.
 
 ```
 ╔══════════════════════════════════════════════════════════════════╗

--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ The Enterprise Platform adds the governed workflows, scanners, dashboards, and e
 **The Enterprise Platform adds:**
 
 - **PII scanner** — probability-scored field detection with configurable thresholds via DataWorkbench
-- **Multi-system execution** — Oracle / MongoDB / Kafka / EDIFACT / SWIFT MT / HL7 v2.x / HL7 FHIR in coordinated workflows with referential integrity
+- **Multi-system execution** — Oracle / MongoDB / Kafka in coordinated workflows with referential integrity
+- **Industry message templates** — EDIFACT / SWIFT MT / HL7 v2.x / HL7 FHIR generated as deterministic test/training artefacts
 - **Governance layer** — role-based dashboards, audit trails, approval flows, reusable enterprise templates, scheduler
 - **Performance core** — Rust fastpath, ML/auto-regressive engine for complex distributions, keyset and manifest building, optimised distributed execution
 - **On-premise / air-gapped deployment** — podman-compose or Helm, with consulting-led rollout
 
-> Deployed in a regulated EU banking engagement for deterministic test data across Oracle, MongoDB, and Kafka pipelines (see [datamimic.io case studies](https://datamimic.io)).
+> Deployed in regulated EU banking environments for deterministic test data across Oracle, MongoDB, and Kafka pipelines. Reference customers available under NDA — see also [datamimic.io case studies](https://datamimic.io).
 
 ---
 
@@ -83,7 +84,7 @@ CE and EE are **not the same engine with a feature flag**. They share the DSL an
 | Scheduled execution + task runner | ✅ |
 | CI/CD pipeline integration (Tosca, Jenkins, GitLab) | ✅ |
 | Multi-system execution: Oracle, MongoDB, Kafka | ✅ |
-| **Template engine: schema-aware editors for EDIFACT, SWIFT MT, HL7 v2.x, and HL7 FHIR — customer-uploadable specs, further industry formats deliverable in days on the same framework** | ✅ |
+| **Template engine: schema-aware editors for EDIFACT, SWIFT MT, HL7 v2.x, and HL7 FHIR — customer-uploadable specs, further industry formats built per engagement on the same framework** | ✅ |
 | Audit-evidence artefacts for GDPR Art. 30 records, PCI DSS 4.0 Req. 6.5.5 (test data) reviews, and — for US Covered Entities / Business Associates — HIPAA §164.312 evidence packs | ✅ |
 | On-premise deployment + air-gapped environments | ✅ |
 | LSP-powered IDE tooling for DSL authoring | ✅ |
@@ -128,9 +129,9 @@ The EE template engine generates industry-standard financial messages from DATAM
 | **SWIFT MT** | Schema-aware form editor; categories and SR versions per engagement |
 | **HL7 v2.x** | Schema-aware form editor; versions per engagement |
 | **HL7 FHIR** | Schema-aware form editor for FHIR resources (Patient, Observation, Encounter, …); profiles per engagement |
-| **Further industry formats** (ISO 20022 / MX, vertical dialects) | Built into the editor catalogue as part of POC and 1-year engagement scopes — typically delivered in days on the same framework |
+| **Further industry formats** (ISO 20022 / MX, vertical dialects) | Built into the editor catalogue per customer engagement, on the same framework |
 
-Customers can also download, adjust, and upload their own specs directly — DATAMIMIC's spec library expands with customer needs, not with quarterly vendor release notes.
+Customers can extend the spec catalogue between releases by downloading, adjusting, and uploading their own spec files directly.
 
 Generated messages are deterministic and traceable to their source model, and syntactically valid against the registered spec. They are intended for **test and training environments only** — they are not network-validated and must not be transmitted on production SWIFTNet or EDI networks. See the [SWIFT CSP note](#supported-systems) below.
 
@@ -339,10 +340,14 @@ Most teams adopt CE for one of three reasons. EE is not required for any of them
 **1. Reproducible test data for CI/CD pipelines.** Same seed → byte-identical output across machines. Regression tests stop being flaky because the input data is stable across runs.
 
 ```python
-from datamimic_ce.domains.healthcare.services import PatientService
+from datamimic_ce.domains.facade import generate_domain
 
-# This call returns the exact same patient on every machine, every run.
-patient = PatientService().generate(seed="ci-pipeline-42", locale="en_US")
+response = generate_domain({
+    "domain": "person", "version": "v1", "count": 1,
+    "seed": "ci-pipeline-42", "locale": "en_US",
+    "clock": "2026-01-01T00:00:00Z",
+})
+# Same input → same output, every machine, every run.
 ```
 
 **2. Deterministic data backend for AI agents and LLM tooling.** The bundled MCP server (`pip install datamimic-ce[mcp]`) exposes `generate` as an MCP tool. Agents call it with seed, locale, count; outputs ship with a `determinism_proof.content_hash` so the same call can be re-executed and verified later — useful for agent regression tests and for any workflow where the data the agent saw needs to be reconstructable.
@@ -359,8 +364,8 @@ DATAMIMIC produces evidence and reproducible artifacts that support compliance w
 
 | Regulation / standard | Where DATAMIMIC contributes |
 |---|---|
-| **DORA (Reg. 2022/2554)** — Art. 25 (testing of ICT tools and systems) | Reproducible test datasets for non-TLPT resilience tests; deterministic data fixtures for ICT testing programmes |
-| **ISO/IEC 27701:2019** — A.7.2.1, 7.2.8 (privacy by design and RoPA-supporting evidence) | Synthetic data in lieu of PII in non-production environments; documented model definitions as privacy-by-design evidence |
+| **DORA (Reg. 2022/2554)** — Art. 24 (testing of ICT tools, systems and processes; non-TLPT scope) | Reproducible test datasets for non-TLPT resilience tests; deterministic data fixtures for ICT testing programmes |
+| **ISO/IEC 27701:2019** — A.7.2.8 (records related to processing PII) and A.7.4.5 (PII minimisation) | Synthetic data in lieu of PII in non-production environments; documented model definitions as supporting evidence |
 | **HIPAA Security Rule** — §164.312 technical safeguards *(US Covered Entities / Business Associates only)* | Synthetic Patient/MedicalDevice/MedicalProcedure data for dev and test environments without ePHI exposure |
 | **GDPR** — Art. 4(5) pseudonymization definition; Art. 25 privacy by design; Art. 32 security of processing | Seeded pseudonymization with deterministic mapping; non-seeded mode for stronger privacy posture |
 | **PCI DSS 4.0** — Req. 6.5.5 (live PANs prohibited in test/development) | Synthetic PAN generation for test environments; deterministic tokenisation reproducible across runs |
@@ -406,10 +411,10 @@ CE and EE share the DATAMIMIC DSL and the determinism contract. The execution la
 ╚══════════════════════════════════════════════════════════════════╝
 
          ↓              ↓              ↓              ↓
-    PostgreSQL       Oracle         MongoDB      Kafka / Files
+    PostgreSQL       Oracle         MongoDB      CSV / JSON / XML
 ```
 
-Both editions share the same DATAMIMIC DSL and determinism contract. Scale, throughput, governance, and operational control are EE-only.
+EE adds Kafka, EDIFACT, SWIFT MT, HL7 v2.x, and HL7 FHIR as additional targets — see [Supported systems](#supported-systems) below. Both editions share the DATAMIMIC DSL and determinism contract.
 
 ---
 
@@ -425,6 +430,8 @@ Both editions share the same DATAMIMIC DSL and determinism contract. Scale, thro
 | MongoDB | ✅ | ✅ | EE adds nested document generation |
 | CSV / JSON / XML | ✅ | ✅ | Flat file pipelines |
 | Apache Kafka | — | ✅ | Real-time streaming, payment scenarios |
+| HL7 v2.x | — | ✅ | Test/training output via template engine |
+| HL7 FHIR | — | ✅ | Test/training output via template engine |
 | EDIFACT / SWIFT MT | — | ✅ | Test/training output only; does not satisfy SWIFT CSCF v2025 secure-zone controls (1.1 environment protection, 1.4 internet restriction). Generated messages must not be transmitted from a CSP-attested secure zone. |
 
 ---
@@ -440,7 +447,7 @@ Both editions share the same DATAMIMIC DSL and determinism contract. Scale, thro
 | **Public sector** | AdministrationOffice, EducationalInstitution, PoliceOfficer |
 | **Demographics** | Person (DE / US / VN locale packs), Address |
 
-All services are versioned and seeded; each generation emits a provenance hash suitable as evidence in audit reviews. Same deterministic API across domains: `Service().generate(seed=…, locale=…, count=…)`.
+All services are versioned and seeded; each generation emits a provenance hash suitable as evidence in audit reviews. Domain services can be used directly via constructor injection, or driven through the higher-level `generate_domain({...})` facade for seed/locale/clock/count parameterisation (currently supports `person`, `address`, `patient`, `doctor` at `v1`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **This repository contains the DATAMIMIC Community Edition (CE)** — the open-source deterministic data engine at the core of the **DATAMIMIC Enterprise Platform**.
 >
-> CE is fully usable standalone for deterministic synthetic data generation and PII-aware pseudonymization. The Enterprise Platform builds on a separately optimised EE core and adds governed workflows, PII scanning, role-based access, audit logging, scheduling, multi-system execution, and the full operational layer that regulated enterprises require.
+> CE is fully usable standalone for deterministic synthetic data generation and PII-aware pseudonymization. The Enterprise Platform adds governed workflows, PII scanning, role-based access, audit logging, scheduling, multi-system execution, and the full operational layer that regulated enterprises require.
 >
 > 👉 **Enterprise Platform:** [datamimic.io](https://datamimic.io) &nbsp;|&nbsp; 📘 **Docs:** [docs.datamimic.io](https://docs.datamimic.io) &nbsp;|&nbsp; 📅 **Book a strategy call:** [datamimic.io/contact](https://datamimic.io/contact)
 
@@ -21,7 +21,7 @@
 
 **DATAMIMIC CE is the open-source deterministic data engine at the core of the DATAMIMIC Enterprise Platform.** It is usable standalone for synthetic data generation and PII-aware pseudonymization in any local, CI, or agent-driven workflow.
 
-The Enterprise Platform builds on a separately-optimised EE core and adds the governed workflows, scanners, dashboards, and execution layer that regulated enterprises require for production-scale test-data operations.
+The Enterprise Platform adds the governed workflows, scanners, dashboards, and execution layer that regulated enterprises require for production-scale test-data operations.
 
 **Available in CE (this repo):**
 
@@ -45,7 +45,7 @@ The Enterprise Platform builds on a separately-optimised EE core and adds the go
 
 ## CE vs Enterprise Platform
 
-CE and EE are **not the same engine with a feature flag**. The EE core is an independently optimised execution engine built for enterprise-scale throughput and operational control.
+CE and EE are **not the same engine with a feature flag**. They share the DSL and determinism contract, but EE is an independently optimised execution engine built for enterprise-scale throughput and operational control.
 
 ### Engine comparison
 
@@ -327,7 +327,7 @@ from datamimic_ce.domains.healthcare.services import PatientService
 patient = PatientService().generate(seed="ci-pipeline-42", locale="en_US")
 ```
 
-**2. Deterministic data backend for AI agents and LLM tooling.** The bundled MCP server (`pip install datamimic-ce[mcp]`) exposes `generate` as an MCP tool. Agents call it with seed, locale, count; outputs ship with a `determinism_proof.content_hash` for verification — exactly the kind of evidence EU AI Act Art. 10 (data governance) and Art. 50 (transparency) audits want to see.
+**2. Deterministic data backend for AI agents and LLM tooling.** The bundled MCP server (`pip install datamimic-ce[mcp]`) exposes `generate` as an MCP tool. Agents call it with seed, locale, count; outputs ship with a `determinism_proof.content_hash` so the same call can be re-executed and verified later — useful for agent regression tests and for any workflow where the data the agent saw needs to be reconstructable.
 
 **3. Pseudonymization of staging and QA exports.** Manual model in CE (XML pipeline), no scanner license required. Seeded mode for stable regression test data; non-seeded mode for one-time deliveries with maximized privacy posture. See the [Pseudonymization section above](#pseudonymization--ce-manual-model).
 
@@ -341,7 +341,6 @@ DATAMIMIC produces evidence and reproducible artifacts that support compliance w
 
 | Regulation / standard | Where DATAMIMIC contributes |
 |---|---|
-| **EU AI Act (Reg. 2024/1689)** — Art. 10 (data governance) | Provenance-hashed synthetic datasets for training/test data with reproducible lineage; supports the data-governance documentation that high-risk-AI providers must maintain |
 | **DORA (Reg. 2022/2554)** — Art. 25 (testing of ICT tools and systems) | Reproducible test datasets for non-TLPT resilience tests; deterministic data fixtures for ICT testing programmes |
 | **ISO/IEC 27701:2019** — A.7.2.1, 7.2.8 (privacy by design and RoPA-supporting evidence) | Synthetic data in lieu of PII in non-production environments; documented model definitions as privacy-by-design evidence |
 | **HIPAA Security Rule** — §164.312 technical safeguards *(US Covered Entities / Business Associates only)* | Synthetic Patient/MedicalDevice/MedicalProcedure data for dev and test environments without ePHI exposure |
@@ -354,7 +353,7 @@ DATAMIMIC produces evidence and reproducible artifacts that support compliance w
 
 ## Architecture
 
-CE and EE have **separate, independently maintained cores**. CE is not a stripped-down EE. EE is not CE with features unlocked. They share the same DSL and determinism contract but diverge completely at the execution layer.
+CE and EE share the DATAMIMIC DSL and the determinism contract. The execution layer is separate: CE is a single-machine engine built on Python; EE is an independently-optimised execution engine with a Rust fastpath, ML/auto-regressive generation, keyset and manifest building from live schemas, and distributed execution at billion-record scale.
 
 ```
 ╔══════════════════════════════════════════════════════════════════╗

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@
 
 Enterprises in banking, insurance, and regulated industries use DATAMIMIC to:
 
-- **Scan** source systems for PII — probability-scored field detection with configurable thresholds (EE: automated via DataWorkbench; CE: manual model definition)
-- **Generate** fully synthetic, deterministic datasets — model-driven, zero production data, no compliance risk
+- **Scan** source systems for PII — probability-scored field detection with configurable thresholds *(EE: automated via DataWorkbench; CE: manual model definition)*
+- **Generate** fully synthetic, deterministic datasets — model-driven, zero production data
 - **Pseudonymize** source data — deterministic (seeded) or privacy-maximized (non-seeded) field transformation from source to target system
-- **Execute** repeatable workflows across complex system landscapes: Oracle, PostgreSQL, MongoDB, Kafka, JSON, XML, CSV
-- **Audit** every run with immutable logs, provenance hashing, and role-based traceability
-- **Govern** test data demand through reusable templates, approval flows, and self-service execution
+- **Execute** repeatable workflows: single-system pipelines in CE; multi-system landscapes (Oracle, PostgreSQL, MongoDB, Kafka, JSON, XML, CSV) in EE
+- **Produce audit evidence** — append-only execution logs and provenance hashing on every output; role-based dashboards in EE
+- **Govern** test data demand through reusable templates, approval flows, and self-service execution *(EE)*
 
-> Used in production at Tier-1 European banks and global payment processing enterprises for deterministic test data across Oracle, MongoDB, and Kafka pipelines.
+> Deployed in regulated EU banking environments for deterministic test data across Oracle, MongoDB, and Kafka pipelines.
 
 ---
 
@@ -49,7 +49,7 @@ CE and EE are **not the same engine with a feature flag**. The EE core is an ind
 | Domain models: Finance, Healthcare, Demographics | ✅ | ✅ |
 | MCP server for AI agent integration | ✅ | ✅ |
 | CLI + local execution | ✅ | ✅ |
-| **Scale** | millions of records | **linearly scalable to 1,000,000,000+ records** via isolated multiprocessing and Ray-based distributed execution |
+| **Scale** | millions of records | **designed for billion-record workloads** via isolated multiprocessing and Ray-based distributed execution |
 | **PII scanner** | ❌ | ✅ probability-scored field detection, configurable threshold, DataWorkbench integration |
 | **Runtime configuration profiles** | ❌ | ✅ Performance · Balanced · Flexibility |
 | **Memory management** | standard | optimised for high-volume batch and streaming |
@@ -73,7 +73,7 @@ CE and EE are **not the same engine with a feature flag**. The EE core is an ind
 | CI/CD pipeline integration (Tosca, Jenkins, GitLab) | ✅ |
 | Multi-system execution: Oracle, MongoDB, Kafka | ✅ |
 | **Template engine: EDIFACT, SWIFT MT, HL7 + spec-specific editors** | ✅ |
-| GDPR / HIPAA / PCI audit compliance layer | ✅ |
+| Audit evidence support for GDPR / HIPAA / PCI assessments | ✅ |
 | On-premise deployment + air-gapped environments | ✅ |
 | LSP-powered IDE tooling for DSL authoring | ✅ |
 
@@ -305,6 +305,41 @@ anyio.run(main)
 
 ---
 
+## Where CE fits on its own
+
+Most teams adopt CE for one of three reasons. EE is not required for any of them.
+
+**1. Reproducible test data for CI/CD pipelines.** Same seed → byte-identical output across machines. Regression tests stop being flaky because the input data is stable across runs.
+
+```python
+from datamimic_ce.domains.healthcare.services import PatientService
+
+# This call returns the exact same patient on every machine, every run.
+patient = PatientService().generate(seed="ci-pipeline-42", locale="en_US")
+```
+
+**2. Deterministic data backend for AI agents and LLM tooling.** The bundled MCP server (`pip install datamimic-ce[mcp]`) exposes `generate` as an MCP tool. Agents call it with seed, locale, count; outputs ship with a `determinism_proof.content_hash` for verification — exactly the kind of evidence EU AI Act Art. 10 (data governance) and Art. 50 (transparency) audits want to see.
+
+**3. Pseudonymization of staging and QA exports.** Manual model in CE (XML pipeline), no scanner license required. Seeded mode for stable regression test data; non-seeded mode for one-time deliveries with maximized privacy posture. See the [Pseudonymization section above](#pseudonymization--ce-manual-model).
+
+---
+
+## Where DATAMIMIC fits in your compliance program
+
+DATAMIMIC produces evidence and reproducible artifacts that support compliance work. It does not replace your DPO, your CISO, or your auditor. The following are pointers for where DATAMIMIC outputs commonly slot into established programs:
+
+| Regulation / standard | Where DATAMIMIC contributes |
+|---|---|
+| **EU AI Act (Reg. 2024/1689)** — Art. 10 (data governance), Art. 50 (transparency) | Provenance-hashed synthetic datasets for training/test data with reproducible lineage; deterministic outputs that audit reviewers can re-execute |
+| **DORA (Reg. 2022/2554)** — Art. 24–27 (resilience testing), Art. 8 (asset register) | Reproducible test datasets for resilience testing programs; deterministic data fixtures for ICT system inventories |
+| **ISO/IEC 27701:2025** — A.1.4 (privacy by design), A.1.2.9 (RoPA) | Synthetic data in lieu of PII in non-production environments; documented model definitions as privacy-by-design evidence |
+| **HIPAA Security Rule** — §164.312 technical safeguards | Synthetic Patient/MedicalDevice/MedicalProcedure data for dev and test environments without ePHI exposure |
+| **GDPR Art. 25** (data protection by design) | Seeded pseudonymization with deterministic mapping; non-seeded mode for stronger privacy posture |
+
+> These pointers do not constitute legal advice or a compliance attestation. Consult your DPO, CISO, or qualified counsel for formal compliance determinations. Full anonymization status under GDPR depends on re-identification risk across the complete dataset — see the [pseudonymization disclaimer above](#pseudonymization--ce-manual-model).
+
+---
+
 ## Architecture
 
 CE and EE have **separate, independently maintained cores**. CE is not a stripped-down EE. EE is not CE with features unlocked. They share the same DSL and determinism contract but diverge completely at the execution layer.
@@ -348,42 +383,56 @@ Both editions share the same DATAMIMIC DSL and determinism contract. Scale, thro
 
 ---
 
-## Supported systems (Enterprise Platform)
+## Supported systems
 
-| System | Read | Write | Notes |
+| System | CE | EE | Notes |
 |---|---|---|---|
-| PostgreSQL | ✅ | ✅ | Schema introspection, referential integrity |
-| Oracle | ✅ | ✅ | Production-validated in Tier-1 banking environments |
-| MongoDB | ✅ | ✅ | Nested document generation |
-| Apache Kafka | ✅ | ✅ | Real-time streaming, payment scenarios |
+| PostgreSQL | ✅ | ✅ | EE adds schema introspection and referential integrity |
+| MySQL | ✅ | ✅ | |
+| Oracle | ✅ | ✅ | EE production-validated in regulated banking environments |
+| MS SQL Server | ✅ | ✅ | |
+| SQLite | ✅ | ✅ | Lightweight CI/CD fixtures |
+| MongoDB | ✅ | ✅ | EE adds nested document generation |
 | CSV / JSON / XML | ✅ | ✅ | Flat file pipelines |
-| EDIFACT / SWIFT MT | — | ✅ | Financial message formats |
+| Apache Kafka | — | ✅ | Real-time streaming, payment scenarios |
+| EDIFACT / SWIFT MT | — | ✅ | Test/training output only; does not satisfy SWIFT CSP production-environment controls (1.1, 1.4) |
 
 ---
 
 ## CE domains
 
-| Domain | Models available |
+| Domain | Services available |
 |---|---|
-| **Healthcare** | Patient, Doctor, Hospital, MedicalRecord |
-| **Finance** | BankAccount, CreditCard, Transaction, LoanRecord |
+| **Healthcare** | Patient, Doctor, Hospital, MedicalDevice, MedicalProcedure |
+| **Finance** | Bank, BankAccount, CreditCard, Transaction |
+| **Insurance** | InsuranceCompany, InsuranceProduct, InsurancePolicy, InsuranceCoverage |
+| **E-commerce** | Order, Product |
+| **Public sector** | AdministrationOffice, EducationalInstitution, PoliceOfficer |
 | **Demographics** | Person (DE / US / VN locale packs), Address, Company |
 
-All domains are versioned, seeded, and audit-ready.
+All services are versioned, seeded, and audit-ready. Each service exposes the same deterministic API: `Service().generate(seed=…, locale=…, count=…)`.
 
 ---
 
 ## CLI reference
 
 ```bash
+# Initialize a new project
+datamimic init ./my-scenario
+
+# Validate an XML descriptor without executing it
+datamimic validate ./my-scenario/datamimic.xml
+
 # Run a scenario
 datamimic run ./my-scenario/datamimic.xml
 
-# Launch a demo
+# Demos
+datamimic demo list
 datamimic demo create healthcare-example
-datamimic run ./healthcare-example/datamimic.xml
+datamimic demo create --all --target ./my_demos
 
-# Version check
+# System and version info
+datamimic info
 datamimic version
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,18 +19,27 @@
 
 ## What is DATAMIMIC?
 
-**DATAMIMIC is the enterprise standard for governed test data operations.**
+**DATAMIMIC CE is the open-source deterministic data engine at the core of the DATAMIMIC Enterprise Platform.** It is usable standalone for synthetic data generation and PII-aware pseudonymization in any local, CI, or agent-driven workflow.
 
-Enterprises in banking, insurance, and regulated industries use DATAMIMIC to:
+The Enterprise Platform builds on a separately-optimised EE core and adds the governed workflows, scanners, dashboards, and execution layer that regulated enterprises require for production-scale test-data operations.
 
-- **Scan** source systems for PII — probability-scored field detection with configurable thresholds *(EE: automated via DataWorkbench; CE: manual model definition)*
-- **Generate** fully synthetic, deterministic datasets — model-driven, zero production data
-- **Pseudonymize** source data — deterministic (seeded) or privacy-maximized (non-seeded) field transformation from source to target system
-- **Execute** repeatable workflows: single-system pipelines in CE; multi-system landscapes (Oracle, PostgreSQL, MongoDB, Kafka, JSON, XML, CSV) in EE
-- **Produce audit evidence** — append-only execution logs and provenance hashing on every output; role-based dashboards in EE
-- **Govern** test data demand through reusable templates, approval flows, and self-service execution *(EE)*
+**Available in CE (this repo):**
 
-> Deployed in regulated EU banking environments for deterministic test data across Oracle, MongoDB, and Kafka pipelines.
+- **Generate** fully synthetic, deterministic datasets — model-driven, no source data required
+- **Pseudonymize** staging/QA exports — deterministic (seeded) or privacy-maximized (non-seeded) field transformation; PII fields identified and modeled manually in the XML pipeline
+- **Execute** single-system pipelines against PostgreSQL · MySQL · Oracle · MS SQL · SQLite · MongoDB · CSV · JSON · XML
+- **Emit provenance** — append-only execution logs and per-output content hash for audit re-execution
+- **Serve agents** — bundled MCP server exposing `generate` as a deterministic tool for AI/LLM tooling
+
+**The Enterprise Platform adds:**
+
+- **PII scanner** — probability-scored field detection with configurable thresholds via DataWorkbench
+- **Multi-system execution** — Oracle / MongoDB / Kafka / EDIFACT / SWIFT MT / HL7 in coordinated workflows with referential integrity
+- **Governance layer** — role-based dashboards, audit trails, approval flows, reusable enterprise templates, scheduler
+- **Performance core** — Rust fastpath, ML/auto-regressive engine for complex distributions, keyset and manifest building, optimised distributed execution
+- **On-premise / air-gapped deployment** — podman-compose or Helm, with consulting-led rollout
+
+> Deployed in a regulated EU banking engagement for deterministic test data across Oracle, MongoDB, and Kafka pipelines (see [datamimic.io case studies](https://datamimic.io)).
 
 ---
 
@@ -43,7 +52,7 @@ CE and EE are **not the same engine with a feature flag**. The EE core is an ind
 | Capability | Community Edition (CE) | Enterprise Platform (EE) |
 |---|---|---|
 | Deterministic data generation | ✅ | ✅ |
-| **Pseudonymization — seeded (GDPR Art. 25)** | ✅ manual model | ✅ automated via DataWorkbench |
+| **Pseudonymization — seeded** *(GDPR Art. 4(5); supports Art. 25 / Art. 32)* | ✅ manual model | ✅ automated via DataWorkbench |
 | **Pseudonymization — non-seeded (privacy-maximized)** | ✅ manual model | ✅ automated via DataWorkbench |
 | Python API + XML pipelines | ✅ | ✅ |
 | Domain models: Finance, Healthcare, Demographics | ✅ | ✅ |
@@ -73,11 +82,11 @@ CE and EE are **not the same engine with a feature flag**. The EE core is an ind
 | CI/CD pipeline integration (Tosca, Jenkins, GitLab) | ✅ |
 | Multi-system execution: Oracle, MongoDB, Kafka | ✅ |
 | **Template engine: EDIFACT, SWIFT MT, HL7 + spec-specific editors** | ✅ |
-| Audit evidence support for GDPR / HIPAA / PCI assessments | ✅ |
+| Audit-evidence artefacts for GDPR Art. 30 records, PCI DSS 4.0 Req. 6.5.5 (test data) reviews, and — for US Covered Entities / Business Associates — HIPAA §164.312 evidence packs | ✅ |
 | On-premise deployment + air-gapped environments | ✅ |
 | LSP-powered IDE tooling for DSL authoring | ✅ |
 
-👉 [Compare editions in detail](https://datamimic.io) &nbsp;|&nbsp; [Book a platform demo](https://datamimic.io/contact)
+👉 [Explore the Enterprise Platform](https://datamimic.io) &nbsp;|&nbsp; [Book a platform demo](https://datamimic.io/contact)
 
 ---
 
@@ -154,7 +163,7 @@ response = generate_domain(request)
 
 ---
 
-## Why DATAMIMIC beats Faker and generic generators
+## How DATAMIMIC differs from Faker and generic generators
 
 | | Faker / Random generators | DATAMIMIC CE | DATAMIMIC EE |
 |---|---|---|---|
@@ -328,13 +337,16 @@ patient = PatientService().generate(seed="ci-pipeline-42", locale="en_US")
 
 DATAMIMIC produces evidence and reproducible artifacts that support compliance work. It does not replace your DPO, your CISO, or your auditor. The following are pointers for where DATAMIMIC outputs commonly slot into established programs:
 
+> Both editions produce reproducible artefacts. CE covers single-system fixtures and provenance evidence; multi-system audit evidence with role-based dashboards is EE.
+
 | Regulation / standard | Where DATAMIMIC contributes |
 |---|---|
-| **EU AI Act (Reg. 2024/1689)** — Art. 10 (data governance), Art. 50 (transparency) | Provenance-hashed synthetic datasets for training/test data with reproducible lineage; deterministic outputs that audit reviewers can re-execute |
-| **DORA (Reg. 2022/2554)** — Art. 24–27 (resilience testing), Art. 8 (asset register) | Reproducible test datasets for resilience testing programs; deterministic data fixtures for ICT system inventories |
-| **ISO/IEC 27701:2025** — A.1.4 (privacy by design), A.1.2.9 (RoPA) | Synthetic data in lieu of PII in non-production environments; documented model definitions as privacy-by-design evidence |
-| **HIPAA Security Rule** — §164.312 technical safeguards | Synthetic Patient/MedicalDevice/MedicalProcedure data for dev and test environments without ePHI exposure |
-| **GDPR Art. 25** (data protection by design) | Seeded pseudonymization with deterministic mapping; non-seeded mode for stronger privacy posture |
+| **EU AI Act (Reg. 2024/1689)** — Art. 10 (data governance) | Provenance-hashed synthetic datasets for training/test data with reproducible lineage; supports the data-governance documentation that high-risk-AI providers must maintain |
+| **DORA (Reg. 2022/2554)** — Art. 25 (testing of ICT tools and systems) | Reproducible test datasets for non-TLPT resilience tests; deterministic data fixtures for ICT testing programmes |
+| **ISO/IEC 27701:2019** — A.7.2.1, 7.2.8 (privacy by design and RoPA-supporting evidence) | Synthetic data in lieu of PII in non-production environments; documented model definitions as privacy-by-design evidence |
+| **HIPAA Security Rule** — §164.312 technical safeguards *(US Covered Entities / Business Associates only)* | Synthetic Patient/MedicalDevice/MedicalProcedure data for dev and test environments without ePHI exposure |
+| **GDPR** — Art. 4(5) pseudonymization definition; Art. 25 privacy by design; Art. 32 security of processing | Seeded pseudonymization with deterministic mapping; non-seeded mode for stronger privacy posture |
+| **PCI DSS 4.0** — Req. 6.5.5 (live PANs prohibited in test/development) | Synthetic PAN generation for test environments; deterministic tokenisation reproducible across runs |
 
 > These pointers do not constitute legal advice or a compliance attestation. Consult your DPO, CISO, or qualified counsel for formal compliance determinations. Full anonymization status under GDPR depends on re-identification risk across the complete dataset — see the [pseudonymization disclaimer above](#pseudonymization--ce-manual-model).
 
@@ -356,14 +368,15 @@ CE and EE have **separate, independently maintained cores**. CE is not a strippe
 ║  └──────────────────────────────────────────────────────────┘    ║
 ║                                                                  ║
 ║  ┌──────────────────────────────────────────────────────────┐    ║
-║  │  EE CORE  (optimised, separate from CE)                  │    ║
+║  │  EE CORE  (separately maintained, more advanced than CE) │    ║
 ║  │                                                          │    ║
-║  │  Ray-based distributed execution                         │    ║
-║  │  Isolated multiprocessing · Linear scalability           │    ║
+║  │  Rust fastpath for performance-critical paths            │    ║
+║  │  ML / auto-regressive engine for complex distributions   │    ║
+║  │  Keyset and manifest building from live DB schemas       │    ║
+║  │  Optimised distributed execution at billion-record scale │    ║
 ║  │  Runtime profiles: Performance · Balanced · Flexibility  │    ║
 ║  │  Deep nested evaluation · Conditions · Rulesets          │    ║
-║  │  ML engine integration · Structured error catalog        │    ║
-║  │  Per-stage importer/exporter logging                     │    ║
+║  │  Structured error catalog · Per-stage execution logging  │    ║
 ║  └──────────────────────────────────────────────────────────┘    ║
 ╚══════════════════════════════════════════════════════════════════╝
 
@@ -395,7 +408,7 @@ Both editions share the same DATAMIMIC DSL and determinism contract. Scale, thro
 | MongoDB | ✅ | ✅ | EE adds nested document generation |
 | CSV / JSON / XML | ✅ | ✅ | Flat file pipelines |
 | Apache Kafka | — | ✅ | Real-time streaming, payment scenarios |
-| EDIFACT / SWIFT MT | — | ✅ | Test/training output only; does not satisfy SWIFT CSP production-environment controls (1.1, 1.4) |
+| EDIFACT / SWIFT MT | — | ✅ | Test/training output only; does not satisfy SWIFT CSCF v2025 secure-zone controls (1.1 environment protection, 1.4 internet restriction). Generated messages must not be transmitted from a CSP-attested secure zone. |
 
 ---
 
@@ -408,9 +421,9 @@ Both editions share the same DATAMIMIC DSL and determinism contract. Scale, thro
 | **Insurance** | InsuranceCompany, InsuranceProduct, InsurancePolicy, InsuranceCoverage |
 | **E-commerce** | Order, Product |
 | **Public sector** | AdministrationOffice, EducationalInstitution, PoliceOfficer |
-| **Demographics** | Person (DE / US / VN locale packs), Address, Company |
+| **Demographics** | Person (DE / US / VN locale packs), Address |
 
-All services are versioned, seeded, and audit-ready. Each service exposes the same deterministic API: `Service().generate(seed=…, locale=…, count=…)`.
+All services are versioned and seeded; each generation emits a provenance hash suitable as evidence in audit reviews. Same deterministic API across domains: `Service().generate(seed=…, locale=…, count=…)`.
 
 ---
 
@@ -468,6 +481,6 @@ The DATAMIMIC Enterprise Platform (EE) is a commercial product. [Contact us](htt
 
 ---
 
-**DATAMIMIC — Make test data a standard, not a manual process.**
+**DATAMIMIC — Deterministic, governed test data for regulated enterprises.**
 
 [datamimic.io](https://datamimic.io) &nbsp;|&nbsp; [Book a demo](https://datamimic.io/contact) &nbsp;|&nbsp; [LinkedIn](https://linkedin.com/company/rapiddweller)

--- a/docs/website-and-case-study-fixes.md
+++ b/docs/website-and-case-study-fixes.md
@@ -1,0 +1,391 @@
+# Website & Case Study Fixes — Tracker für Eri & Bao
+
+**Owner:** Eri (form), Bao (technische Umsetzung im CMS), Alex (content sign-off)
+**Datum erstellt:** 2026-05-18
+**Status:** Active
+**Quelle:** Multi-Agent-Review (Compliance · Marketing Voice · CE/EE Boundary)
+
+---
+
+## Wichtige Vorabklärungen
+
+1. **Volle Synthese ≠ Pseudonymisierung.** Wo eine Case Study ein vollsynthetisches Pipeline-Modell beschreibt (keine Quelldaten eingelesen), sind absolute Aussagen wie „0% PII", „no live data", „100% automated runs" **faktisch korrekt** und müssen NICHT entschärft werden. Zu unterscheiden:
+   - **Daten-Eigenschaft** (synthetic ⇒ no PII) — Absolute okay
+   - **Programm-Eigenschaft** (compliance = governance, training, procedures) — Absolute NICHT okay
+   - **Engineering-Eigenschaft** (zero latency, no perf impact) — braucht Messwert
+
+2. **CE bleibt low-profile auf der Website** (Owner-Präferenz). Keine CE-vs-EE-Vergleichstabellen auf marketing-relevanten Seiten. Diskreter GitHub-Link im Footer ist genug.
+
+3. **Consulting-Positioning ist das eigentliche Differenzierungsmerkmal** — sollte über dem Fold sichtbar werden.
+
+---
+
+## Track A: Homepage (datamimic.io)
+
+**Owner:** Eri (form), Bao (CMS), Alex (sign-off)
+
+### A1 [P0] — Falsche Anonymisierungs-Begrifflichkeit
+
+**Aktuell (Hero / FAQ-Antwort):**
+> "Teams generate compliant data on demand — without production data ever leaving your environment."
+> "...excels at generating fully anonymized synthetic data"
+
+**Probleme:**
+- „compliant data" — Compliance ist eine Programm-Eigenschaft (Governance, Procedures, Schulungen), keine Daten-Eigenschaft
+- „fully anonymized" — Anonymisierung unter GDPR Recital 26 ist eine **Dataset-Level**-Bestimmung (singling-out, linkability, inference), nicht ein Output-Garantie
+- Direkter Widerspruch zur README-Disclaimer (die ist sauber)
+
+**Ersetzen mit:**
+> "Teams generate synthetic test data on demand inside your own environment — no production data egress."
+> "DATAMIMIC generates fully synthetic data and supports privacy-maximized pseudonymization; full GDPR anonymization status depends on a re-identification risk assessment across the complete dataset."
+
+### A2 [P0] — Consulting-Positioning über dem Fold
+
+**Aktuell:** Hero = pures Produkt-Framing („Test Data Platform For Regulated Enterprises"). Consulting-Differentiator erst weit unten in „Going Beyond for You!".
+
+**Vorschlag — Sub-Headline unter Hero ergänzen:**
+> "Software plus the team that built it — deployed across Oracle, MongoDB, and Kafka in EU tier-1 banking."
+
+Einzeiler, kein CE-Branding, macht das eigentliche Differenzierungsmerkmal sichtbar.
+
+### A3 [P1] — Compliance-Claims ohne Methodik
+
+**Aktuell:**
+> "satisfying DORA, GDPR, and BCBS 239 data lineage requirements"
+> "directly aligned with the traceability, accuracy, and resilience testing requirements of DORA"
+
+**Probleme:**
+- „satisfying" / „directly aligned" sind bindende Compliance-Behauptungen. Ein Tool **produziert Evidenz**; es **erfüllt** keine regulatorischen Pflichten alleine.
+- BCBS 239 gilt **nur** für G-SIBs/D-SIBs (global/domestic systemically important banks) — als generischer Constraint missverständlich.
+- DORA-Pflichten liegen bei den **Financial Entities**, nicht beim Vendor (außer bei CTPP-Designation Art. 31).
+
+**Ersetzen mit:**
+> "Supporting evidence for DORA Art. 25 ICT-testing requirements, GDPR Art. 30 records, and — for in-scope banks — BCBS 239 lineage documentation."
+> "Helps in-scope financial entities meet DORA Art. 25 ICT-testing requirements."
+
+### A4 [P1] — GitHub-Link im Footer
+
+**Aktuell:** Footer-Link zeigt auf `github.com/rapiddweller` (Organisation).
+
+**Problem:** Org hat mehrere Repos — neugieriger Developer muss raten.
+
+**Fix:** Link auf `https://github.com/rapiddweller/datamimic` umstellen. Eine-Zeichen-Änderung. Respektiert Positioning-Präferenz (immer noch Footer-only, immer noch diskret).
+
+### Sign-off
+- [ ] Eri: A1 Texte ersetzt, A2 Sub-Headline live, A4 Link korrigiert
+- [ ] Alex: A3 Compliance-Texte review & sign-off
+
+---
+
+## Track B: Data Protection Software Page
+
+**URL:** https://datamimic.io/data-protection-software/
+**Owner:** Eri + Bao, Alex sign-off
+**Hinweis:** Track C in Eris Blog-Tracker behandelt diese Seite separat als Landingpage-Umbau. Diese Punkte ergänzen den Umbau, ersetzen ihn nicht.
+
+### B1 [P0] — SWIFT CSP Disclaimer ergänzen
+
+**Aktuell:** SWIFT MT wird als unterstütztes Format gelistet, ohne CSP-Kontext.
+
+**Ergänzen (an passender Stelle, z. B. als Disclaimer-Box oder Footnote):**
+> SWIFT MT message generation is for test and training environments only. Generated messages do not satisfy SWIFT CSCF v2025 secure-zone controls (1.1 environment protection, 1.4 internet restriction) and must not be transmitted from a CSP-attested production zone.
+
+### B2 [P1] — Compliance-Mapping-Tabelle ergänzen
+
+**Status quo:** GDPR Art. 25/32, DORA, BCBS 239 werden in einem Binding-Constraints-Diagramm gezeigt, ohne explizite Erklärung welche Frameworks adressiert werden.
+
+**Vorschlag — kompakter Mapping-Block:**
+
+| Framework | Was DATAMIMIC beiträgt |
+|---|---|
+| GDPR Art. 4(5) / Art. 25 / Art. 32 | Seeded pseudonymization mit deterministischem Mapping; provenance-hashed Outputs als TOMs-Evidenz |
+| EU AI Act (Reg. 2024/1689) Art. 10 | Provenance-hashed synthetic datasets als data-governance documentation für High-Risk-AI-Provider |
+| DORA (Reg. 2022/2554) Art. 25 | Reproducible test datasets für ICT-Tools-Testing (nicht TLPT) |
+| ISO/IEC 27701:2019 A.7.2.1 / 7.2.8 | Synthetic data statt PII in Non-Prod; dokumentierte Model-Definitionen als Privacy-by-Design-Evidenz |
+| PCI DSS 4.0 Req. 6.5.5 | Synthetic PAN generation für Test/Dev (kein Live-PAN-Test) |
+| HIPAA §164.312 *(US Covered Entities / Business Associates only)* | Synthetic Patient-Daten ohne ePHI-Exposition |
+| BCBS 239 *(G-SIBs / D-SIBs only)* | Reproducible lineage documentation für Risk-Data-Aggregation |
+
+**Footnote:** „BCBS 239 applies to globally and domestically systemically important banks."
+
+### B3 [P1] — „Rust fastpath" als EE-Feature labeln
+
+**Aktuell:** „Performance via Rust fastpath and Ray cluster distribution" steht ohne Edition-Kontext.
+
+**Fix:** Sicherstellen dass im Kontext klar ist, dass das ein **EE-Core-Feature** ist (Rust fastpath, ML/auto-regressive engine, keyset/manifest building sind EE-only). Da die Seite primär die Enterprise Platform vermarktet ist das implizit — aber ein explizites „in the Enterprise Platform core" verhindert Missverständnisse.
+
+### Sign-off
+- [ ] Eri: B1 Disclaimer eingebaut, B3 Edition-Label gesetzt
+- [ ] Alex: B2 Compliance-Mapping content review
+
+---
+
+## Track C: User Interface Page
+
+**URL:** https://datamimic.io/user-interface/
+**Owner:** Eri (form), Bao (CMS), Alex (sign-off)
+
+### C1 [P0] — Buzzword-CTA ersetzen
+
+**Aktuell:**
+> "Embrace the power of DATAMIMIC UI today and begin transforming your test data generation processes immediately."
+
+**Probleme:** „Embrace the power", „transforming", „immediately" — pure Infomercial-Sprache. Failt den bank-CTO-reshare test.
+
+**Ersetzen mit:**
+> "Try DATAMIMIC UI — open a scenario, edit the model, run it locally."
+
+### C2 [P0] — „Monotonous dweller tasks" verständlich machen
+
+**Aktuell:**
+> "monotonous dweller tasks to leave meaningful work for humans"
+
+**Problem:** „Dweller tasks" ist internes Brand-Sprech (rapiddweller), Leser parsen das nicht.
+
+**Ersetzen mit:**
+> "Automate repetitive test-data preparation so engineers can focus on test design."
+
+### C3 [P1] — Hero und Grammatik
+
+**Aktuell:**
+> "Test Data made easy with DATAMIMIC UI's"
+
+**Probleme:** „Made easy" ist Consumer-Software-Register; Stray Apostrophe-S.
+
+**Ersetzen mit:**
+> "Author, run, and schedule DATAMIMIC scenarios from the browser."
+
+### C4 [P1] — Seite als EE-only labeln
+
+**Aktuell:** Die UI-Seite beschreibt EE-only Features (DataWorkbench, visuelle Editoren, Auto-Model-Generation) ohne Edition-Marker. Reader vom GitHub-README (wo DataWorkbench explizit EE ist) wird verwirrt.
+
+**Fix — eine Zeile in der Intro ergänzen:**
+> "DATAMIMIC UI is part of the DATAMIMIC Enterprise Platform."
+
+Kein Vergleich, keine CE-Erwähnung — nur ein klares Label.
+
+### Sign-off
+- [ ] Eri: C1/C2/C3 Texte ersetzt, C4 Label eingebaut
+- [ ] Alex: review
+
+---
+
+## Track D: Case Studies
+
+**Owner:** Eri (form), Alex (content sign-off + reference rights confirmation)
+
+### D1 [P0] — School Case Study: Wortwahl
+
+**URL:** https://datamimic.io/case-study/school-management-system-...
+
+**Aktuell:** „Bulletproof Compliance & Risk Mitigation"
+
+**Problem:** „Bulletproof" failt den bank-CTO-reshare test unabhängig von der Substanz. Die Substanz ist verteidigbar (vollsynthetisch ⇒ keine Live-Daten), nur die Wortwahl muss raus.
+
+**Ersetzen mit:**
+> "PII exposure eliminated in dev and test environments across 30 schemas."
+
+**Behalten (Substanz korrekt bei vollsynthetischem Pipeline-Modell):**
+- ✅ „0% PII exposure"
+- ✅ „No live student data outside production"
+- ✅ „100% automated reporting" (wenn jeder Run einen Report emittiert)
+
+### D2 [P1] — School Case Study: „Zero compliance risk" nuancieren
+
+**Aktuell:** „Zero compliance risk, full development velocity"
+
+**Problem:** „Zero compliance risk" ist zu breit. Synthetic eliminiert die **PII-Leg** des Compliance-Risikos, nicht das gesamte Compliance-Risiko (AVV mit Hosting-Provider, GDPR Art. 8 child-consent processes, organisatorische Maßnahmen, RoPA-Pflege).
+
+**Ersetzen mit:**
+> "No production student data in non-production environments; no measured slowdown in feature delivery."
+
+### D3 [P1] — School Case Study: Framework benennen
+
+**Aktuell:** „child safety requirements" und „child protection laws" generisch erwähnt.
+
+**Fix:** Jurisdiktion benennen, z. B.:
+> "GDPR Art. 8 (children's consent under 16) and applicable national child-protection statutes."
+
+### D4 [P0] — ACI Case Study: Begriffspräzision Anonymisierung
+
+**URL:** https://datamimic.io/case-study/aci-worldwide-real-time-anonymisation-of-streaming-payment-data/
+
+**Aktuell:** „Real-Time Anonymisation of Streaming Payment Data"
+
+**Problem:** Inline-Anonymisierung pro Event ist unter GDPR Recital 26 fast immer **Pseudonymisierung**, nicht Anonymisierung — echte Anonymisierung verlangt Dataset-Level-Risk-Assessment, das pro-Event nicht durchführbar ist.
+
+**Ersetzen mit:**
+> "Real-Time Pseudonymisation of Streaming Payment Data"
+
+Im Body durchgehend `anonymisation` → `pseudonymisation`.
+
+### D5 [P0] — ACI Case Study: „Zero latency impact" mit Messwert
+
+**Aktuell:** „Millions of payment records anonymised hourly with zero latency impact"
+
+**Problem:** Engineering-Absolute. Kein reales Streaming-System hat literally zero added latency.
+
+**Ersetzen mit:**
+> "Added P99 latency of <X> ms across the Kafka topic under <M>-record/hour load."
+
+**Aktion Alex:** Konkreten Latenz-Wert vom ACI-Engagement liefern (oder von Eri über Kunden-Kontakt einholen).
+
+### D6 [P1] — ACI Case Study: PCI DSS Kontext ergänzen
+
+**Aktuell:** Payment-Streaming-Case ohne PCI-DSS-Erwähnung.
+
+**Ergänzen — „Regulatory context" Box:**
+> "PAN handling aligned with PCI DSS 4.0 Req. 3.5 (PAN rendering unreadable) via deterministic tokenisation. Not a PCI-DSS-validated tokenisation solution; customer remains responsible for QSA assessment of the integrated environment."
+
+### D7 [P2] — ACI Case Study: Wortwahl-Sweep
+
+| Aktuell | Ersetzen |
+|---|---|
+| „bulletproof data protection at global scale" | „high-throughput protection for streaming payment data" |
+| „existential threats to payment processors" | „regulatory fines and customer-trust loss" |
+| „Full deterministic integrity across entities" | „Same input record produces identical pseudonymized output across consumer topics" |
+
+### D8 [P1] — Tier-1 Bank Case Study: Anonyme Attribution
+
+**URL:** https://datamimic.io/case-study/tier-1-european-bank-...
+
+**Aktuell:** Gesamte Page basiert auf unverifizierbarer „Tier-1 European Bank"-Attribution mit Quote von unbenanntem Program Manager.
+
+**Optionen — Alex muss entscheiden:**
+1. **(A) Kunden namentlich machen** mit schriftlicher Reference-Permission. Massive Stärkung. Idealer Lead-Case.
+2. **(B) Deskriptiv ohne Tier-Claim:** „A regulated EU retail banking engagement (customer name available under NDA)." Quote-Attribution: „Program Manager, EU retail banking engagement."
+3. **(C) Case Study durch ACI als Lead ersetzen** — ACI ist namentlich und unter D4-D7 reparierbar.
+
+**Empfehlung:** B oder C. A nur wenn realistisch erreichbar.
+
+### D9 [P1] — Tier-1 Bank Case Study: Wortwahl + Units
+
+**Wortwahl:**
+| Aktuell | Ersetzen |
+|---|---|
+| „Bulletproof Compliance & Risk Mitigation" | „Reduced compliance and re-identification risk in non-production environments" |
+| „dependency hell" | „cross-schema dependency conflicts" |
+
+**Units im Results-Table:**
+- „Parallel execution capability \| 0% \| 90%" → Nenner unklar. Konkret:
+> "Share of refresh jobs runnable in parallel: 0 of 12 → 11 of 12"
+
+### D10 [P1] — Tier-1 Bank Case Study: PII-Methodik
+
+**Aktuell:** „Pre-production environments reduced live PII from ~100% to ≤5% residual, on track to zero"
+
+**Probleme:**
+- „On track to zero" ist forward-looking ohne Zeitrahmen.
+- „5% residual live PII" in pre-prod ist eine notable Veröffentlichung — Regulator könnte nachfragen.
+
+**Fix:** Methodik ergänzen oder weicher formulieren:
+> "Residual live PII in pre-production reduced from ~100% to <5% (measured by the customer's PII scanner at confidence threshold X)."
+
+Forward-looking-Phrase entweder entfernen oder mit Datum anchoren.
+
+### D11 [P1] — Tier-1 Bank Case Study: DORA-Kontext
+
+**Aktuell:** Bank-Context, kein DORA-Mention.
+
+**Ergänzen — kurze „Regulatory context" Sektion:**
+> "Engagement contributed reproducible test datasets to the customer's DORA Art. 25 (testing of ICT tools and systems) testing programme. DATAMIMIC outputs are not in SWIFT CSP scope."
+
+### D12 [P2] — Alle Case Studies: Software/Consulting-Split
+
+**Pattern:** Jede Case Study mischt Software-Capability und Consulting-Outcome. Buyer fragt zurecht: „Wenn ich nur Software kaufe, bekomme ich das?"
+
+**Fix pro Case Study:** „How we delivered" Mini-Sektion mit zwei Bullets:
+- **Software delivered:** <was das Produkt tat>
+- **Consulting delivered:** <was das Team rapiddweller tat>
+
+Verstärkt die Consulting-Led-Positionierung statt sie zu verstecken.
+
+### Sign-off
+- [ ] Alex: D8 entschieden (A / B / C)
+- [ ] Alex: D5 Latenz-Wert geliefert oder „measured by customer"-Verweis bestätigt
+- [ ] Alex: D10 PII-Methodik geliefert
+- [ ] Eri: alle Wortwahl-Sweeps D1/D7/D9 angewendet
+- [ ] Eri: D2/D3/D6/D11 Texte eingebaut
+- [ ] Eri: D12 Software/Consulting-Split-Pattern auf alle drei Case Studies angewendet
+
+---
+
+## Track E: FAQ
+
+**URL:** https://datamimic.io/faq/
+**Owner:** Eri, Alex sign-off
+
+### E1 [P1] — Anonymisierungs-Antwort mit README angleichen
+
+**Aktuell:** FAQ behauptet „excels at generating fully anonymized synthetic data" — widerspricht direkt der vorsichtigen README-Disclaimer.
+
+**Ersetzen mit:**
+> "DATAMIMIC generates fully synthetic data and supports privacy-maximized pseudonymization. Full GDPR anonymization status (Recital 26) depends on a re-identification risk assessment across the complete dataset, which DATAMIMIC does not perform on the customer's behalf."
+
+### E2 [P1] — Generic-Marketing-Phrasen ersetzen
+
+| Aktuell | Ersetzen |
+|---|---|
+| „an advanced test data tool" | „a Python+Rust core with multi-process execution and a browser-based scenario editor" |
+| „user-friendly UI" | „a browser-based editor for scenario authoring" |
+| „generate and anonymize data more quickly and efficiently" | „Run N worker processes in parallel; observed Mx speedup vs single-process on the bundled benchmark" (Alex: konkrete Zahlen liefern) |
+
+### E3 [P2] — „Ensure secure testing" entschärfen
+
+**Aktuell:** „data obfuscation and anonymization features to ensure secure testing"
+
+**Problem:** Vermischt Anonymisierung (Privacy) mit Security; „ensure" ist absolut.
+
+**Ersetzen mit:**
+> "data masking and pseudonymisation features that support secure non-production testing workflows"
+
+### Sign-off
+- [ ] Alex: E2 konkrete Benchmark-Zahlen geliefert
+- [ ] Eri: E1/E2/E3 Texte ersetzt
+
+---
+
+## Universal Checks (für alle Track-A bis Track-E Änderungen)
+
+### Forbidden Words — auf Sicht entfernen
+unleash, revolutionary, AI-driven, AI-powered, AI-enhanced, AI-native, leverage, seamless(ly), empower, ecosystem, journey, comprehensive solution, cutting-edge, innovative, unparalleled, robust, state-of-the-art, next-generation, trusted solution, effortless(ly), bulletproof, world-class, best-in-class, embrace the power, made easy.
+
+### Fünf Marketing-Tests vor Sign-off
+1. **Specificity** — würde der Satz auch auf Mostly-AI / Gretel / Tonic passen? Wenn ja: umschreiben.
+2. **Audience** — wer ist der Reader (architect / CISO / DPO / QA Lead)?
+3. **Persona** — kannst du 1-3 namentliche Personas benennen?
+4. **Promise** — jeder Claim beweisbar? Absolutwerte unter den richtigen Kategorien angewendet (siehe Vorabklärung 1)?
+5. **Scope** — nur die vereinbarte Änderung, kein Layout-Drift.
+
+### Bank-CTO-Reshare-Test
+Würde ein Head of Engineering einer Tier-1-Bank das ohne Peinlichkeit weiterleiten?
+
+---
+
+## Prioritäts-Übersicht
+
+| Prio | Track | Items |
+|---|---|---|
+| **P0** | A, B, C, D | A1, A2, B1, C1, C2, D1, D4, D5 |
+| **P1** | A, B, C, D, E | A3, A4, B2, B3, C3, C4, D2, D3, D6, D8, D9, D10, D11, E1, E2 |
+| **P2** | D, E | D7, D12, E3 |
+
+---
+
+## Empfohlene Sequenz
+
+**Sprint 1 (diese Woche):**
+- P0-Block durch Eri (A1, B1, C1, C2, D1, D4) — alles reine Text-Ersetzungen ohne Alex-Input
+- A4 (GitHub-Link) durch Bao
+
+**Sprint 2 (nach Alex-Input):**
+- A3, B2, D5, D10, E2 — brauchen Content-Input/Bestätigung von Alex
+- D8 (Tier-1 Entscheidung A/B/C) — Strategie-Call
+
+**Sprint 3 (parallel):**
+- A2 (Sub-Headline) — wenn Consulting-Positioning als richtige Richtung bestätigt
+- C4, D11, B3 — Edition-Labels und Compliance-Kontext-Ergänzungen
+- D12 — Software/Consulting-Split-Pattern auf alle Case Studies (etwas mehr Arbeit)
+
+**Sprint 4:**
+- D7, E3, alle P2-Polish

--- a/docs/website-and-case-study-fixes.md
+++ b/docs/website-and-case-study-fixes.md
@@ -99,7 +99,6 @@ Einzeiler, kein CE-Branding, macht das eigentliche Differenzierungsmerkmal sicht
 | Framework | Was DATAMIMIC beiträgt |
 |---|---|
 | GDPR Art. 4(5) / Art. 25 / Art. 32 | Seeded pseudonymization mit deterministischem Mapping; provenance-hashed Outputs als TOMs-Evidenz |
-| EU AI Act (Reg. 2024/1689) Art. 10 | Provenance-hashed synthetic datasets als data-governance documentation für High-Risk-AI-Provider |
 | DORA (Reg. 2022/2554) Art. 25 | Reproducible test datasets für ICT-Tools-Testing (nicht TLPT) |
 | ISO/IEC 27701:2019 A.7.2.1 / 7.2.8 | Synthetic data statt PII in Non-Prod; dokumentierte Model-Definitionen als Privacy-by-Design-Evidenz |
 | PCI DSS 4.0 Req. 6.5.5 | Synthetic PAN generation für Test/Dev (kein Live-PAN-Test) |


### PR DESCRIPTION
…ation

Three motivations:

1. Compliance/claim hygiene
   - Drop "compliance layer" framing for GDPR/HIPAA/PCI; replace with "audit evidence support" — DATAMIMIC produces evidence, it does not provide a regulatory safe harbor.
   - Drop unverified "Tier-1 European banks" attribution; replace with "regulated EU banking environments".
   - Soften "linearly scalable to 1,000,000,000+ records" to "designed for billion-record workloads" until a published benchmark backs the specific number.
   - Add SWIFT CSP caveat next to EDIFACT/SWIFT MT output: test/training only, does not satisfy production-environment controls 1.1/1.4.
   - Mark EE-only bullets in the "What is DATAMIMIC" list explicitly.

2. CE value-add
   - New section "Where CE fits on its own" with three concrete standalone use cases (CI/CD, MCP for AI agents, pseudonymization).
   - Expand CE domains table from 3 to 6 domains (Healthcare, Finance, Insurance, E-commerce, Public sector, Demographics) reflecting what is actually shipped in datamimic_ce/domains/.
   - Expand CLI reference from 3 to 8 verified commands (init, validate, run, demo list/create, info, version).

3. CE vs EE clarity
   - Rework "Supported systems" table into explicit CE/EE columns; correct prior errors (Oracle, MS SQL, MySQL, SQLite are CE).
   - Add new "Where DATAMIMIC fits in your compliance program" table mapping deterministic outputs to EU AI Act Art. 10/50, DORA Art. 8/24-27, ISO 27701:2025 A.1.4/A.1.2.9, HIPAA \xa7164.312, and GDPR Art. 25 — with a legal disclaimer.