### PR TITLE
fix(dsl): reject unique with non-random distribution; tidy brittle st…

### DIFF
--- a/datamimic_ce/data_sources/data_source_registry.py
+++ b/datamimic_ce/data_sources/data_source_registry.py
@@ -9,6 +9,7 @@ import itertools
 from collections.abc import Iterable, Iterator
 from pathlib import Path
 from random import Random
+from typing import Any
 
 import xmltodict
 from sqlalchemy.exc import OperationalError, ProgrammingError
@@ -287,7 +288,9 @@ class DataSourceRegistry:
         return DataSourceRegistry.get_shuffled_data_with_cyclic(data, pagination, cyclic, seed)
 
     @staticmethod
-    def get_unique_data(data: Iterable, pagination: DataSourcePagination | None, seed: int, label: str) -> list:
+    def get_unique_data(
+        data: Iterable[Any], pagination: DataSourcePagination | None, seed: int, label: str
+    ) -> list[Any]:
         """Select distinct rows without replacement: dedupe + shuffle, then return the page
         window. Sibling of get_cumulated_data; the unique counterpart of the random/cumulated
         selection. All pages/workers share ``seed`` -> one global deduped order -> each takes a

--- a/datamimic_ce/model/model_util.py
+++ b/datamimic_ce/model/model_util.py
@@ -13,6 +13,7 @@ from datamimic_ce.constants.attribute_constants import (
     ATTR_CYCLIC,
     ATTR_DATASET,
     ATTR_DEFAULT_VALUE,
+    ATTR_DISTRIBUTION,
     ATTR_ENTITY,
     ATTR_GENERATOR,
     ATTR_IN_DATE_FORMAT,
@@ -33,6 +34,7 @@ from datamimic_ce.constants.attribute_constants import (
     ATTR_WEIGHTS,
 )
 from datamimic_ce.constants.data_type_constants import DATA_TYPE_STRING
+from datamimic_ce.enums.distribution_enums import SourceDistribution
 from datamimic_ce.utils.string_util import StringUtil
 
 # Parse XML bool attributes exactly like the pydantic bool fields do, so a "before"
@@ -86,9 +88,10 @@ class ModelUtil:
 
     @staticmethod
     def check_unique_constraints(values: dict) -> dict:
-        """'unique' draws distinct values without replacement from a finite pool — an
-        inline 'values' set or a 'source'. It is incompatible with 'weights' (no weighted
-        sampling without replacement) and with 'cyclic' (no-repeat vs repeat)."""
+        """'unique' draws distinct values without replacement from a finite pool — an inline
+        'values' set or a 'source'. It implies distinct random order, so it only combines with
+        distribution='random' (the default) and is incompatible with 'weights' (no weighted
+        sampling without replacement), 'cyclic' and ordered/cumulated (no-repeat vs repeat/bell)."""
         if not _attr_true(values.get(ATTR_UNIQUE)):
             return values
         if ATTR_VALUES not in values and ATTR_SOURCE not in values:
@@ -97,6 +100,12 @@ class ModelUtil:
             raise ValueError(f"'{ATTR_UNIQUE}' cannot be combined with '{ATTR_WEIGHTS}'")
         if _attr_true(values.get(ATTR_CYCLIC)):
             raise ValueError(f"'{ATTR_UNIQUE}' cannot be combined with '{ATTR_CYCLIC}' (no-repeat vs repeat)")
+        distribution = SourceDistribution.coerce(values.get(ATTR_DISTRIBUTION))
+        if distribution is not SourceDistribution.RANDOM:
+            raise ValueError(
+                f"'{ATTR_UNIQUE}' only combines with distribution='{SourceDistribution.RANDOM.value}' "
+                f"(it implies distinct random order), not '{distribution.value}'"
+            )
         return values
 
     @staticmethod

--- a/datamimic_ce/tasks/key_variable_task.py
+++ b/datamimic_ce/tasks/key_variable_task.py
@@ -6,10 +6,11 @@
 
 import ast
 from abc import abstractmethod
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from datetime import datetime, timedelta
 from decimal import Decimal
 from random import Random
+from typing import Any
 
 import numpy
 
@@ -60,7 +61,7 @@ class KeyVariableTask:
 
         self._mode: str | None = None
         # Lazily-built distinct-value iterator for unique="true" (sampling without replacement).
-        self._unique_iter = None
+        self._unique_iter: Iterator[Any] | None = None
 
         self._simple_type_set = {
             DATA_TYPE_STRING,
@@ -288,7 +289,7 @@ class KeyVariableTask:
 
         return value
 
-    def _next_unique_value(self, ctx):
+    def _next_unique_value(self, ctx: Context) -> Any:
         """Emit a distinct value per call (sampling 'values' without replacement,
         seeded via ctx.rng). Shared with <variable source unique> via unique_value_iter."""
         if self._unique_iter is None:

--- a/tests_ce/integration_tests/test_unique_source/test_unique_source.py
+++ b/tests_ce/integration_tests/test_unique_source/test_unique_source.py
@@ -57,6 +57,13 @@ def test_empty_source_raises_not_silent_zero():
         _run("unique_source_empty.xml", gen="x")
 
 
+@pytest.mark.parametrize("dist", ["ordered", "cumulated"])
+def test_unique_only_combines_with_random_distribution(dist):
+    # unique implies distinct random order -> ordered/cumulated are rejected (not silently overridden).
+    with pytest.raises(Exception, match="unique|distribution"):
+        _run(f"unique_dist_{dist}.xml", gen="x")
+
+
 # --- <generate source unique="true"> : distinct entities straight from the source ---
 
 

--- a/tests_ce/integration_tests/test_unique_source/unique_dist_cumulated.xml
+++ b/tests_ce/integration_tests/test_unique_source/unique_dist_cumulated.xml
@@ -1,0 +1,7 @@
+<setup rngSeed="9">
+    <!-- unique implies random order -> distribution="cumulated" must be rejected. -->
+    <generate name="x" count="3" target="">
+        <variable name="row" source="codes.csv" unique="true" distribution="cumulated"/>
+        <key name="code" script="row.code"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_unique_source/unique_dist_ordered.xml
+++ b/tests_ce/integration_tests/test_unique_source/unique_dist_ordered.xml
@@ -1,0 +1,7 @@
+<setup rngSeed="9">
+    <!-- unique implies random order -> distribution="ordered" must be rejected. -->
+    <generate name="x" count="3" target="">
+        <variable name="row" source="codes.csv" unique="true" distribution="ordered"/>
+        <key name="code" script="row.code"/>
+    </generate>
+</setup>


### PR DESCRIPTION
…rings + typing

- unique implies distinct random order, so combining it with distribution=ordered or cumulated (no-repeat vs sequential/bell-with-replacement) is now a clear validation error instead of silently overriding the distribution.
- use SourceDistribution.coerce for an enum comparison instead of a str(...).strip().lower() != "random" brittle-string/str-cast check.
- tighten typing: get_unique_data -> Iterable[Any]/list[Any]; KeyVariableTask _unique_iter: Iterator[Any] | None; _next_unique_value(ctx: Context) -> Any.

DSL tests: distribution=ordered and =cumulated with unique are both rejected.