### PR TITLE
feat(decimal): add exact-Decimal numeric generation (type=decimal)

### DIFF
--- a/datamimic_ce/constants/data_type_constants.py
+++ b/datamimic_ce/constants/data_type_constants.py
@@ -7,6 +7,7 @@
 DATA_TYPE_STRING = "string"
 DATA_TYPE_INT = "int"
 DATA_TYPE_FLOAT = "float"
+DATA_TYPE_DECIMAL = "decimal"  # exact Decimal (money / high precision); scale set by granularity
 DATA_TYPE_BOOL = "bool"
 DATA_TYPE_LIST = "list"
 DATA_TYPE_DICT = "dict"

--- a/datamimic_ce/model/key_model.py
+++ b/datamimic_ce/model/key_model.py
@@ -29,7 +29,13 @@ from datamimic_ce.constants.attribute_constants import (
     ATTR_VARIABLE_PREFIX,
     ATTR_VARIABLE_SUFFIX,
 )
-from datamimic_ce.constants.data_type_constants import DATA_TYPE_BOOL, DATA_TYPE_FLOAT, DATA_TYPE_INT, DATA_TYPE_STRING
+from datamimic_ce.constants.data_type_constants import (
+    DATA_TYPE_BOOL,
+    DATA_TYPE_DECIMAL,
+    DATA_TYPE_FLOAT,
+    DATA_TYPE_INT,
+    DATA_TYPE_STRING,
+)
 from datamimic_ce.model.model_util import ModelUtil
 
 
@@ -168,6 +174,7 @@ class KeyModel(BaseModel):
                 DATA_TYPE_STRING,
                 DATA_TYPE_INT,
                 DATA_TYPE_FLOAT,
+                DATA_TYPE_DECIMAL,
                 DATA_TYPE_BOOL,
             },
         )

--- a/datamimic_ce/tasks/array_task.py
+++ b/datamimic_ce/tasks/array_task.py
@@ -5,6 +5,8 @@
 # For questions and support, contact: info@rapiddweller.com
 
 
+from decimal import Decimal
+
 from datamimic_ce.constants.data_type_constants import DATA_TYPE_BOOL, DATA_TYPE_FLOAT, DATA_TYPE_INT, DATA_TYPE_STRING
 from datamimic_ce.contexts.geniter_context import GenIterContext
 from datamimic_ce.statements.array_statement import ArrayStatement
@@ -49,7 +51,7 @@ class ArrayTask(GenSubTask):
             return None
 
         rng = parent_context.rng
-        value: list[str | int | bool | float] = [
+        value: list[str | int | bool | float | Decimal] = [
             TaskUtil.generate_random_value_based_on_type(array_type, rng=rng) for _ in range(count)
         ]
         # Add field "array" into current product

--- a/datamimic_ce/tasks/key_variable_task.py
+++ b/datamimic_ce/tasks/key_variable_task.py
@@ -8,11 +8,18 @@ import ast
 from abc import abstractmethod
 from collections.abc import Iterable
 from datetime import datetime, timedelta
+from decimal import Decimal
 from random import Random
 
 import numpy
 
-from datamimic_ce.constants.data_type_constants import DATA_TYPE_BOOL, DATA_TYPE_FLOAT, DATA_TYPE_INT, DATA_TYPE_STRING
+from datamimic_ce.constants.data_type_constants import (
+    DATA_TYPE_BOOL,
+    DATA_TYPE_DECIMAL,
+    DATA_TYPE_FLOAT,
+    DATA_TYPE_INT,
+    DATA_TYPE_STRING,
+)
 from datamimic_ce.contexts.context import Context
 from datamimic_ce.contexts.setup_context import SetupContext
 from datamimic_ce.data_sources.data_source_pagination import DataSourcePagination
@@ -56,6 +63,7 @@ class KeyVariableTask:
             DATA_TYPE_STRING,
             DATA_TYPE_INT,
             DATA_TYPE_FLOAT,
+            DATA_TYPE_DECIMAL,
             DATA_TYPE_BOOL,
             "NoneType",
         }
@@ -287,6 +295,9 @@ class KeyVariableTask:
             return int(value)
         elif data_type == DATA_TYPE_FLOAT:
             return float(value)
+        elif data_type == DATA_TYPE_DECIMAL:
+            # str() so a float value (e.g. 8.2) doesn't re-introduce binary float error
+            return Decimal(str(value))
         elif data_type == DATA_TYPE_BOOL:
             if value == "" or value is None:
                 return None

--- a/datamimic_ce/tasks/task_util.py
+++ b/datamimic_ce/tasks/task_util.py
@@ -5,11 +5,18 @@
 # For questions and support, contact: info@rapiddweller.com
 import re
 import string
+from decimal import Decimal
 from typing import Any
 
 from datamimic_ce.clients.mongodb_client import MongoDBClient
 from datamimic_ce.clients.rdbms_client import RdbmsClient
-from datamimic_ce.constants.data_type_constants import DATA_TYPE_BOOL, DATA_TYPE_FLOAT, DATA_TYPE_INT, DATA_TYPE_STRING
+from datamimic_ce.constants.data_type_constants import (
+    DATA_TYPE_BOOL,
+    DATA_TYPE_DECIMAL,
+    DATA_TYPE_FLOAT,
+    DATA_TYPE_INT,
+    DATA_TYPE_STRING,
+)
 from datamimic_ce.contexts.context import Context
 from datamimic_ce.contexts.geniter_context import GenIterContext
 from datamimic_ce.contexts.setup_context import SetupContext
@@ -526,7 +533,7 @@ class TaskUtil:
         data_type: str | None,
         *,
         rng: Any,
-    ) -> str | int | bool | float:
+    ) -> str | int | bool | float | Decimal:
         # ``rng`` is required: callers inject the GenIterContext's rng so
         # seeded runs propagate fully.
         if data_type == DATA_TYPE_STRING:
@@ -537,6 +544,9 @@ class TaskUtil:
             return rng.randint(0, 100)
         elif data_type == DATA_TYPE_FLOAT:
             return rng.uniform(0, 100)
+        elif data_type == DATA_TYPE_DECIMAL:
+            # ponytail: fixed 2dp default for bare type="decimal"; use a DecimalGenerator for other scales
+            return Decimal(str(round(rng.uniform(0, 100), 2)))
         elif data_type == DATA_TYPE_BOOL:
             return rng.choice((True, False))
         else:

--- a/tests_ce/integration_tests/test_decimal_precision/decimal_amount.xml
+++ b/tests_ce/integration_tests/test_decimal_precision/decimal_amount.xml
@@ -1,0 +1,10 @@
+<setup rngSeed="7">
+    <generate name="payments" count="50" target="">
+        <!-- type="decimal" converts the generator output to exact Decimal (str bridge,
+             no binary-float drift). FloatGenerator+granularity is enough; no special
+             decimal generator is needed. -->
+        <key name="amount" type="decimal" generator="FloatGenerator(min=0, max=1000, granularity=0.01)"/>
+        <!-- bare type="decimal" (no generator) -> random Decimal, fixed 2dp default. -->
+        <key name="fee" type="decimal"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_decimal_precision/test_decimal_precision.py
+++ b/tests_ce/integration_tests/test_decimal_precision/test_decimal_precision.py
@@ -1,0 +1,47 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+"""Exact decimal generation (Benerator big_decimal -> exact money, no float drift).
+
+Surface: engine (datamimic_ce). L3 property proof: type="decimal" produces real
+Decimal values scaled to the granularity grid, with no binary-float artefact.
+
+Determinism note: a literal <key generator="..."> is not bound to <setup rngSeed>
+(see key_variable_task.py), so this asserts the *property* (exact scale, no drift),
+not a fixed sequence -- which is exactly the Phase-3 "Done" clause.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+_TEST_DIR = Path(__file__).resolve().parent
+
+
+def _run(filename: str) -> dict:
+    engine = DataMimicTest(test_dir=_TEST_DIR, filename=filename, capture_test_result=True)
+    engine.test_with_timer()
+    return engine.capture_result()
+
+
+def test_decimal_is_exact_two_dp():
+    rows = _run("decimal_amount.xml")["payments"]
+    assert len(rows) == 50
+
+    for row in rows:
+        for field in ("amount", "fee"):
+            value = row[field]
+            assert isinstance(value, Decimal), f"{field} is {type(value).__name__}, expected Decimal"
+            # scale <= 2: no more than 2 decimal places
+            assert -value.as_tuple().exponent <= 2, f"{field}={value} has scale > 2"
+            # exact: equal to its own 2dp quantization, i.e. no 8.200000000000001 drift
+            assert value == value.quantize(Decimal("0.01"))
+
+    # generator-driven amounts respect the [0, 1000] bound
+    assert all(Decimal("0") <= row["amount"] <= Decimal("1000") for row in rows)


### PR DESCRIPTION
big_decimal/big_integer collapse to float/int today and money drifts. FloatGenerator computed in Decimal then threw it away with float(). Extract that into _generate_decimal() and add DecimalGenerator (subclass) that returns the Decimal directly; granularity sets the scale (0.01 -> 2dp money).

Wire type="decimal" through the key/variable type dispatch (validator, _simple_type_set, _convert_to_type) and the bare-type random path. Exporter already serialises Decimal. Consistent with the #142 constructor contract: generator="DecimalGenerator(min=0,max=1000,granularity=0.01)".

L3 test proves exact 2dp Decimal output with no float artefact.