### PR TITLE
fix(finance): generate Luhn-valid credit card numbers

### DIFF
--- a/datamimic_ce/domains/finance/generators/credit_card_generator.py
+++ b/datamimic_ce/domains/finance/generators/credit_card_generator.py
@@ -80,9 +80,12 @@ class CreditCardGenerator(DatasetAwareDomainGenerator):
         # columns: type,prefix,length,cvv_length,weight
         weights = [float(r[4]) for r in rows]
         chosen = self._rng.choices(rows, weights=weights, k=1)[0]
+        # 'prefix' may list alternative BINs pipe-separated (e.g. AMEX "34|37"); pick one
+        # so the card number is a clean numeric payload.
+        prefix = self._rng.choice(str(chosen[1]).split("|"))
         self._card_specs = {
             "type": chosen[0],
-            "prefix": str(chosen[1]),
+            "prefix": prefix,
             "length": int(chosen[2]),
             "cvv_length": int(chosen[3]),
         }

--- a/datamimic_ce/domains/finance/models/credit_card.py
+++ b/datamimic_ce/domains/finance/models/credit_card.py
@@ -19,6 +19,7 @@ from datamimic_ce.domains.domain_core.property_cache import property_cache
 from datamimic_ce.domains.finance.generators.credit_card_generator import CreditCardGenerator
 from datamimic_ce.domains.finance.models.bank import Bank
 from datamimic_ce.domains.finance.models.bank_account import BankAccount
+from datamimic_ce.utils.luhn_util import luhn_check_digit
 
 
 class CreditCard(BaseEntity):
@@ -54,13 +55,14 @@ class CreditCard(BaseEntity):
         prefix = specs.get("prefix", "")
         total_len = specs.get("length", 16)
         remaining = max(0, total_len - len(prefix))
-        if remaining > 0:
-            # Use generator RNG instead of global exrex RNG so rngSeed descriptors replay.
-            digits = [str(self._credit_card_generator.rng.randint(0, 9)) for _ in range(remaining)]
-            suffix = "".join(digits)
-        else:
-            suffix = ""
-        return f"{prefix}{suffix}"
+        if remaining == 0:
+            #  degenerate spec: prefix fills the whole length, no room for a check digit
+            return prefix
+        # Fill all but the last position randomly (generator RNG so rngSeed descriptors
+        # replay), then set the last digit to the Luhn check digit (ISO/IEC 7812-1).
+        random_digits = "".join(str(self._credit_card_generator.rng.randint(0, 9)) for _ in range(remaining - 1))
+        payload = f"{prefix}{random_digits}"
+        return f"{payload}{luhn_check_digit(payload)}"
 
     @property
     @property_cache

--- a/datamimic_ce/utils/luhn_util.py
+++ b/datamimic_ce/utils/luhn_util.py
@@ -1,0 +1,24 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+
+def luhn_check_digit(payload: str) -> str:
+    """Return the Luhn (ISO/IEC 7812-1, mod 10) check digit for ``payload``.
+
+    Single source of truth for card check-digit generation: ``payload + check``
+    passes Luhn validation. Doubling starts at the rightmost payload digit, since
+    once the check digit is appended that digit sits at the second-from-right
+    position (the first doubled position).
+    """
+    total = 0
+    for i, ch in enumerate(reversed(payload)):
+        d = int(ch)
+        if i % 2 == 0:
+            d *= 2
+            if d > 9:
+                d -= 9
+        total += d
+    return str((10 - (total % 10)) % 10)

--- a/tests_ce/integration_tests/test_credit_card_luhn/credit_card_luhn.xml
+++ b/tests_ce/integration_tests/test_credit_card_luhn/credit_card_luhn.xml
@@ -1,0 +1,7 @@
+<setup rngSeed="42">
+    <!-- Every generated card number must satisfy the Luhn (ISO/IEC 7812-1) checksum. -->
+    <generate name="cards" count="50" target="">
+        <variable name="cc" entity="CreditCard"/>
+        <key name="card_number" script="cc.card_number"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_credit_card_luhn/test_credit_card_luhn.py
+++ b/tests_ce/integration_tests/test_credit_card_luhn/test_credit_card_luhn.py
@@ -1,0 +1,55 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+"""Generated credit card numbers must be Luhn-valid (ISO/IEC 7812-1).
+
+Surface: engine (datamimic_ce, finance domain). The validator below is an
+independent mod-10 check (verification pass), deliberately NOT the production
+luhn_check_digit, so it genuinely cross-checks the generated numbers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+_TEST_DIR = Path(__file__).resolve().parent
+
+
+def _luhn_is_valid(number: str) -> bool:
+    """Standard Luhn validation pass: double every 2nd digit from the right
+    (the check digit at index 0 is not doubled); the total must be a multiple of 10."""
+    total = 0
+    for i, ch in enumerate(reversed(number)):
+        d = int(ch)
+        if i % 2 == 1:
+            d *= 2
+            if d > 9:
+                d -= 9
+        total += d
+    return total % 10 == 0
+
+
+def _run(filename: str) -> dict:
+    engine = DataMimicTest(test_dir=_TEST_DIR, filename=filename, capture_test_result=True)
+    engine.test_with_timer()
+    return engine.capture_result()
+
+
+def test_card_numbers_are_luhn_valid():
+    rows = _run("credit_card_luhn.xml")["cards"]
+    assert len(rows) == 50
+    for r in rows:
+        num = r["card_number"]
+        assert num.isdigit(), f"non-numeric card number: {num!r}"
+        assert _luhn_is_valid(num), f"card number fails Luhn: {num}"
+
+
+def test_luhn_validator_rejects_tampered():
+    # guard the test's own validator: a tampered valid number must fail
+    assert _luhn_is_valid("79927398713")
+    assert not _luhn_is_valid("79927398714")


### PR DESCRIPTION
Card numbers were prefix + random digits, so they failed the Luhn (ISO/IEC 7812-1) checksum every real card scheme uses. Two fixes:

- get_card_specs now resolves the pipe-separated 'prefix' column (e.g. AMEX "34|37", DINERS "300|301|...") to a single BIN. The old code used the raw string, emitting non-numeric numbers like "34|37..." — a latent bug masked because nothing validated the output.
- card_number fills all but the last position randomly (generator RNG, so rngSeed replays) and sets the last digit to the Luhn check digit.

SPOT: luhn_check_digit lives in utils/luhn_util.py. DSL test asserts every generated card passes an INDEPENDENT mod-10 validation pass (verified against canonical vectors), with a self-guard that the validator rejects tampered input.