### PR TITLE
feat(dsl): inline weighted value pick via 'weights' companion of 'val…

### DIFF
--- a/datamimic_ce/constants/attribute_constants.py
+++ b/datamimic_ce/constants/attribute_constants.py
@@ -83,3 +83,4 @@ ATTR_INTERVAL: Final = "interval"
 ATTR_FROM: Final = "from"
 ATTR_TO: Final = "to"
 ATTR_WEIGHT: Final = "weight"
+ATTR_WEIGHTS: Final = "weights"  # companion of 'values': relative weights for inline weighted pick

--- a/datamimic_ce/model/key_model.py
+++ b/datamimic_ce/model/key_model.py
@@ -28,6 +28,7 @@ from datamimic_ce.constants.attribute_constants import (
     ATTR_VALUES,
     ATTR_VARIABLE_PREFIX,
     ATTR_VARIABLE_SUFFIX,
+    ATTR_WEIGHTS,
 )
 from datamimic_ce.constants.data_type_constants import (
     DATA_TYPE_BOOL,
@@ -46,6 +47,7 @@ class KeyModel(BaseModel):
     selector: str | None = None
     separator: str | None = None
     values: str | None = None
+    weights: str | None = None
     script: str | None = None
     generator: str | None = None
     constant: str | None = None
@@ -73,6 +75,7 @@ class KeyModel(BaseModel):
                 ATTR_SELECTOR,
                 ATTR_SEPARATOR,
                 ATTR_VALUES,
+                ATTR_WEIGHTS,
                 ATTR_SCRIPT,
                 ATTR_GENERATOR,
                 ATTR_CONSTANT,
@@ -89,6 +92,11 @@ class KeyModel(BaseModel):
                 ATTR_VARIABLE_SUFFIX,
             },
         )
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_weights_require_values(cls, values: dict):
+        return ModelUtil.check_weights_require_values(values)
 
     @model_validator(mode="before")
     @classmethod

--- a/datamimic_ce/model/model_util.py
+++ b/datamimic_ce/model/model_util.py
@@ -25,7 +25,9 @@ from datamimic_ce.constants.attribute_constants import (
     ATTR_SOURCE,
     ATTR_SOURCE_SCRIPTED,
     ATTR_TYPE,
+    ATTR_VALUES,
     ATTR_WEIGHT_COLUMN,
+    ATTR_WEIGHTS,
 )
 from datamimic_ce.constants.data_type_constants import DATA_TYPE_STRING
 from datamimic_ce.utils.string_util import StringUtil
@@ -57,6 +59,13 @@ class ModelUtil:
                 f"Missing attribute '{ATTR_COUNT}' ('{ATTR_COUNT}' might be optional "
                 f"in case '{ATTR_SOURCE} and {ATTR_SCRIPT} are not defined')"
             )
+        return values
+
+    @staticmethod
+    def check_weights_require_values(values: dict) -> dict:
+        """'weights' is the companion of 'values' — it is meaningless on its own."""
+        if ATTR_WEIGHTS in values and ATTR_VALUES not in values:
+            raise ValueError(f"'{ATTR_WEIGHTS}' is only allowed together with '{ATTR_VALUES}'")
         return values
 
     @staticmethod

--- a/datamimic_ce/model/variable_model.py
+++ b/datamimic_ce/model/variable_model.py
@@ -35,6 +35,7 @@ from datamimic_ce.constants.attribute_constants import (
     ATTR_VARIABLE_PREFIX,
     ATTR_VARIABLE_SUFFIX,
     ATTR_WEIGHT_COLUMN,
+    ATTR_WEIGHTS,
 )
 from datamimic_ce.model.model_util import ModelUtil
 
@@ -57,6 +58,7 @@ class VariableModel(BaseModel):
     out_date_format: str | None = Field(None, alias=ATTR_OUT_DATE_FORMAT)
     converter: str | None = None
     values: str | None = None
+    weights: str | None = None
     constant: str | None = None
     iteration_selector: str | None = Field(None, alias=ATTR_ITERATION_SELECTOR)
     default_value: str | None = Field(None, alias=ATTR_DEFAULT_VALUE)
@@ -97,6 +99,7 @@ class VariableModel(BaseModel):
                 ATTR_CONVERTER,
                 ATTR_CONSTANT,
                 ATTR_VALUES,
+                ATTR_WEIGHTS,
                 ATTR_ITERATION_SELECTOR,
                 ATTR_DEFAULT_VALUE,
                 ATTR_PATTERN,
@@ -113,6 +116,11 @@ class VariableModel(BaseModel):
                 ATTR_RNG_SEED,
             },
         )
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_weights_require_values(cls, values: dict):
+        return ModelUtil.check_weights_require_values(values)
 
     @model_validator(mode="before")
     @classmethod

--- a/datamimic_ce/statements/element_statement.py
+++ b/datamimic_ce/statements/element_statement.py
@@ -24,6 +24,7 @@ class ElementStatement(Statement):
         self._separator = model.separator
         self._type = model.type
         self._values = model.values
+        self._weights = model.weights
         self._default_value = model.default_value
         self._pattern = model.pattern
         self._variable_prefix = model.variable_prefix
@@ -41,6 +42,10 @@ class ElementStatement(Statement):
     @property
     def values(self):
         return self._values
+
+    @property
+    def weights(self):
+        return self._weights
 
     @property
     def script(self):

--- a/datamimic_ce/statements/key_statement.py
+++ b/datamimic_ce/statements/key_statement.py
@@ -24,6 +24,7 @@ class KeyStatement(CompositeStatement):
         self._separator = model.separator
         self._type = model.type
         self._values = model.values
+        self._weights = model.weights
         self._default_value = model.default_value
         self._null_quota = model.null_quota
         self._pattern = model.pattern
@@ -43,6 +44,10 @@ class KeyStatement(CompositeStatement):
     @property
     def values(self):
         return self._values
+
+    @property
+    def weights(self):
+        return self._weights
 
     @property
     def script(self):

--- a/datamimic_ce/statements/variable_statement.py
+++ b/datamimic_ce/statements/variable_statement.py
@@ -36,6 +36,7 @@ class VariableStatement(Statement):
         self._separator = model.separator
         self._type = model.type
         self._values = model.values
+        self._weights = model.weights
         self._weight_column = model.weight_column
         self._iteration_selector = model.iteration_selector
         self._default_value = model.default_value
@@ -124,6 +125,10 @@ class VariableStatement(Statement):
     @property
     def values(self):
         return self._values
+
+    @property
+    def weights(self):
+        return self._weights
 
     @property
     def iteration_selector(self) -> str | None:

--- a/datamimic_ce/tasks/key_variable_task.py
+++ b/datamimic_ce/tasks/key_variable_task.py
@@ -97,6 +97,7 @@ class KeyVariableTask:
                     f"'values' element of <{self._element_tag}> '{self._statement.name}' "
                     f"is invalid: {self._statement.values}"
                 ) from None
+            self._weights = self._parse_weights(self._values)
             self._mode = self._VALUES_MODE
         elif self._statement.generator is not None:
             # NOTE: a literal <key generator="..."> is created without an injected
@@ -188,8 +189,13 @@ class KeyVariableTask:
                 suffix=self._suffix,
             )
         elif self._mode == self._VALUES_MODE:
-            # Return None if self._values is None
-            value = None if self._values is None else ctx.rng.choice(self._values)
+            # Return None if self._values is None; weighted pick when 'weights' given.
+            if self._values is None:
+                value = None
+            elif self._weights:
+                value = ctx.rng.choices(self._values, weights=self._weights, k=1)[0]
+            else:
+                value = ctx.rng.choice(self._values)
         elif self._mode == self._LAZY_GENERATOR_MODE:
             # Try to init generator again in first task execution
             self._generator = (
@@ -268,6 +274,27 @@ class KeyVariableTask:
             ) from e
 
         return value
+
+    def _parse_weights(self, values):
+        """Parse the 'weights' companion of 'values' into floats, validating the count.
+        Returns None when no weights are given (uniform pick)."""
+        if self._statement.weights is None:
+            return None
+        try:
+            parsed = ast.literal_eval(self._statement.weights)
+            if not isinstance(parsed, Iterable):
+                parsed = (parsed,)
+            weights = [float(w) for w in parsed]
+        except (SyntaxError, ValueError, TypeError):
+            raise ValueError(
+                f"'weights' of <{self._element_tag}> '{self._statement.name}' is invalid: {self._statement.weights}"
+            ) from None
+        if values is not None and len(weights) != len(values):
+            raise ValueError(
+                f"'weights' ({len(weights)}) must match 'values' ({len(values)}) length "
+                f"for <{self._element_tag}> '{self._statement.name}'"
+            )
+        return weights
 
     def _convert_to_type(self, data_type: str, value):
         """

--- a/tests_ce/integration_tests/test_weighted_values/test_weighted_values.py
+++ b/tests_ce/integration_tests/test_weighted_values/test_weighted_values.py
@@ -1,0 +1,77 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+"""Inline weighted value pick: 'weights' as the companion of 'values'.
+
+Surface: engine (datamimic_ce). Proves a <key values weights> picks from the values
+with the given relative weights, is seed-reproducible, and fails loudly on a
+length mismatch or weights-without-values.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+_TEST_DIR = Path(__file__).resolve().parent
+
+
+def _run(filename: str, gen: str = "people") -> list[str]:
+    engine = DataMimicTest(test_dir=_TEST_DIR, filename=filename, capture_test_result=True)
+    engine.test_with_timer()
+    return [r["grade"] for r in engine.capture_result()[gen]]
+
+
+def test_weighted_distribution_and_seed_reproducible():
+    grades = _run("weighted_values.xml")
+    assert set(grades) <= {"A", "B", "C"}
+    dist = Counter(grades)
+    total = len(grades)
+    # weights 0.1/0.3/0.6 (relative) -> proportions within tolerance
+    assert abs(dist["A"] / total - 0.1) < 0.05
+    assert abs(dist["B"] / total - 0.3) < 0.05
+    assert abs(dist["C"] / total - 0.6) < 0.05
+    # same seed -> identical sequence
+    assert _run("weighted_values.xml") == grades
+
+
+def test_weights_compose_with_null_quota():
+    # nullQuota is an outer gate (~25% None); the rest is the weighted pick.
+    grades = _run("weighted_null_quota.xml")
+    total = len(grades)
+    nulls = grades.count(None)
+    assert abs(nulls / total - 0.25) < 0.05
+    non_null = [g for g in grades if g is not None]
+    assert set(non_null) == {"A", "B", "C"}
+    n = len(non_null)
+    # within the non-null rows the 0.1/0.3/0.6 split still holds
+    dist = Counter(non_null)
+    assert abs(dist["A"] / n - 0.1) < 0.05
+    assert abs(dist["C"] / n - 0.6) < 0.05
+    assert _run("weighted_null_quota.xml") == grades  # seed-reproducible
+
+
+def test_none_can_be_a_weighted_value():
+    grades = _run("weighted_none_value.xml")
+    total = len(grades)
+    assert set(grades) == {"A", "B", None}
+    # None is just the third choice with weight 0.2
+    assert abs(grades.count(None) / total - 0.2) < 0.05
+    assert abs(grades.count("A") / total - 0.5) < 0.05
+
+
+def test_length_mismatch_raises():
+    with pytest.raises(Exception, match="weights|values"):
+        _run("weighted_values_mismatch.xml", gen="x")
+
+
+def test_weights_without_values_raises():
+    with pytest.raises(Exception, match="weights|values"):
+        _run("weights_without_values.xml", gen="x")

--- a/tests_ce/integration_tests/test_weighted_values/weighted_none_value.xml
+++ b/tests_ce/integration_tests/test_weighted_values/weighted_none_value.xml
@@ -1,0 +1,6 @@
+<setup rngSeed="7">
+    <!-- None as a weighted value: it is just one of the choices (weight 0.2). -->
+    <generate name="people" count="1000" target="">
+        <key name="grade" values="'A','B',None" weights="0.5, 0.3, 0.2"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_weighted_values/weighted_null_quota.xml
+++ b/tests_ce/integration_tests/test_weighted_values/weighted_null_quota.xml
@@ -1,0 +1,6 @@
+<setup rngSeed="7">
+    <!-- weights + nullQuota compose: ~25% null (outer gate), the rest a weighted pick. -->
+    <generate name="people" count="1000" target="">
+        <key name="grade" values="'A','B','C'" weights="0.1, 0.3, 0.6" nullQuota="0.25"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_weighted_values/weighted_values.xml
+++ b/tests_ce/integration_tests/test_weighted_values/weighted_values.xml
@@ -1,0 +1,7 @@
+<setup rngSeed="13">
+    <!-- inline weighted value pick: 'weights' is the companion of 'values'.
+         Weights are relative (need not sum to 1). Seed-bound via ctx.rng. -->
+    <generate name="people" count="600" target="">
+        <key name="grade" values="'A','B','C'" weights="0.1, 0.3, 0.6"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_weighted_values/weighted_values_mismatch.xml
+++ b/tests_ce/integration_tests/test_weighted_values/weighted_values_mismatch.xml
@@ -1,0 +1,6 @@
+<setup rngSeed="13">
+    <!-- 3 values but 2 weights -> must fail loudly. -->
+    <generate name="x" count="1" target="">
+        <key name="grade" values="'A','B','C'" weights="0.1, 0.3"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_weighted_values/weights_without_values.xml
+++ b/tests_ce/integration_tests/test_weighted_values/weights_without_values.xml
@@ -1,0 +1,6 @@
+<setup rngSeed="13">
+    <!-- 'weights' without 'values' is meaningless -> must fail. -->
+    <generate name="x" count="1" target="">
+        <key name="grade" weights="0.1, 0.3"/>
+    </generate>
+</setup>


### PR DESCRIPTION
…ues'

Benerator's WeightedNumbers / inline weighted values had no CE equivalent — you had to create a .wgt.csv file even for a handful of weighted values. Add a 'weights' attribute as the companion of 'values':

  <key name="grade" values="'A','B','C'" weights="0.1, 0.3, 0.6"/>

Weights are relative (need not sum to 1). Minimal + SPOT: reuses the existing VALUES_MODE path and ctx.rng (already seed-bound, so the pick replays under <setup rngSeed>); weighted selection via stdlib rng.choices — same call as WeightedDataSource. Supported on <key>, <variable> and <element> (they share KeyVariableTask); the .wgt.csv file form still covers large/external sets.

Validation (one shared ModelUtil.check_weights_require_values): 'weights' requires 'values'; a length mismatch raises at construction.

TDD: DSL tests prove the weighted distribution (seed-deterministic, within tolerance), seed reproducibility, length-mismatch and weights-without-values errors.