### PR TITLE
feat(dsl): support minCount/maxCount on <generate>

### DIFF
--- a/datamimic_ce/model/generate_model.py
+++ b/datamimic_ce/model/generate_model.py
@@ -17,6 +17,8 @@ from datamimic_ce.constants.attribute_constants import (
     ATTR_END,
     ATTR_EXPORT_URI,
     ATTR_INTERVAL,
+    ATTR_MAX_COUNT,
+    ATTR_MIN_COUNT,
     ATTR_MP_PLATFORM,
     ATTR_MULTIPROCESSING,
     ATTR_NAME,
@@ -35,6 +37,7 @@ from datamimic_ce.constants.attribute_constants import (
     ATTR_VARIABLE_PREFIX,
     ATTR_VARIABLE_SUFFIX,
 )
+from datamimic_ce.constants.element_constants import EL_GENERATE
 from datamimic_ce.model.model_util import ModelUtil
 
 _TIMESERIES_ATTRS: frozenset[str] = frozenset({ATTR_START, ATTR_END, ATTR_INTERVAL})
@@ -43,6 +46,8 @@ _TIMESERIES_ATTRS: frozenset[str] = frozenset({ATTR_START, ATTR_END, ATTR_INTERV
 class GenerateModel(BaseModel):
     name: str
     count: str | None = None
+    min_count: int | None = Field(None, alias=ATTR_MIN_COUNT)
+    max_count: int | None = Field(None, alias=ATTR_MAX_COUNT)
     source: str | None = None
     cyclic: bool | None = None
     type: str | None = None
@@ -77,6 +82,8 @@ class GenerateModel(BaseModel):
             valid_attributes={
                 ATTR_TARGET,
                 ATTR_COUNT,
+                ATTR_MIN_COUNT,
+                ATTR_MAX_COUNT,
                 ATTR_CYCLIC,
                 ATTR_NAME,
                 ATTR_SELECTOR,
@@ -121,6 +128,11 @@ class GenerateModel(BaseModel):
         if _TIMESERIES_ATTRS & values.keys():
             return values
         return ModelUtil.check_exist_count(values=values)
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_min_max_count(cls, values: dict):
+        return ModelUtil.check_min_max_count(values, EL_GENERATE)
 
     @model_validator(mode="before")
     @classmethod

--- a/datamimic_ce/model/model_util.py
+++ b/datamimic_ce/model/model_util.py
@@ -15,6 +15,8 @@ from datamimic_ce.constants.attribute_constants import (
     ATTR_GENERATOR,
     ATTR_IN_DATE_FORMAT,
     ATTR_LOCALE,
+    ATTR_MAX_COUNT,
+    ATTR_MIN_COUNT,
     ATTR_OUT_DATE_FORMAT,
     ATTR_RNG_SEED,
     ATTR_SCRIPT,
@@ -50,10 +52,30 @@ class ModelUtil:
         :param values:
         :return:
         """
-        if all(attr not in values for attr in [ATTR_SOURCE, ATTR_SCRIPT, ATTR_COUNT]):
+        if all(attr not in values for attr in [ATTR_SOURCE, ATTR_SCRIPT, ATTR_COUNT, ATTR_MIN_COUNT, ATTR_MAX_COUNT]):
             raise ValueError(
                 f"Missing attribute '{ATTR_COUNT}' ('{ATTR_COUNT}' might be optional "
                 f"in case '{ATTR_SOURCE} and {ATTR_SCRIPT} are not defined')"
+            )
+        return values
+
+    @staticmethod
+    def check_min_max_count(values: dict, element_tag: str) -> dict:
+        """count and minCount/maxCount are mutually exclusive; minCount must not exceed maxCount.
+        Shared by <generate> and <nestedKey>."""
+        key_set = set(values.keys())
+        if ATTR_COUNT in key_set:
+            if ATTR_MIN_COUNT in key_set or ATTR_MAX_COUNT in key_set:
+                raise ValueError(
+                    f"'{ATTR_MIN_COUNT}' and '{ATTR_MAX_COUNT}' must not be defined "
+                    f"when '{ATTR_COUNT}' exists in <{element_tag}>"
+                )
+        elif (
+            ATTR_MIN_COUNT in key_set and ATTR_MAX_COUNT in key_set and values[ATTR_MIN_COUNT] > values[ATTR_MAX_COUNT]
+        ):
+            raise ValueError(
+                f"'{ATTR_MIN_COUNT}' value ({values[ATTR_MIN_COUNT]}) "
+                f"must be less than or equal to '{ATTR_MAX_COUNT}' value ({values[ATTR_MAX_COUNT]})"
             )
         return values
 
@@ -266,4 +288,3 @@ class ModelUtil:
         if not value.isdigit() and re.match(r"^\{[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_]+)*\}$", value) is None:
             raise ValueError(f"must be string of digits or script, but get: '{value}'")
         return value
-

--- a/datamimic_ce/model/nested_key_model.py
+++ b/datamimic_ce/model/nested_key_model.py
@@ -26,6 +26,7 @@ from datamimic_ce.constants.attribute_constants import (
     ATTR_VARIABLE_SUFFIX,
 )
 from datamimic_ce.constants.data_type_constants import DATA_TYPE_LIST
+from datamimic_ce.constants.element_constants import EL_NESTED_KEY
 from datamimic_ce.model.model_util import ModelUtil
 
 
@@ -89,25 +90,7 @@ class NestedKeyModel(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate_min_max_count(cls, values: dict):
-        key_set = set(values.keys())
-        if ATTR_COUNT in key_set:
-            # Not allow minCount or maxCount is defined with count
-            if ATTR_MIN_COUNT in key_set or ATTR_MAX_COUNT in key_set:
-                raise ValueError(
-                    f"'{ATTR_MIN_COUNT}' and '{ATTR_MAX_COUNT}' must not be defined "
-                    f"when '{ATTR_COUNT}' exists in <nestedKey>"
-                )
-        else:
-            if (
-                ATTR_MIN_COUNT in key_set
-                and ATTR_MAX_COUNT in key_set
-                and (values[ATTR_MIN_COUNT] > values[ATTR_MAX_COUNT])
-            ):
-                raise ValueError(
-                    f"'{ATTR_MIN_COUNT}' value ({values[ATTR_MIN_COUNT]}) "
-                    f"must be less than or equal to '{ATTR_MAX_COUNT}' value ({values[ATTR_MAX_COUNT]})"
-                )
-        return values
+        return ModelUtil.check_min_max_count(values, EL_NESTED_KEY)
 
     @model_validator(mode="before")
     @classmethod

--- a/datamimic_ce/statements/generate_statement.py
+++ b/datamimic_ce/statements/generate_statement.py
@@ -22,6 +22,8 @@ class GenerateStatement(CompositeStatement):
         name = model.name
         super().__init__(name, parent_stmt)
         self._count = model.count
+        self._min_count = model.min_count
+        self._max_count = model.max_count
         self._source = model.source
         self._cyclic = model.cyclic
         self._source_script = model.source_scripted
@@ -67,6 +69,14 @@ class GenerateStatement(CompositeStatement):
     @count.setter
     def count(self, value):
         self._count = value
+
+    @property
+    def min_count(self) -> int | None:
+        return self._min_count
+
+    @property
+    def max_count(self) -> int | None:
+        return self._max_count
 
     def get_int_count(self, ctx: Context):
         """

--- a/datamimic_ce/statements/statement_util.py
+++ b/datamimic_ce/statements/statement_util.py
@@ -45,3 +45,23 @@ class StatementUtil:
             return int(count)
         else:
             return int(ctx.evaluate_python_expression(count[1:-1]))
+
+    @staticmethod
+    def resolve_count(count: int | None, min_count: int | None, max_count: int | None, rng) -> int | None:
+        """Single source of truth for resolving an effective row count from an explicit
+        count or a [minCount, maxCount] range. Shared by <generate> and <nestedKey>.
+
+        - explicit count wins
+        - none set -> None (caller falls back to source length)
+        - only one bound -> a ±5 window around it
+        - both -> rng.randint(min, max)
+        """
+        if count is not None:
+            return count
+        if min_count is not None and max_count is not None:
+            return rng.randint(min_count, max_count)
+        if max_count is not None:
+            return rng.randint(max(0, max_count - 5), max_count)
+        if min_count is not None:
+            return rng.randint(min_count, min_count + 5)
+        return None

--- a/datamimic_ce/tasks/generate_task.py
+++ b/datamimic_ce/tasks/generate_task.py
@@ -23,6 +23,7 @@ from datamimic_ce.statements.composite_statement import CompositeStatement
 from datamimic_ce.statements.generate_statement import GenerateStatement
 from datamimic_ce.statements.key_statement import KeyStatement
 from datamimic_ce.statements.statement import Statement
+from datamimic_ce.statements.statement_util import StatementUtil
 from datamimic_ce.tasks.task import CommonSubTask
 from datamimic_ce.tasks.task_util import TaskUtil
 from datamimic_ce.utils.logging_util import gen_timer
@@ -61,8 +62,14 @@ class GenerateTask(CommonSubTask):
             series_count = self._statement.get_int_count(context) or 1
             return series_count * ts_config.ticks_per_series
 
-        # Get count from statement
-        count = self._statement.get_int_count(context)
+        # Get count from statement: explicit count, or a random value within the
+        # minCount/maxCount range (seed-bound via context.rng). Same resolution as <nestedKey>.
+        count = StatementUtil.resolve_count(
+            self._statement.get_int_count(context),
+            self._statement.min_count,
+            self._statement.max_count,
+            context.rng,
+        )
 
         # Set length of data source if count is not defined explicitly in statement
         if count is None:

--- a/datamimic_ce/tasks/nested_key_task.py
+++ b/datamimic_ce/tasks/nested_key_task.py
@@ -14,6 +14,7 @@ from datamimic_ce.data_sources.data_source_pagination import DataSourcePaginatio
 from datamimic_ce.data_sources.data_source_registry import DataSourceRegistry
 from datamimic_ce.logger import logger
 from datamimic_ce.statements.nested_key_statement import NestedKeyStatement
+from datamimic_ce.statements.statement_util import StatementUtil
 from datamimic_ce.tasks.element_task import ElementTask
 from datamimic_ce.tasks.task import GenSubTask
 from datamimic_ce.tasks.task_util import TaskUtil
@@ -346,21 +347,7 @@ class NestedKeyTask(GenSubTask):
         :return:
         """
         count = self._statement.get_int_count(context)
-        min_count = self._statement.min_count
-        max_count = self._statement.max_count
-
-        if count is not None:
-            return count
-        if count is None and min_count is None and max_count is None:
-            return None
-
-        rng = context.rng
-        if min_count is None:
-            return rng.randint(max(0, max_count - 5), max_count)
-        elif max_count is None:
-            return rng.randint(min_count, min_count + 5)
-        else:
-            return rng.randint(min_count, max_count)
+        return StatementUtil.resolve_count(count, self._statement.min_count, self._statement.max_count, context.rng)
 
     def _post_convert(self, value):
         """

--- a/tests_ce/integration_tests/test_generate_count_range/count_conflict.xml
+++ b/tests_ce/integration_tests/test_generate_count_range/count_conflict.xml
@@ -1,0 +1,6 @@
+<setup rngSeed="42">
+    <!-- count and minCount/maxCount are mutually exclusive -> must fail at parse. -->
+    <generate name="items" count="5" minCount="3" maxCount="7" target="">
+        <key name="v" constant="x"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_generate_count_range/count_range.xml
+++ b/tests_ce/integration_tests/test_generate_count_range/count_range.xml
@@ -1,0 +1,6 @@
+<setup rngSeed="42">
+    <!-- minCount/maxCount: random row count in [3, 7] per run, seed-bound. -->
+    <generate name="items" minCount="3" maxCount="7" target="">
+        <key name="v" constant="x"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_generate_count_range/count_range_cascade.xml
+++ b/tests_ce/integration_tests/test_generate_count_range/count_range_cascade.xml
@@ -1,0 +1,10 @@
+<setup rngSeed="42">
+    <!-- Cascading: each parent row gets its OWN random child count in [2, 4],
+         re-rolled per parent via the shared context rng. -->
+    <generate name="orders" count="3" target="">
+        <key name="oid" generator="IncrementGenerator()"/>
+        <generate name="lines" minCount="2" maxCount="4" target="">
+            <key name="sku" constant="s"/>
+        </generate>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_generate_count_range/count_range_source.xml
+++ b/tests_ce/integration_tests/test_generate_count_range/count_range_source.xml
@@ -1,0 +1,7 @@
+<setup rngSeed="42" defaultSeparator=",">
+    <!-- minCount/maxCount with a source: read a random N rows in [3, 7] from the
+         source (same source handling as a fixed count=N). -->
+    <generate name="picked" minCount="3" maxCount="7" source="rows.csv" distribution="ordered" target="">
+        <key name="v" script="v"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_generate_count_range/rows.csv
+++ b/tests_ce/integration_tests/test_generate_count_range/rows.csv
@@ -1,0 +1,11 @@
+v
+a
+b
+c
+d
+e
+f
+g
+h
+i
+j

--- a/tests_ce/integration_tests/test_generate_count_range/test_generate_count_range.py
+++ b/tests_ce/integration_tests/test_generate_count_range/test_generate_count_range.py
@@ -1,0 +1,60 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+"""minCount/maxCount on <generate> (Benerator-style random row count).
+
+Surface: engine (datamimic_ce). Mirrors the existing <nestedKey> minCount/maxCount
+behaviour; count resolution is the single shared StatementUtil.resolve_count.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+_TEST_DIR = Path(__file__).resolve().parent
+
+
+def _run(filename: str) -> dict:
+    engine = DataMimicTest(test_dir=_TEST_DIR, filename=filename, capture_test_result=True)
+    engine.test_with_timer()
+    return engine.capture_result()
+
+
+def test_count_in_range_and_deterministic():
+    first = _run("count_range.xml")["items"]
+    assert 3 <= len(first) <= 7
+    # seed-bound: same rngSeed -> same count
+    second = _run("count_range.xml")["items"]
+    assert len(first) == len(second)
+
+
+def test_count_and_min_max_mutually_exclusive():
+    with pytest.raises(Exception, match="minCount.*maxCount|maxCount.*minCount|count"):
+        _run("count_conflict.xml")
+
+
+def test_cascading_child_count_per_parent():
+    # 3 parents, each with an independently-rolled child count in [2, 4].
+    first = _run("count_range_cascade.xml")
+    assert [r["oid"] for r in first["orders"]] == [1, 2, 3]
+    total_lines = len(first["lines"])  # nested products captured flattened under their key
+    assert 3 * 2 <= total_lines <= 3 * 4
+    # seed-bound: identical across runs
+    assert len(_run("count_range_cascade.xml")["lines"]) == total_lines
+
+
+def test_min_max_with_source():
+    first = _run("count_range_source.xml")["picked"]
+    assert 3 <= len(first) <= 7
+    source = {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
+    assert all(row["v"] in source for row in first)
+    # ordered + seed -> deterministic count and content
+    second = _run("count_range_source.xml")["picked"]
+    assert [r["v"] for r in first] == [r["v"] for r in second]

--- a/tests_ce/unit_tests/test_task/test_generate_task.py
+++ b/tests_ce/unit_tests/test_task/test_generate_task.py
@@ -132,6 +132,8 @@ class TestGenerateTask:
         statement.variable_suffix = "test_suffix"
         statement.distribution = "uniform"
         statement.converter = "json"
+        statement.min_count = None
+        statement.max_count = None
         statement._count = 1000
         statement._source_uri = "mongodb://localhost:27017"
         statement._separator = ","


### PR DESCRIPTION
Benerator descriptors use minCount/maxCount pervasively for a random per-run row count; <generate> only accepted a fixed/script count. Add it, mirroring the existing <nestedKey> behaviour.

SPOT: count-range resolution now lives in one place, StatementUtil.resolve_count, called by both GenerateTask._determine_count and NestedKeyTask (the duplicated inline logic there is removed). count and minCount/maxCount are mutually exclusive (validator mirrors <nestedKey>); check_exist_count accepts min/max as satisfying the count requirement.

DSL tests: flat range + determinism, mutual-exclusion, cascading (per-parent re-rolled child count), and source-backed (random N rows from CSV). Count resolution is datasource-agnostic, so one source type is representative.