### PR TITLE
Composite `<reference>` (multi-field FK) · unified cross-page distribution correctness · CE single-process policy

### DIFF
--- a/datamimic_ce/clients/rdbms_client.py
+++ b/datamimic_ce/clients/rdbms_client.py
@@ -353,22 +353,22 @@ class RdbmsClient(DatabaseClient):
         return [dict(row._mapping) if hasattr(row, "_mapping") else dict(row) for row in result]
 
     def get_random_rows_by_columns(self, table_name: str, column_names: list[str]) -> list[tuple]:
-        """Fetch the given columns for a <reference>, preserving row-tuple integrity. The
-        reference task does the distinct/with-replacement sampling deterministically via
-        ctx.rng (so the full column set is returned, not a pre-limited slice)."""
+        """Fetch the given columns for a <reference> in a stable order, preserving row-tuple
+        integrity. The reference task does the distinct/with-replacement sampling deterministically
+        via DataSourceRegistry.get_unique_data / ctx.rng (so the full column set is returned, not a
+        pre-limited slice)."""
         engine = self._create_engine()
 
         with engine.connect() as conn:
             actual_table_name = self._get_actual_table_name(table_name)
             table = self._get_metadata(engine).tables[actual_table_name]
             columns = [table.c[name] for name in column_names]
-            # Fetch the full column set; the reference task does the distinct/with-replacement
-            # sampling deterministically via ctx.rng. (Limiting before dedupe would under-count
-            # the distinct pool — the cause of spurious 'insufficient unique values' errors;
-            # DB-side ORDER BY random() would break ctx.rng reproducibility.)
-            # ponytail: fetch-all suits reference/lookup tables; a huge source wants SELECT DISTINCT
-            # or DB-side sampling — an EE-scale concern, not CE's determinism-first reference path.
-            return [tuple(row) for row in conn.execute(select(*columns)).fetchall()]
+            # ORDER BY the selected columns (NOT random): a stable input order so the seeded
+            # shuffle in get_unique_data is reproducible run-to-run. ORDER BY random() would
+            # destroy that reproducibility.
+            # ponytail: fetch-all + sort suits reference/lookup tables; a huge source wants
+            # SELECT DISTINCT or DB-side sampling — an EE-scale concern, not CE's reference path.
+            return [tuple(row) for row in conn.execute(select(*columns).order_by(*columns)).fetchall()]
 
     def insert(self, table_name: str, data_list: list):
         """

--- a/datamimic_ce/clients/rdbms_client.py
+++ b/datamimic_ce/clients/rdbms_client.py
@@ -352,46 +352,20 @@ class RdbmsClient(DatabaseClient):
         # Handle both SQLAlchemy 1.x and 2.x Row objects
         return [dict(row._mapping) if hasattr(row, "_mapping") else dict(row) for row in result]
 
-    def get_random_rows_by_column(
-        self,
-        table_name: str,
-        column_name: str,
-        pagination: DataSourcePagination | None,
-        unique: bool,
-    ) -> list:
-        """
-        Get column data for reference
-        :param count:
-        :param table_name:
-        :param column_name:
-        :return:
-        """
+    def get_random_rows_by_columns(self, table_name: str, column_names: list[str]) -> list[tuple]:
+        """Fetch the given columns for a <reference>, preserving row-tuple integrity. The
+        reference task does the distinct/with-replacement sampling deterministically via
+        ctx.rng (so the full column set is returned, not a pre-limited slice)."""
         engine = self._create_engine()
 
         with engine.connect() as conn:
             actual_table_name = self._get_actual_table_name(table_name)
             table = self._get_metadata(engine).tables[actual_table_name]
-
-            # Get number of random rows from table
-            if self._credential.dbms == "mssql":
-                order_func = func.newid()
-            elif self._credential.dbms == "oracle":
-                order_func = func.dbms_random.value()
-            else:
-                order_func = func.random()
-
-            if pagination and hasattr(pagination, "skip") and hasattr(pagination, "limit"):
-                query = (
-                    select(table.c[column_name]).offset(pagination.skip).limit(pagination.limit)
-                    if unique
-                    else select(table.c[column_name]).order_by(order_func)
-                )
-            else:
-                query = select(table.c[column_name])
-
-            random_rows = conn.execute(query).fetchall()
-
-            return [row[0] for row in random_rows]
+            columns = [table.c[name] for name in column_names]
+            # Fetch the full column set; the reference task does the distinct/with-replacement
+            # sampling deterministically via ctx.rng. (Limiting before dedupe would under-count
+            # the distinct pool — the cause of spurious 'insufficient unique values' errors.)
+            return [tuple(row) for row in conn.execute(select(*columns)).fetchall()]
 
     def insert(self, table_name: str, data_list: list):
         """

--- a/datamimic_ce/clients/rdbms_client.py
+++ b/datamimic_ce/clients/rdbms_client.py
@@ -364,7 +364,10 @@ class RdbmsClient(DatabaseClient):
             columns = [table.c[name] for name in column_names]
             # Fetch the full column set; the reference task does the distinct/with-replacement
             # sampling deterministically via ctx.rng. (Limiting before dedupe would under-count
-            # the distinct pool — the cause of spurious 'insufficient unique values' errors.)
+            # the distinct pool — the cause of spurious 'insufficient unique values' errors;
+            # DB-side ORDER BY random() would break ctx.rng reproducibility.)
+            # ponytail: fetch-all suits reference/lookup tables; a huge source wants SELECT DISTINCT
+            # or DB-side sampling — an EE-scale concern, not CE's determinism-first reference path.
             return [tuple(row) for row in conn.execute(select(*columns)).fetchall()]
 
     def insert(self, table_name: str, data_list: list):

--- a/datamimic_ce/clients/rdbms_client.py
+++ b/datamimic_ce/clients/rdbms_client.py
@@ -366,7 +366,7 @@ class RdbmsClient(DatabaseClient):
             # ORDER BY the selected columns (NOT random): a stable input order so the seeded
             # shuffle in get_unique_data is reproducible run-to-run. ORDER BY random() would
             # destroy that reproducibility.
-            # ponytail: fetch-all + sort suits reference/lookup tables; a huge source wants
+            # fetch-all + sort suits reference/lookup tables; a huge source would want
             # SELECT DISTINCT or DB-side sampling — an EE-scale concern, not CE's reference path.
             return [tuple(row) for row in conn.execute(select(*columns).order_by(*columns)).fetchall()]
 

--- a/datamimic_ce/constants/element_constants.py
+++ b/datamimic_ce/constants/element_constants.py
@@ -31,3 +31,4 @@ EL_DEMOGRAPHICS = "demographics"
 EL_COMMENT = "comment"  # Benerator documentation element, ignored (no-op) wherever it appears
 EL_STATE_MACHINE = "state-machine"  # named, reusable weighted state machine (builds StateTransitionGenerator)
 EL_TRANSITION = "transition"  # one weighted edge of a <state-machine>
+EL_FIELD = "field"  # one source-column -> target-field mapping of a composite <reference>

--- a/datamimic_ce/contexts/setup_context.py
+++ b/datamimic_ce/contexts/setup_context.py
@@ -61,6 +61,9 @@ class SetupContext(Context):
         self._descriptor_dir = descriptor_dir
         self._clients = {} if clients is None else clients
         self._data_source_len = {} if data_source_len is None else data_source_len
+        # Per-statement full unique sequence (dedupe+shuffle), built once and reused across pages
+        # so unique="true" holds across pages, not just within one. Held in memory for the run.
+        self._unique_pool_cache: dict[str, list] = {}
         self._properties = {} if properties is None else properties
         self._memstore_manager = memstore_manager
         self._namespace = {} if namespace is None else namespace
@@ -279,6 +282,10 @@ class SetupContext(Context):
     @property
     def data_source_len(self):
         return self._data_source_len
+
+    @property
+    def unique_pool_cache(self) -> dict[str, list]:
+        return self._unique_pool_cache
 
     @property
     def properties(self):

--- a/datamimic_ce/contexts/setup_context.py
+++ b/datamimic_ce/contexts/setup_context.py
@@ -61,9 +61,9 @@ class SetupContext(Context):
         self._descriptor_dir = descriptor_dir
         self._clients = {} if clients is None else clients
         self._data_source_len = {} if data_source_len is None else data_source_len
-        # Per-statement full unique sequence (dedupe+shuffle), built once and reused across pages
-        # so unique="true" holds across pages, not just within one. Held in memory for the run.
-        self._unique_pool_cache: dict[str, list] = {}
+        # Per-statement distribution seed, computed once and reused across a statement's pages so
+        # paginated sub-task selection (random / cumulated / unique) stays globally consistent.
+        self._distribution_seed_cache: dict[str | None, int] = {}
         self._properties = {} if properties is None else properties
         self._memstore_manager = memstore_manager
         self._namespace = {} if namespace is None else namespace
@@ -283,9 +283,6 @@ class SetupContext(Context):
     def data_source_len(self):
         return self._data_source_len
 
-    @property
-    def unique_pool_cache(self) -> dict[str, list]:
-        return self._unique_pool_cache
 
     @property
     def properties(self):
@@ -452,6 +449,16 @@ class SetupContext(Context):
         :return:
         """
         return self._clients.get(client_id)
+
+    def stable_distribution_seed(self, key: str | None) -> int:
+        """A distribution seed that stays constant across a statement's pages (cached by ``key``,
+        the statement full_name — a unique path per statement, so distinct statements never collide).
+        A sub-task is rebuilt per page, so calling get_distribution_seed() directly would draw a
+        different seed each page and break paginated random / cumulated / unique selection.
+        Computed once via get_distribution_seed()."""
+        if key not in self._distribution_seed_cache:
+            self._distribution_seed_cache[key] = self.get_distribution_seed()
+        return self._distribution_seed_cache[key]
 
     def get_distribution_seed(self) -> int:
         """Seed for source shuffling (``distribution="random"``).

--- a/datamimic_ce/data_sources/data_source_registry.py
+++ b/datamimic_ce/data_sources/data_source_registry.py
@@ -325,7 +325,7 @@ class DataSourceRegistry:
         span = end_idx - start_idx
 
         # One seeded RNG drives a single continuous draw sequence, so paginated batches
-        # stay consistent (page 2 continues page 1). ponytail: O(start_idx + span) draws;
+        # stay consistent (page 2 continues page 1). O(start_idx + span) draws;
         # fine for typical skips, revisit only if huge offsets show up.
         rng = Random(seed)
         picks = [rows[cumulated_index(rng, source_len - 1)] for _ in range(start_idx + span)]

--- a/datamimic_ce/data_sources/data_source_registry.py
+++ b/datamimic_ce/data_sources/data_source_registry.py
@@ -287,13 +287,29 @@ class DataSourceRegistry:
         return DataSourceRegistry.get_shuffled_data_with_cyclic(data, pagination, cyclic, seed)
 
     @staticmethod
-    def get_unique_data(data: Iterable, pagination: DataSourcePagination | None, seed: int, label: str) -> list:
+    def get_unique_data(
+        data: Iterable,
+        pagination: DataSourcePagination | None,
+        seed: int,
+        label: str,
+        cache: dict[str, list] | None = None,
+        cache_key: str | None = None,
+    ) -> list:
         """Select distinct rows without replacement: dedupe + shuffle, then return the page
         window. Sibling of get_cumulated_data; the unique counterpart of the random/cumulated
-        selection. All pages/workers share ``seed`` -> one global deduped order -> each takes a
-        disjoint window -> unique holds across pages AND ray workers. Strict: raises rather than
-        silently under-generate when the window exceeds the distinct pool."""
-        distinct = unique_values(data, Random(seed))
+        selection. Strict: raises rather than silently under-generate when the window exceeds
+        the distinct pool.
+
+        When ``cache``/``cache_key`` are given, the full deduped+shuffled sequence is built once
+        and reused across pages — so a sub-task whose per-page seed/data are not stable (e.g.
+        <variable>/<reference> source unique) still takes disjoint windows and stays unique
+        across pages. Without a cache, all pages must share ``seed`` (the worker-level path)."""
+        if cache is not None and cache_key in cache:
+            distinct = cache[cache_key]
+        else:
+            distinct = unique_values(data, Random(seed))
+            if cache is not None and cache_key is not None:
+                cache[cache_key] = distinct
         if pagination is None:
             return distinct
         end = pagination.skip + pagination.limit

--- a/datamimic_ce/data_sources/data_source_registry.py
+++ b/datamimic_ce/data_sources/data_source_registry.py
@@ -287,29 +287,13 @@ class DataSourceRegistry:
         return DataSourceRegistry.get_shuffled_data_with_cyclic(data, pagination, cyclic, seed)
 
     @staticmethod
-    def get_unique_data(
-        data: Iterable,
-        pagination: DataSourcePagination | None,
-        seed: int,
-        label: str,
-        cache: dict[str, list] | None = None,
-        cache_key: str | None = None,
-    ) -> list:
+    def get_unique_data(data: Iterable, pagination: DataSourcePagination | None, seed: int, label: str) -> list:
         """Select distinct rows without replacement: dedupe + shuffle, then return the page
         window. Sibling of get_cumulated_data; the unique counterpart of the random/cumulated
-        selection. Strict: raises rather than silently under-generate when the window exceeds
-        the distinct pool.
-
-        When ``cache``/``cache_key`` are given, the full deduped+shuffled sequence is built once
-        and reused across pages — so a sub-task whose per-page seed/data are not stable (e.g.
-        <variable>/<reference> source unique) still takes disjoint windows and stays unique
-        across pages. Without a cache, all pages must share ``seed`` (the worker-level path)."""
-        if cache is not None and cache_key in cache:
-            distinct = cache[cache_key]
-        else:
-            distinct = unique_values(data, Random(seed))
-            if cache is not None and cache_key is not None:
-                cache[cache_key] = distinct
+        selection. All pages share ``seed`` (stable per statement) -> one global deduped order ->
+        each takes a disjoint window -> unique holds across pages. Strict: raises rather than
+        silently under-generate when the window exceeds the distinct pool."""
+        distinct = unique_values(data, Random(seed))
         if pagination is None:
             return distinct
         end = pagination.skip + pagination.limit

--- a/datamimic_ce/model/reference_field_model.py
+++ b/datamimic_ce/model/reference_field_model.py
@@ -1,0 +1,28 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from datamimic_ce.constants.attribute_constants import ATTR_SOURCE_KEY, ATTR_TARGET
+from datamimic_ce.model.model_util import ModelUtil
+
+
+class ReferenceFieldModel(BaseModel):
+    """A <field> child of a composite <reference>: maps a source column to a target field."""
+
+    target: str = Field(alias=ATTR_TARGET)
+    source_key: str = Field(alias=ATTR_SOURCE_KEY)
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_valid_attributes(cls, values: dict):
+        return ModelUtil.check_valid_attributes(values=values, valid_attributes={ATTR_TARGET, ATTR_SOURCE_KEY})
+
+    @field_validator("target", "source_key")
+    @classmethod
+    def validate_not_empty(cls, value):
+        return ModelUtil.check_not_empty(value=value)

--- a/datamimic_ce/model/reference_model.py
+++ b/datamimic_ce/model/reference_model.py
@@ -20,7 +20,8 @@ from datamimic_ce.model.model_util import ModelUtil
 class ReferenceModel(BaseModel):
     name: str
     source: str
-    source_key: str = Field(alias=ATTR_SOURCE_KEY)
+    # Optional legacy single-field shortcut; composite references use <field> children instead.
+    source_key: str | None = Field(default=None, alias=ATTR_SOURCE_KEY)
     source_type: str = Field(alias=ATTR_SOURCE_TYPE)
     unique: bool | None = None
 
@@ -38,7 +39,7 @@ class ReferenceModel(BaseModel):
             },
         )
 
-    @field_validator("name", "source", "source_type", "source_key")
+    @field_validator("name", "source", "source_type")
     @classmethod
     def validate_not_none(cls, value):
         return ModelUtil.check_not_empty(value=value)

--- a/datamimic_ce/parsers/parser_util.py
+++ b/datamimic_ce/parsers/parser_util.py
@@ -254,13 +254,16 @@ class ParserUtil:
                     MemstoreParser
                     | ExecuteParser
                     | IncludeParser
-                    | ReferenceParser
                     | ArrayParser
                     | EchoParser
                     | GeneratorParser
                     | StateMachineParser,
                 ):
                     stmt = parser.parse()
+                elif isinstance(parser, ReferenceParser):
+                    # Pass the parent so the reference's full_name is a unique path (e.g.
+                    # "orders|slot"), not a bare name that collides across <generate>s.
+                    stmt = parser.parse(parent_stmt=parent_stmt)
                 elif isinstance(parser, KeyParser):
                     stmt = parser.parse(descriptor_dir=descriptor_dir, parent_stmt=parent_stmt)
                 elif isinstance(parser, ConditionParser):

--- a/datamimic_ce/parsers/parser_util.py
+++ b/datamimic_ce/parsers/parser_util.py
@@ -23,6 +23,7 @@ from datamimic_ce.constants.element_constants import (
     EL_ELSE,
     EL_ELSE_IF,
     EL_EXECUTE,
+    EL_FIELD,
     EL_GENERATE,
     EL_GENERATOR,
     EL_ID,
@@ -109,6 +110,7 @@ class ParserUtil:
                 EL_STATE_MACHINE,
             },
             EL_STATE_MACHINE: {EL_TRANSITION},
+            EL_REFERENCE: {EL_FIELD},
             EL_NESTED_KEY: {
                 EL_KEY,
                 EL_ID,

--- a/datamimic_ce/parsers/reference_parser.py
+++ b/datamimic_ce/parsers/reference_parser.py
@@ -11,6 +11,7 @@ from datamimic_ce.model.reference_field_model import ReferenceFieldModel
 from datamimic_ce.model.reference_model import ReferenceModel
 from datamimic_ce.parsers.statement_parser import StatementParser
 from datamimic_ce.statements.reference_statement import ReferenceField, ReferenceStatement
+from datamimic_ce.statements.statement import Statement
 
 
 class ReferenceParser(StatementParser):
@@ -19,7 +20,7 @@ class ReferenceParser(StatementParser):
     def __init__(self, element: Element, properties: dict):
         super().__init__(element, properties, valid_element_tag=EL_REFERENCE)
 
-    def parse(self) -> ReferenceStatement:
+    def parse(self, parent_stmt: Statement) -> ReferenceStatement:
         model = self.validate_attributes(ReferenceModel)
         fields = self._parse_fields()
         name = model.name
@@ -32,7 +33,7 @@ class ReferenceParser(StatementParser):
         # Normalise the legacy single-field form to one ReferenceField.
         if not fields:
             fields = [ReferenceField(target=name, source_key=str(model.source_key))]
-        return ReferenceStatement(model, fields)
+        return ReferenceStatement(model, fields, parent_stmt)
 
     def _parse_fields(self) -> list[ReferenceField]:
         fields: list[ReferenceField] = []

--- a/datamimic_ce/parsers/reference_parser.py
+++ b/datamimic_ce/parsers/reference_parser.py
@@ -5,31 +5,46 @@
 # For questions and support, contact: info@rapiddweller.com
 from xml.etree.ElementTree import Element
 
-from datamimic_ce.constants.element_constants import EL_REFERENCE
+from datamimic_ce.constants.attribute_constants import ATTR_SOURCE_KEY
+from datamimic_ce.constants.element_constants import EL_COMMENT, EL_FIELD, EL_REFERENCE
+from datamimic_ce.model.reference_field_model import ReferenceFieldModel
 from datamimic_ce.model.reference_model import ReferenceModel
 from datamimic_ce.parsers.statement_parser import StatementParser
-from datamimic_ce.statements.reference_statement import ReferenceStatement
+from datamimic_ce.statements.reference_statement import ReferenceField, ReferenceStatement
 
 
 class ReferenceParser(StatementParser):
-    """
-    Parse element "reference" into ReferenceStatement
-    """
+    """Parse element "reference" (single-field legacy, or composite with <field> children)."""
 
-    def __init__(
-        self,
-        element: Element,
-        properties: dict,
-    ):
-        super().__init__(
-            element,
-            properties,
-            valid_element_tag=EL_REFERENCE,
-        )
+    def __init__(self, element: Element, properties: dict):
+        super().__init__(element, properties, valid_element_tag=EL_REFERENCE)
 
     def parse(self) -> ReferenceStatement:
-        """
-        Parse element "reference" into ReferenceStatement
-        :return:
-        """
-        return ReferenceStatement(self.validate_attributes(ReferenceModel))
+        model = self.validate_attributes(ReferenceModel)
+        fields = self._parse_fields()
+        name = model.name
+        if fields and model.source_key is not None:
+            raise ValueError(
+                f"<reference> '{name}': '{ATTR_SOURCE_KEY}' is not allowed when <{EL_FIELD}> children exist"
+            )
+        if not fields and model.source_key is None:
+            raise ValueError(f"<reference> '{name}': define '{ATTR_SOURCE_KEY}' or at least one <{EL_FIELD}> child")
+        # Normalise the legacy single-field form to one ReferenceField.
+        if not fields:
+            fields = [ReferenceField(target=name, source_key=str(model.source_key))]
+        return ReferenceStatement(model, fields)
+
+    def _parse_fields(self) -> list[ReferenceField]:
+        fields: list[ReferenceField] = []
+        seen: set[str] = set()
+        for child in self._element:
+            if child.tag == EL_COMMENT:
+                continue
+            if child.tag != EL_FIELD:
+                raise ValueError(f"<{EL_REFERENCE}> only accepts <{EL_FIELD}> children, got <{child.tag}>")
+            field_model = ReferenceFieldModel(**child.attrib)
+            if field_model.source_key in seen:
+                raise ValueError(f"<{EL_FIELD}> has duplicate sourceKey '{field_model.source_key}'")
+            seen.add(field_model.source_key)
+            fields.append(ReferenceField(target=field_model.target, source_key=field_model.source_key))
+        return fields

--- a/datamimic_ce/statements/reference_statement.py
+++ b/datamimic_ce/statements/reference_statement.py
@@ -19,8 +19,10 @@ class ReferenceField:
 
 
 class ReferenceStatement(Statement):
-    def __init__(self, model: ReferenceModel, fields: list[ReferenceField]):
-        super().__init__(model.name, None)
+    def __init__(self, model: ReferenceModel, fields: list[ReferenceField], parent_stmt: Statement | None = None):
+        # Pass the parent so full_name is a path (e.g. "orders|slot"), unique per statement —
+        # two same-named references in different <generate>s must not share a cache key.
+        super().__init__(model.name, parent_stmt)
         self._source = model.source
         self._source_type = model.source_type
         self._unique = model.unique

--- a/datamimic_ce/statements/reference_statement.py
+++ b/datamimic_ce/statements/reference_statement.py
@@ -4,17 +4,28 @@
 # See LICENSE file for the full text of the license.
 # For questions and support, contact: info@rapiddweller.com
 
+from dataclasses import dataclass
+
 from datamimic_ce.model.reference_model import ReferenceModel
 from datamimic_ce.statements.statement import Statement
 
 
+@dataclass(frozen=True)
+class ReferenceField:
+    """One source-column -> target-field mapping in a (composite) reference."""
+
+    target: str
+    source_key: str
+
+
 class ReferenceStatement(Statement):
-    def __init__(self, model: ReferenceModel):
+    def __init__(self, model: ReferenceModel, fields: list[ReferenceField]):
         super().__init__(model.name, None)
         self._source = model.source
         self._source_type = model.source_type
-        self._source_key = model.source_key
         self._unique = model.unique
+        # Always >= 1: a legacy 'sourceKey' is normalised to a single field by the parser.
+        self._fields = fields
 
     @property
     def source(self):
@@ -26,8 +37,25 @@ class ReferenceStatement(Statement):
 
     @property
     def source_key(self):
-        return self._source_key
+        # Legacy single-field accessor (first field's source column).
+        return self._fields[0].source_key
 
     @property
     def unique(self):
         return self._unique
+
+    @property
+    def fields(self) -> list[ReferenceField]:
+        return self._fields
+
+    @property
+    def source_keys(self) -> list[str]:
+        return [field.source_key for field in self._fields]
+
+    @property
+    def targets(self) -> list[str]:
+        return [field.target for field in self._fields]
+
+    @property
+    def is_composite(self) -> bool:
+        return len(self._fields) > 1

--- a/datamimic_ce/tasks/generate_task.py
+++ b/datamimic_ce/tasks/generate_task.py
@@ -22,10 +22,9 @@ from datamimic_ce.logger import logger
 from datamimic_ce.statements.composite_statement import CompositeStatement
 from datamimic_ce.statements.generate_statement import GenerateStatement
 from datamimic_ce.statements.key_statement import KeyStatement
-from datamimic_ce.statements.reference_statement import ReferenceStatement
 from datamimic_ce.statements.statement import Statement
 from datamimic_ce.statements.statement_util import StatementUtil
-from datamimic_ce.statements.variable_statement import VariableStatement
+from datamimic_ce.tasks.single_process_policy import resolve_single_process
 from datamimic_ce.tasks.task import CommonSubTask
 from datamimic_ce.tasks.task_util import TaskUtil
 from datamimic_ce.utils.logging_util import gen_timer
@@ -149,33 +148,12 @@ class GenerateTask(CommonSubTask):
                 GenerateTask._scan_data_source(ctx, child_stmt)
 
     @staticmethod
-    def _is_global_constraint(stmt: Statement) -> bool:
-        """A cross-row constraint CE serialises (single-process): a unique <generate>/<key>/
-        <variable>, or a unique or composite <reference>. Multiprocess scaling is an EE feature."""
-        if isinstance(stmt, GenerateStatement):
-            return bool(stmt.unique)
-        if isinstance(stmt, KeyStatement | VariableStatement):
-            return bool(stmt.unique)
-        if isinstance(stmt, ReferenceStatement):
-            return bool(stmt.unique) or stmt.is_composite
-        return False
-
-    @staticmethod
     def _determine_num_workers(context: GenIterContext | SetupContext, stmt: GenerateStatement) -> int:
-        """
-        Determine number of Ray workers for multiprocessing. Default to 1 if not specified.
-        Do not apply multiprocessing (return 1) if:
-        - There is a delete operation.
-        - Statement is inner gen_stmt.
-        """
+        """Number of Ray workers. 1 for inner gen_stmt; otherwise the requested count unless a
+        single-process policy (unique/composite/delete — see single_process_policy) overrides it."""
         # Do not apply multiprocessing for inner gen_stmt
         if isinstance(context, GenIterContext):
             return 1
-
-        # If there is a delete operation, do not apply multiprocessing
-        for exporter_str in stmt.targets:
-            if ".delete" in exporter_str:
-                return 1
 
         # Get number of workers from statement, setup context, or default to 1
         current_setup_context = context
@@ -189,32 +167,8 @@ class GenerateTask(CommonSubTask):
         else:
             num_workers = 1
 
-        # CE single-process policy for cross-row constraints (unique / composite).
-        forced = GenerateTask._apply_single_process_policy(stmt, num_workers)
+        forced = resolve_single_process(stmt, num_workers)
         return forced if forced is not None else num_workers
-
-    @staticmethod
-    def _apply_single_process_policy(stmt: GenerateStatement, requested_workers: int) -> int | None:
-        """CE policy: 'unique' and 'composite' are global cross-row constraints (no value/tuple
-        repeats across the whole run). Parallel workers would each restart the constraint and emit
-        overlaps, so CE serialises them (single-process); multiprocess scaling of these is an
-        Enterprise feature. Single source of truth for the policy decision AND its user-facing log.
-
-        Returns 1 when the policy applies (logging once when it overrides a multiprocess request),
-        otherwise None (no constraint -> caller keeps the requested worker count).
-        """
-        constrained = GenerateTask._is_global_constraint(stmt) or any(
-            GenerateTask._is_global_constraint(child) for child in stmt.sub_statements
-        )
-        if not constrained:
-            return None
-        if requested_workers > 1:
-            logger.info(
-                f"<generate> '{stmt.name}': 'unique'/'composite' is a global cross-row constraint — "
-                f"CE runs it single-process ({requested_workers} requested workers ignored). "
-                f"Multiprocess scaling of these is an Enterprise (EE) feature."
-            )
-        return 1
 
     def execute(
         self,

--- a/datamimic_ce/tasks/generate_task.py
+++ b/datamimic_ce/tasks/generate_task.py
@@ -22,6 +22,7 @@ from datamimic_ce.logger import logger
 from datamimic_ce.statements.composite_statement import CompositeStatement
 from datamimic_ce.statements.generate_statement import GenerateStatement
 from datamimic_ce.statements.key_statement import KeyStatement
+from datamimic_ce.statements.reference_statement import ReferenceStatement
 from datamimic_ce.statements.statement import Statement
 from datamimic_ce.statements.statement_util import StatementUtil
 from datamimic_ce.statements.variable_statement import VariableStatement
@@ -148,6 +149,18 @@ class GenerateTask(CommonSubTask):
                 GenerateTask._scan_data_source(ctx, child_stmt)
 
     @staticmethod
+    def _is_global_constraint(stmt: Statement) -> bool:
+        """A cross-row constraint CE serialises (single-process): a unique <generate>/<key>/
+        <variable>, or a unique or composite <reference>. Multiprocess scaling is an EE feature."""
+        if isinstance(stmt, GenerateStatement):
+            return bool(stmt.unique)
+        if isinstance(stmt, KeyStatement | VariableStatement):
+            return bool(stmt.unique)
+        if isinstance(stmt, ReferenceStatement):
+            return bool(stmt.unique) or stmt.is_composite
+        return False
+
+    @staticmethod
     def _determine_num_workers(context: GenIterContext | SetupContext, stmt: GenerateStatement) -> int:
         """
         Determine number of Ray workers for multiprocessing. Default to 1 if not specified.
@@ -164,16 +177,6 @@ class GenerateTask(CommonSubTask):
             if ".delete" in exporter_str:
                 return 1
 
-        # A unique INLINE <key/variable values> samples via a per-task iterator that parallel
-        # workers would each restart, emitting overlapping values -> serialize. Source-backed
-        # unique (<variable source>, <generate source>) is page-sliced in the registry and stays
-        # multiprocessing-safe, so it is not forced here.
-        if any(
-            isinstance(child, KeyStatement | VariableStatement) and child.unique and child.values is not None
-            for child in stmt.sub_statements
-        ):
-            return 1
-
         # Get number of workers from statement, setup context, or default to 1
         current_setup_context = context
         while not isinstance(current_setup_context, SetupContext):
@@ -186,7 +189,32 @@ class GenerateTask(CommonSubTask):
         else:
             num_workers = 1
 
-        return num_workers
+        # CE single-process policy for cross-row constraints (unique / composite).
+        forced = GenerateTask._apply_single_process_policy(stmt, num_workers)
+        return forced if forced is not None else num_workers
+
+    @staticmethod
+    def _apply_single_process_policy(stmt: GenerateStatement, requested_workers: int) -> int | None:
+        """CE policy: 'unique' and 'composite' are global cross-row constraints (no value/tuple
+        repeats across the whole run). Parallel workers would each restart the constraint and emit
+        overlaps, so CE serialises them (single-process); multiprocess scaling of these is an
+        Enterprise feature. Single source of truth for the policy decision AND its user-facing log.
+
+        Returns 1 when the policy applies (logging once when it overrides a multiprocess request),
+        otherwise None (no constraint -> caller keeps the requested worker count).
+        """
+        constrained = GenerateTask._is_global_constraint(stmt) or any(
+            GenerateTask._is_global_constraint(child) for child in stmt.sub_statements
+        )
+        if not constrained:
+            return None
+        if requested_workers > 1:
+            logger.info(
+                f"<generate> '{stmt.name}': 'unique'/'composite' is a global cross-row constraint — "
+                f"CE runs it single-process ({requested_workers} requested workers ignored). "
+                f"Multiprocess scaling of these is an Enterprise (EE) feature."
+            )
+        return 1
 
     def execute(
         self,

--- a/datamimic_ce/tasks/reference_task.py
+++ b/datamimic_ce/tasks/reference_task.py
@@ -59,7 +59,7 @@ class ReferenceTask(GenSubTask):
         non-unique reference picks with replacement (a foreign key may repeat the same row), which
         has no registry counterpart, so it stays here."""
         if self._statement.unique:
-            # ponytail: distinctness holds within a page, not across pages — the per-page seed
+            # Limitation: distinctness holds within a page, not across pages — the per-page seed
             # advances, same pre-existing limitation as <variable source unique>. The default
             # pageSize (>= count up to 10k) keeps it single-page; cross-page paging is a separate fix.
             return DataSourceRegistry.get_unique_data(

--- a/datamimic_ce/tasks/reference_task.py
+++ b/datamimic_ce/tasks/reference_task.py
@@ -59,11 +59,15 @@ class ReferenceTask(GenSubTask):
         non-unique reference picks with replacement (a foreign key may repeat the same row), which
         has no registry counterpart, so it stays here."""
         if self._statement.unique:
-            # Limitation: distinctness holds within a page, not across pages — the per-page seed
-            # advances, same pre-existing limitation as <variable source unique>. The default
-            # pageSize (>= count up to 10k) keeps it single-page; cross-page paging is a separate fix.
+            # Cache the full deduped sequence (built once) so distinctness holds across pages,
+            # not just within one — the per-page seed is not stable for a sub-task.
             return DataSourceRegistry.get_unique_data(
-                records, self._pagination, ctx.root.get_distribution_seed(), f"<reference> '{self._statement.name}'"
+                records,
+                self._pagination,
+                ctx.root.get_distribution_seed(),
+                f"<reference> '{self._statement.name}'",
+                cache=ctx.root.unique_pool_cache,
+                cache_key=self._statement.full_name,
             )
         size = self._pagination.limit if self._pagination is not None else 1
         return [ctx.rng.choice(records) for _ in range(size)]

--- a/datamimic_ce/tasks/reference_task.py
+++ b/datamimic_ce/tasks/reference_task.py
@@ -59,15 +59,10 @@ class ReferenceTask(GenSubTask):
         non-unique reference picks with replacement (a foreign key may repeat the same row), which
         has no registry counterpart, so it stays here."""
         if self._statement.unique:
-            # Cache the full deduped sequence (built once) so distinctness holds across pages,
-            # not just within one — the per-page seed is not stable for a sub-task.
+            # Stable per-statement seed so distinctness holds across pages, not just within one.
+            seed = ctx.root.stable_distribution_seed(self._statement.full_name)
             return DataSourceRegistry.get_unique_data(
-                records,
-                self._pagination,
-                ctx.root.get_distribution_seed(),
-                f"<reference> '{self._statement.name}'",
-                cache=ctx.root.unique_pool_cache,
-                cache_key=self._statement.full_name,
+                records, self._pagination, seed, f"<reference> '{self._statement.name}'"
             )
         size = self._pagination.limit if self._pagination is not None else 1
         return [ctx.rng.choice(records) for _ in range(size)]

--- a/datamimic_ce/tasks/reference_task.py
+++ b/datamimic_ce/tasks/reference_task.py
@@ -5,16 +5,15 @@
 # For questions and support, contact: info@rapiddweller.com
 
 from collections.abc import Iterator
-from random import Random
 from typing import Any
 
 from datamimic_ce.clients.rdbms_client import RdbmsClient
 from datamimic_ce.contexts.context import Context
 from datamimic_ce.contexts.geniter_context import GenIterContext
 from datamimic_ce.data_sources.data_source_pagination import DataSourcePagination
+from datamimic_ce.data_sources.data_source_registry import DataSourceRegistry
 from datamimic_ce.statements.reference_statement import ReferenceStatement
 from datamimic_ce.tasks.task import GenSubTask
-from datamimic_ce.utils.unique_sampling import unique_values
 
 
 class ReferenceTask(GenSubTask):
@@ -52,17 +51,19 @@ class ReferenceTask(GenSubTask):
             raise ValueError(f"No data found for reference {self._statement.name}")
         # Map each source row tuple to a {target: value} record.
         records = [dict(zip(self._statement.targets, row, strict=True)) for row in rows]
-        return iter(self._sample(records, ctx.rng))
+        return iter(self._select(records, ctx))
 
-    def _sample(self, records: list[dict[str, Any]], rng: Random) -> list[dict[str, Any]]:
-        size = self._pagination.limit if self._pagination is not None else 1
+    def _select(self, records: list[dict[str, Any]], ctx: Context) -> list[dict[str, Any]]:
+        """Distinct combinations route through the shared DataSourceRegistry.get_unique_data — the
+        same SPOT as <variable>/<generate> unique (dedupe + shuffle + page window + strict). A
+        non-unique reference picks with replacement (a foreign key may repeat the same row), which
+        has no registry counterpart, so it stays here."""
         if self._statement.unique:
-            # Distinct combinations without replacement (dedupe + shuffle); strict on exhaustion.
-            distinct = unique_values(records, rng)
-            if size > len(distinct):
-                raise RuntimeError(
-                    f"Cannot generate {size} unique values - only {len(distinct)} available for "
-                    f"{self._statement.name}"
-                )
-            return distinct[:size]
-        return [rng.choice(records) for _ in range(size)]
+            # ponytail: distinctness holds within a page, not across pages — the per-page seed
+            # advances, same pre-existing limitation as <variable source unique>. The default
+            # pageSize (>= count up to 10k) keeps it single-page; cross-page paging is a separate fix.
+            return DataSourceRegistry.get_unique_data(
+                records, self._pagination, ctx.root.get_distribution_seed(), f"<reference> '{self._statement.name}'"
+            )
+        size = self._pagination.limit if self._pagination is not None else 1
+        return [ctx.rng.choice(records) for _ in range(size)]

--- a/datamimic_ce/tasks/reference_task.py
+++ b/datamimic_ce/tasks/reference_task.py
@@ -6,6 +6,7 @@
 
 from collections.abc import Iterator
 from random import Random
+from typing import Any
 
 from datamimic_ce.clients.rdbms_client import RdbmsClient
 from datamimic_ce.contexts.context import Context
@@ -13,51 +14,55 @@ from datamimic_ce.contexts.geniter_context import GenIterContext
 from datamimic_ce.data_sources.data_source_pagination import DataSourcePagination
 from datamimic_ce.statements.reference_statement import ReferenceStatement
 from datamimic_ce.tasks.task import GenSubTask
+from datamimic_ce.utils.unique_sampling import unique_values
 
 
 class ReferenceTask(GenSubTask):
     def __init__(self, statement: ReferenceStatement, pagination: DataSourcePagination | None = None):
         self._statement: ReferenceStatement = statement
         self._pagination: DataSourcePagination | None = pagination
-        self._iterator: Iterator[str | int | float] | None = None
+        # Each item is a {target: value} record (one source row's selected columns).
+        self._iterator: Iterator[dict[str, Any]] | None = None
 
     @property
     def statement(self) -> ReferenceStatement:
         return self._statement
 
     def execute(self, ctx: Context):
-        """Generate a reference value from an RDBMS data source."""
+        """Generate a (composite) reference record from an RDBMS data source."""
         if self._iterator is None:
             self._iterator = self._init_iterator(ctx)
         try:
-            value = next(self._iterator)
+            record = next(self._iterator)
         except StopIteration:
             self._iterator = None
             return self.execute(ctx)
         if isinstance(ctx, GenIterContext):
-            ctx.add_current_product_field(self._statement.name, value)
-        return value
+            for target, value in record.items():
+                ctx.add_current_product_field(target, value)
+        # Legacy single-field references return the scalar; composite ones return the record.
+        return record[self._statement.targets[0]] if not self._statement.is_composite else record
 
-    def _init_iterator(self, ctx: Context) -> Iterator[str | int | float]:
+    def _init_iterator(self, ctx: Context) -> Iterator[dict[str, Any]]:
         client = ctx.root.clients.get(self.statement.source)
         if not isinstance(client, RdbmsClient):
             raise ValueError("Reference task currently only supports RDBMS data sources")
-        dataset: list[str | int | float] = client.get_random_rows_by_column(
-            self.statement.source_type, self.statement.source_key, self._pagination, self._statement.unique
-        )
-        if not dataset:
+        rows = client.get_random_rows_by_columns(self.statement.source_type, self.statement.source_keys)
+        if not rows:
             raise ValueError(f"No data found for reference {self._statement.name}")
-        return iter(self._sample(dataset, ctx.rng))
+        # Map each source row tuple to a {target: value} record.
+        records = [dict(zip(self._statement.targets, row, strict=True)) for row in rows]
+        return iter(self._sample(records, ctx.rng))
 
-    def _sample(self, dataset: list[str | int | float], rng: Random) -> list[str | int | float]:
+    def _sample(self, records: list[dict[str, Any]], rng: Random) -> list[dict[str, Any]]:
+        size = self._pagination.limit if self._pagination is not None else 1
         if self._statement.unique:
-            sample_size = self._pagination.limit if self._pagination is not None else 1
-            if sample_size > len(dataset):
+            # Distinct combinations without replacement (dedupe + shuffle); strict on exhaustion.
+            distinct = unique_values(records, rng)
+            if size > len(distinct):
                 raise RuntimeError(
-                    f"Cannot generate {sample_size} unique values - only {len(dataset)} available for "
+                    f"Cannot generate {size} unique values - only {len(distinct)} available for "
                     f"{self._statement.name}"
                 )
-            return rng.sample(dataset, sample_size)
-        if self._pagination is not None:
-            return [rng.choice(dataset) for _ in range(self._pagination.limit)]
-        return [rng.choice(dataset)]
+            return distinct[:size]
+        return [rng.choice(records) for _ in range(size)]

--- a/datamimic_ce/tasks/single_process_policy.py
+++ b/datamimic_ce/tasks/single_process_policy.py
@@ -1,0 +1,89 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+"""Central registry of features CE runs single-process.
+
+One place to maintain WHICH features force single-process, the user-facing reason, and
+the Enterprise (EE) scaling recommendation. Add a feature here (not scattered in the
+worker logic) to make CE serialise it; ``resolve_single_process`` is the single entry
+point used by the generate task.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from datamimic_ce.logger import logger
+from datamimic_ce.statements.generate_statement import GenerateStatement
+from datamimic_ce.statements.key_statement import KeyStatement
+from datamimic_ce.statements.reference_statement import ReferenceStatement
+from datamimic_ce.statements.statement import Statement
+from datamimic_ce.statements.variable_statement import VariableStatement
+
+
+def _is_global_constraint(stmt: Statement) -> bool:
+    """A cross-row constraint (no value/tuple repeats across the whole run): a unique
+    <generate>/<key>/<variable>, or a unique or composite <reference>."""
+    if isinstance(stmt, GenerateStatement):
+        return bool(stmt.unique)
+    if isinstance(stmt, KeyStatement | VariableStatement):
+        return bool(stmt.unique)
+    if isinstance(stmt, ReferenceStatement):
+        return bool(stmt.unique) or stmt.is_composite
+    return False
+
+
+def _uses_global_constraint(stmt: GenerateStatement) -> bool:
+    return _is_global_constraint(stmt) or any(_is_global_constraint(child) for child in stmt.sub_statements)
+
+
+def _has_delete_target(stmt: GenerateStatement) -> bool:
+    return any(".delete" in target for target in stmt.targets)
+
+
+@dataclass(frozen=True)
+class SingleProcessPolicy:
+    """One feature CE serialises. ``ee_scalable`` adds the Enterprise upgrade hint to the log."""
+
+    feature: str
+    applies: Callable[[GenerateStatement], bool]
+    reason: str
+    ee_scalable: bool
+
+
+# THE registry — the single place to maintain CE's single-process policies.
+POLICIES: tuple[SingleProcessPolicy, ...] = (
+    SingleProcessPolicy(
+        feature="unique/composite",
+        applies=_uses_global_constraint,
+        reason="'unique'/'composite' is a global cross-row constraint",
+        ee_scalable=True,
+    ),
+    SingleProcessPolicy(
+        feature="delete",
+        applies=_has_delete_target,
+        reason="delete operations run sequentially",
+        ee_scalable=False,
+    ),
+)
+
+_EE_HINT = " Multiprocess scaling of this is an Enterprise (EE) feature."
+
+
+def resolve_single_process(stmt: GenerateStatement, requested_workers: int) -> int | None:
+    """Return 1 if any single-process policy applies to ``stmt`` (logging once when it overrides
+    a multiprocess request, with the EE recommendation where the feature is EE-scalable), else
+    None so the caller keeps ``requested_workers``."""
+    for policy in POLICIES:
+        if not policy.applies(stmt):
+            continue
+        if requested_workers > 1:
+            hint = _EE_HINT if policy.ee_scalable else ""
+            logger.info(
+                f"<generate> '{stmt.name}': {policy.reason} — CE runs it single-process "
+                f"({requested_workers} requested workers ignored).{hint}"
+            )
+        return 1
+    return None

--- a/datamimic_ce/tasks/task_util.py
+++ b/datamimic_ce/tasks/task_util.py
@@ -550,7 +550,7 @@ class TaskUtil:
         elif data_type == DATA_TYPE_FLOAT:
             return rng.uniform(0, 100)
         elif data_type == DATA_TYPE_DECIMAL:
-            # ponytail: fixed 2dp default for bare type="decimal"; use a DecimalGenerator for other scales
+            # fixed 2dp default for bare type="decimal"; use a DecimalGenerator for other scales
             return Decimal(str(round(rng.uniform(0, 100), 2)))
         elif data_type == DATA_TYPE_BOOL:
             return rng.choice((True, False))

--- a/datamimic_ce/tasks/variable_task.py
+++ b/datamimic_ce/tasks/variable_task.py
@@ -71,6 +71,8 @@ class VariableTask(KeyVariableTask, CommonSubTask):
         # Only ORDERED paginates sequentially; RANDOM and CUMULATED load all rows.
         # unique also needs the whole pool (dedupe + sample without replacement).
         loads_all = self.statement.distribution.loads_all or bool(self.statement.unique)
+        # Shared cache so a unique pool is deduped+shuffled once and reused across pages.
+        self._unique_cache = ctx.root.unique_pool_cache
         if loads_all:
             seed = ctx.root.get_distribution_seed()
 
@@ -311,7 +313,14 @@ class VariableTask(KeyVariableTask, CommonSubTask):
         in the registry, so unique stays multiprocessing-safe. Consumed via ``_full_load_iterator``."""
         if self._statement.unique:
             return iter(
-                DataSourceRegistry.get_unique_data(data, pagination, seed, f"<variable> '{self._statement.name}'")
+                DataSourceRegistry.get_unique_data(
+                    data,
+                    pagination,
+                    seed,
+                    f"<variable> '{self._statement.name}'",
+                    cache=self._unique_cache,
+                    cache_key=self._statement.full_name,
+                )
             )
         return iter(
             DataSourceRegistry.get_distributed_data(

--- a/datamimic_ce/tasks/variable_task.py
+++ b/datamimic_ce/tasks/variable_task.py
@@ -71,10 +71,9 @@ class VariableTask(KeyVariableTask, CommonSubTask):
         # Only ORDERED paginates sequentially; RANDOM and CUMULATED load all rows.
         # unique also needs the whole pool (dedupe + sample without replacement).
         loads_all = self.statement.distribution.loads_all or bool(self.statement.unique)
-        # Shared cache so a unique pool is deduped+shuffled once and reused across pages.
-        self._unique_cache = ctx.root.unique_pool_cache
         if loads_all:
-            seed = ctx.root.get_distribution_seed()
+            # Stable per-statement seed so random / cumulated / unique stay consistent across pages.
+            seed = ctx.root.stable_distribution_seed(self.statement.full_name)
 
         # Try to init generation mode of VariableTask
         if statement.source is not None:
@@ -313,14 +312,7 @@ class VariableTask(KeyVariableTask, CommonSubTask):
         in the registry, so unique stays multiprocessing-safe. Consumed via ``_full_load_iterator``."""
         if self._statement.unique:
             return iter(
-                DataSourceRegistry.get_unique_data(
-                    data,
-                    pagination,
-                    seed,
-                    f"<variable> '{self._statement.name}'",
-                    cache=self._unique_cache,
-                    cache_key=self._statement.full_name,
-                )
+                DataSourceRegistry.get_unique_data(data, pagination, seed, f"<variable> '{self._statement.name}'")
             )
         return iter(
             DataSourceRegistry.get_distributed_data(

--- a/tests_ce/integration_tests/test_composite_reference/composite_exhausted.xml
+++ b/tests_ce/integration_tests/test_composite_reference/composite_exhausted.xml
@@ -1,0 +1,10 @@
+<setup rngSeed="42">
+    <database id="refdb" database="ref_exh_db" dbms="sqlite"/>
+    <execute uri="script/setup_slots.scr.sql" target="refdb"/>
+    <generate name="x" count="8" target="">
+        <reference name="slot" source="refdb" sourceType="slots" unique="true">
+            <field target="aisle" sourceKey="aisle"/>
+            <field target="bin"   sourceKey="bin"/>
+        </reference>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_composite_reference/composite_mp.xml
+++ b/tests_ce/integration_tests/test_composite_reference/composite_mp.xml
@@ -1,0 +1,11 @@
+<setup rngSeed="42">
+    <database id="refdb" database="ref_mp_db" dbms="sqlite"/>
+    <execute uri="script/setup_slots.scr.sql" target="refdb"/>
+    <!-- numProcess>1 but composite unique is a global constraint -> CE forces single-process. -->
+    <generate name="events" count="6" numProcess="4" target="">
+        <reference name="slot" source="refdb" sourceType="slots" unique="true">
+            <field target="aisle" sourceKey="aisle"/>
+            <field target="bin"   sourceKey="bin"/>
+        </reference>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_composite_reference/composite_nonunique.xml
+++ b/tests_ce/integration_tests/test_composite_reference/composite_nonunique.xml
@@ -1,0 +1,11 @@
+<setup rngSeed="42">
+    <database id="refdb" database="ref_nu_db" dbms="sqlite"/>
+    <execute uri="script/setup_slots.scr.sql" target="refdb"/>
+    <!-- non-unique: with replacement -> count may exceed distinct combos, tuples may repeat. -->
+    <generate name="x" count="20" target="">
+        <reference name="slot" source="refdb" sourceType="slots">
+            <field target="aisle" sourceKey="aisle"/>
+            <field target="bin"   sourceKey="bin"/>
+        </reference>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_composite_reference/composite_paged.xml
+++ b/tests_ce/integration_tests/test_composite_reference/composite_paged.xml
@@ -1,0 +1,12 @@
+<setup rngSeed="42">
+    <database id="refdb" database="ref_paged_db" dbms="sqlite"/>
+    <execute uri="script/setup_slots.scr.sql" target="refdb"/>
+    <!-- count(6) > pageSize(2) -> 3 pages. The full unique sequence is cached once, so distinct
+         tuples hold ACROSS pages (regression for the per-page-seed cross-page bug). -->
+    <generate name="events" count="6" pageSize="2" target="">
+        <reference name="slot" source="refdb" sourceType="slots" unique="true">
+            <field target="aisle" sourceKey="aisle"/>
+            <field target="bin"   sourceKey="bin"/>
+        </reference>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_composite_reference/composite_reference.xml
+++ b/tests_ce/integration_tests/test_composite_reference/composite_reference.xml
@@ -1,0 +1,11 @@
+<setup rngSeed="42">
+    <database id="refdb" database="ref_composite_db" dbms="sqlite"/>
+    <execute uri="script/setup_slots.scr.sql" target="refdb"/>
+    <!-- composite reference: each row gets a DISTINCT (aisle, bin) tuple from the source. -->
+    <generate name="events" count="6" target="">
+        <reference name="slot" source="refdb" sourceType="slots" unique="true">
+            <field target="aisle" sourceKey="aisle"/>
+            <field target="bin" sourceKey="bin"/>
+        </reference>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_composite_reference/composite_three_fields.xml
+++ b/tests_ce/integration_tests/test_composite_reference/composite_three_fields.xml
@@ -1,0 +1,11 @@
+<setup rngSeed="42">
+    <database id="refdb" database="ref_three_db" dbms="sqlite"/>
+    <execute uri="script/setup_slots.scr.sql" target="refdb"/>
+    <generate name="rows" count="4" target="">
+        <reference name="part" source="refdb" sourceType="parts" unique="true">
+            <field target="region" sourceKey="region"/>
+            <field target="yr"     sourceKey="year"/>
+            <field target="price"  sourceKey="price"/>
+        </reference>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_composite_reference/fk_integrity.xml
+++ b/tests_ce/integration_tests/test_composite_reference/fk_integrity.xml
@@ -1,0 +1,12 @@
+<setup rngSeed="42">
+    <database id="refdb" database="fk_integ_db" dbms="sqlite"/>
+    <execute uri="script/setup_slots.scr.sql" target="refdb"/>
+    <!-- 30 children referencing a SPARSE parent. Every (region, code) must be a real parent
+         row — never an invented cross like ('EU','U1'). -->
+    <generate name="orders" count="30" target="">
+        <reference name="rc" source="refdb" sourceType="region_codes">
+            <field target="region" sourceKey="region"/>
+            <field target="code"   sourceKey="code"/>
+        </reference>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_composite_reference/fk_unique_assignment.xml
+++ b/tests_ce/integration_tests/test_composite_reference/fk_unique_assignment.xml
@@ -1,0 +1,10 @@
+<setup rngSeed="42">
+    <database id="refdb" database="fk_uassign_db" dbms="sqlite"/>
+    <execute uri="script/setup_slots.scr.sql" target="refdb"/>
+    <generate name="assignments" count="5" target="">
+        <reference name="rc" source="refdb" sourceType="region_codes" unique="true">
+            <field target="region" sourceKey="region"/>
+            <field target="code"   sourceKey="code"/>
+        </reference>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_composite_reference/legacy_single.xml
+++ b/tests_ce/integration_tests/test_composite_reference/legacy_single.xml
@@ -1,0 +1,8 @@
+<setup rngSeed="42">
+    <database id="refdb" database="ref_legacy_db" dbms="sqlite"/>
+    <execute uri="script/setup_slots.scr.sql" target="refdb"/>
+    <!-- legacy single-field form (sourceKey, no <field>) still works. -->
+    <generate name="x" count="3" target="">
+        <reference name="aisle" source="refdb" sourceType="slots" sourceKey="aisle" unique="true"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_composite_reference/script/setup_slots.scr.sql
+++ b/tests_ce/integration_tests/test_composite_reference/script/setup_slots.scr.sql
@@ -17,3 +17,14 @@ INSERT INTO parts (region, year, price) VALUES ('EU', 2024, 2.5);
 INSERT INTO parts (region, year, price) VALUES ('US', 2023, 3.5);
 INSERT INTO parts (region, year, price) VALUES ('US', 2024, 4.5);
 INSERT INTO parts (region, year, price) VALUES ('EU', 2023, 1.5);
+-- Sparse composite key, NOT a full grid. EU codes are E1/E2, US codes are U1/U2/U3.
+-- An independent per-column generator could invent EU+U1, a row that does not exist.
+-- Tuple-integrity generation only ever emits these 5 real pairs (the core composite-FK property).
+-- (Keep this comment free of the semicolon char: the script splits commands on it.)
+DROP TABLE IF EXISTS region_codes;
+CREATE TABLE region_codes (region TEXT, code TEXT);
+INSERT INTO region_codes VALUES ('EU', 'E1');
+INSERT INTO region_codes VALUES ('EU', 'E2');
+INSERT INTO region_codes VALUES ('US', 'U1');
+INSERT INTO region_codes VALUES ('US', 'U2');
+INSERT INTO region_codes VALUES ('US', 'U3');

--- a/tests_ce/integration_tests/test_composite_reference/script/setup_slots.scr.sql
+++ b/tests_ce/integration_tests/test_composite_reference/script/setup_slots.scr.sql
@@ -1,0 +1,19 @@
+-- composite-reference fixture: (aisle, bin) with mixed types (TEXT, INTEGER) + duplicate combos.
+DROP TABLE IF EXISTS slots;
+CREATE TABLE IF NOT EXISTS slots (aisle TEXT, bin INTEGER);
+INSERT INTO slots (aisle, bin) VALUES ('A', 1);
+INSERT INTO slots (aisle, bin) VALUES ('A', 2);
+INSERT INTO slots (aisle, bin) VALUES ('B', 1);
+INSERT INTO slots (aisle, bin) VALUES ('B', 2);
+INSERT INTO slots (aisle, bin) VALUES ('C', 1);
+INSERT INTO slots (aisle, bin) VALUES ('C', 2);
+INSERT INTO slots (aisle, bin) VALUES ('A', 1);
+INSERT INTO slots (aisle, bin) VALUES ('B', 2);
+-- 3-column composite with three types (TEXT, INTEGER, REAL): 4 distinct combos.
+DROP TABLE IF EXISTS parts;
+CREATE TABLE IF NOT EXISTS parts (region TEXT, year INTEGER, price REAL);
+INSERT INTO parts (region, year, price) VALUES ('EU', 2023, 1.5);
+INSERT INTO parts (region, year, price) VALUES ('EU', 2024, 2.5);
+INSERT INTO parts (region, year, price) VALUES ('US', 2023, 3.5);
+INSERT INTO parts (region, year, price) VALUES ('US', 2024, 4.5);
+INSERT INTO parts (region, year, price) VALUES ('EU', 2023, 1.5);

--- a/tests_ce/integration_tests/test_composite_reference/test_composite_reference.py
+++ b/tests_ce/integration_tests/test_composite_reference/test_composite_reference.py
@@ -8,6 +8,7 @@ unique="true" draws distinct multi-column tuples (the EE concept/syntax ported t
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -61,3 +62,31 @@ def test_legacy_single_field_reference_still_works():
     rows = _run("legacy_single.xml", gen="x")
     assert len(rows) == 3
     assert {r["aisle"] for r in rows} == {"A", "B", "C"}  # distinct aisles (deduped)
+
+
+def test_composite_unique_holds_under_multiprocessing():
+    # CE policy: a composite unique <reference> is a global constraint -> forced single-process,
+    # so it stays distinct even when numProcess > 1 (scaling these is an EE feature).
+    rows = _run("composite_mp.xml")
+    tuples = [(r["aisle"], r["bin"]) for r in rows]
+    assert len(set(tuples)) == 6
+
+
+def test_policy_logs_single_process_override():
+    # The CE single-process policy informs the user (testable log) when it overrides a
+    # multiprocess request (composite_mp.xml asks for numProcess=4). The DATAMIMIC logger has
+    # its own handler (propagate=False), so capture by attaching directly to it.
+    messages: list[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            messages.append(record.getMessage())
+
+    handler = _Capture()
+    dm_logger = logging.getLogger("DATAMIMIC")
+    dm_logger.addHandler(handler)
+    try:
+        _run("composite_mp.xml")
+    finally:
+        dm_logger.removeHandler(handler)
+    assert any("single-process" in m and "Enterprise" in m for m in messages)

--- a/tests_ce/integration_tests/test_composite_reference/test_composite_reference.py
+++ b/tests_ce/integration_tests/test_composite_reference/test_composite_reference.py
@@ -64,6 +64,34 @@ def test_legacy_single_field_reference_still_works():
     assert {r["aisle"] for r in rows} == {"A", "B", "C"}  # distinct aisles (deduped)
 
 
+# --- Referential integrity against a SPARSE parent (the real-world composite-FK challenge) ---
+# Web research framing: "referential integrity holds across the tuple, not on either column
+# alone ... producers that generate columns independently break this without noticing."
+# The full-grid fixtures above can't prove this (every cross is valid); a sparse parent can.
+
+_VALID_PAIRS = {("EU", "E1"), ("EU", "E2"), ("US", "U1"), ("US", "U2"), ("US", "U3")}
+
+
+def test_composite_fk_tuple_integrity_against_sparse_parent():
+    # 30 children, fan-out (one-to-many) onto 5 sparse parent rows.
+    rows = _run("fk_integrity.xml", gen="orders")
+    pairs = {(r["region"], r["code"]) for r in rows}
+    # Every (region, code) is a REAL parent row — never an invented cross like ('EU','U1').
+    assert pairs <= _VALID_PAIRS
+    # The columns are NOT generated independently: EU never carries a US code, and vice versa.
+    assert not any(r["region"] == "EU" and r["code"].startswith("U") for r in rows)
+    assert not any(r["region"] == "US" and r["code"].startswith("E") for r in rows)
+    assert len(rows) == 30  # fan-out: far more children than the 5 distinct parents
+
+
+def test_composite_fk_unique_assignment_no_double_booking():
+    # unique="true" -> each parent tuple assigned at most once (1:1 slot assignment).
+    rows = _run("fk_unique_assignment.xml", gen="assignments")
+    pairs = [(r["region"], r["code"]) for r in rows]
+    assert len(pairs) == len(set(pairs)) == 5  # no double-booking
+    assert set(pairs) == _VALID_PAIRS  # the whole sparse parent, each exactly once
+
+
 def test_composite_unique_holds_under_multiprocessing():
     # CE policy: a composite unique <reference> is a global constraint -> forced single-process,
     # so it stays distinct even when numProcess > 1 (scaling these is an EE feature).

--- a/tests_ce/integration_tests/test_composite_reference/test_composite_reference.py
+++ b/tests_ce/integration_tests/test_composite_reference/test_composite_reference.py
@@ -1,0 +1,63 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# See LICENSE file for the full text of the license.
+
+"""Composite <reference>: <field> children map source columns to target fields, and
+unique="true" draws distinct multi-column tuples (the EE concept/syntax ported to CE).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+_TEST_DIR = Path(__file__).resolve().parent
+
+
+def _run(filename: str, gen: str = "events") -> list[dict]:
+    engine = DataMimicTest(test_dir=_TEST_DIR, filename=filename, capture_test_result=True)
+    engine.test_with_timer()
+    return engine.capture_result()[gen]
+
+
+def test_composite_reference_distinct_tuples_and_multiple_targets():
+    rows = _run("composite_reference.xml")
+    assert len(rows) == 6
+    # each <field> target is set on the entity (mixed types: aisle TEXT, bin INT)
+    tuples = [(r["aisle"], r["bin"]) for r in rows]
+    assert all(isinstance(a, str) and isinstance(b, int) for a, b in tuples)
+    # unique -> the 6 distinct (aisle, bin) combinations, no duplicate tuple (despite dup source rows)
+    assert len(set(tuples)) == 6
+    assert set(tuples) == {("A", 1), ("A", 2), ("B", 1), ("B", 2), ("C", 1), ("C", 2)}
+    # seed-reproducible
+    assert [(r["aisle"], r["bin"]) for r in _run("composite_reference.xml")] == tuples
+
+
+def test_three_fields_three_types():
+    rows = _run("composite_three_fields.xml", gen="rows")
+    assert len(rows) == 4
+    tuples = [(r["region"], r["yr"], r["price"]) for r in rows]
+    # three component types: TEXT -> str, INTEGER -> int, REAL -> float
+    assert all(isinstance(a, str) and isinstance(b, int) and isinstance(c, float) for a, b, c in tuples)
+    assert len(set(tuples)) == 4  # the 4 distinct (region, year, price) combos
+
+
+def test_composite_unique_exhaustion_raises():
+    with pytest.raises(Exception, match="unique"):
+        _run("composite_exhausted.xml", gen="x")
+
+
+def test_composite_non_unique_allows_repeats():
+    rows = _run("composite_nonunique.xml", gen="x")
+    assert len(rows) == 20  # with replacement -> more rows than the 6 distinct combos
+    valid = {("A", 1), ("A", 2), ("B", 1), ("B", 2), ("C", 1), ("C", 2)}
+    assert {(r["aisle"], r["bin"]) for r in rows} <= valid
+
+
+def test_legacy_single_field_reference_still_works():
+    rows = _run("legacy_single.xml", gen="x")
+    assert len(rows) == 3
+    assert {r["aisle"] for r in rows} == {"A", "B", "C"}  # distinct aisles (deduped)

--- a/tests_ce/integration_tests/test_composite_reference/test_composite_reference.py
+++ b/tests_ce/integration_tests/test_composite_reference/test_composite_reference.py
@@ -92,6 +92,14 @@ def test_composite_fk_unique_assignment_no_double_booking():
     assert set(pairs) == _VALID_PAIRS  # the whole sparse parent, each exactly once
 
 
+def test_composite_unique_holds_across_pages():
+    # count(6) > pageSize(2): the full unique sequence is cached once, so distinctness holds
+    # across pages (regression for the per-page-seed cross-page bug).
+    rows = _run("composite_paged.xml")
+    tuples = [(r["aisle"], r["bin"]) for r in rows]
+    assert len(set(tuples)) == 6
+
+
 def test_composite_unique_holds_under_multiprocessing():
     # CE policy: a composite unique <reference> is a global constraint -> forced single-process,
     # so it stays distinct even when numProcess > 1 (scaling these is an EE feature).

--- a/tests_ce/integration_tests/test_distribution_matrix/test_distribution_matrix.py
+++ b/tests_ce/integration_tests/test_distribution_matrix/test_distribution_matrix.py
@@ -42,6 +42,10 @@ _TEST_DIR = Path(__file__).resolve().parent
 # (model file, base offset of the 27 source values)
 SOURCE_CASES = [
     ("variable_csv.xml", 0),
+    # Same source/distributions but pageSize < count: the distribution invariants (permutation,
+    # bell) must still hold ACROSS pages — a stable per-statement seed makes random/cumulated/unique
+    # paginate consistently instead of re-shuffling / re-belling per page.
+    ("variable_csv_paged.xml", 0),
     ("variable_json.xml", 0),
     ("variable_sqlite.xml", 0),
     ("variable_memstore.xml", 1),
@@ -106,3 +110,4 @@ def test_nested_key_all_distributions():
     res2 = _run("nestedkey_source.xml")
     for product in ("ordered", "random", "cumulated"):
         assert _nested_vals(res, product) == _nested_vals(res2, product)
+

--- a/tests_ce/integration_tests/test_distribution_matrix/variable_csv_paged.xml
+++ b/tests_ce/integration_tests/test_distribution_matrix/variable_csv_paged.xml
@@ -1,0 +1,17 @@
+<setup rngSeed="42" defaultSeparator=",">
+    <!-- Distribution matrix: <variable source=CSV> × {ordered, random, cumulated}.
+         Source rows.csv holds v = 0..26. ordered = source order, random = seeded
+         permutation, cumulated = bell over the load order (with replacement). -->
+    <generate pageSize="20" name="ordered" count="27" target="">
+        <variable name="row" source="rows.csv" distribution="ordered"/>
+        <key name="v" script="row.v"/>
+    </generate>
+    <generate pageSize="20" name="random" count="27" target="">
+        <variable name="row" source="rows.csv" distribution="random"/>
+        <key name="v" script="row.v"/>
+    </generate>
+    <generate pageSize="20" name="cumulated" count="6000" target="">
+        <variable name="row" source="rows.csv" distribution="cumulated"/>
+        <key name="v" script="row.v"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_unique_source/test_unique_source.py
+++ b/tests_ce/integration_tests/test_unique_source/test_unique_source.py
@@ -93,3 +93,11 @@ def test_key_unique_holds_across_workers():
     codes = _run("key_unique_mp.xml")
     assert len(codes) == 5
     assert set(codes) == {"a", "b", "c", "d", "e"}
+
+
+def test_variable_source_unique_holds_across_pages():
+    # count(5) > pageSize(2) -> 3 pages. The full unique pool is cached once, so distinctness
+    # holds across pages (regression for the per-page-seed cross-page bug in sub-tasks).
+    codes = _run("unique_source_paged.xml")
+    assert len(codes) == 5
+    assert set(codes) == {"A", "B", "C", "D", "E"}

--- a/tests_ce/integration_tests/test_unique_source/unique_source_paged.xml
+++ b/tests_ce/integration_tests/test_unique_source/unique_source_paged.xml
@@ -1,0 +1,7 @@
+<setup rngSeed="9">
+    <!-- unique distinct rows from a csv source (random order, no replacement). -->
+    <generate pageSize="2" name="people" count="5" target="">
+        <variable name="row" source="codes.csv" unique="true"/>
+        <key name="code" script="row.code"/>
+    </generate>
+</setup>

--- a/tests_ce/unit_tests/tasks/test_reference_task.py
+++ b/tests_ce/unit_tests/tasks/test_reference_task.py
@@ -33,8 +33,8 @@ class TestReferenceTask(unittest.TestCase):
         # ReferenceTask reads ctx.rng directly; the random module exposes the
         # same callable API as a Random instance, so it works as a drop-in.
         self.context.rng = random
-        # unique selection routes via DataSourceRegistry.get_unique_data (seed-driven).
-        self.context.root.get_distribution_seed.return_value = 42
+        # unique selection routes via DataSourceRegistry.get_unique_data (stable per-statement seed).
+        self.context.root.stable_distribution_seed.return_value = 42
         self.rdbms_client = MagicMock(spec=RdbmsClient)
         self.context.root.clients.get.return_value = self.rdbms_client
 

--- a/tests_ce/unit_tests/tasks/test_reference_task.py
+++ b/tests_ce/unit_tests/tasks/test_reference_task.py
@@ -22,6 +22,9 @@ class TestReferenceTask(unittest.TestCase):
         self.statement.source = "test_source"
         self.statement.source_type = "test_type"
         self.statement.source_key = "test_key"
+        self.statement.source_keys = ["test_key"]
+        self.statement.targets = ["test_name"]
+        self.statement.is_composite = False
         self.statement.name = "test_name"
         self.pagination = MagicMock(spec=DataSourcePagination)
         self.pagination.limit = 2
@@ -54,7 +57,7 @@ class TestReferenceTask(unittest.TestCase):
 
     def test_execute_empty_dataset(self):
         """Test execution with empty dataset."""
-        self.rdbms_client.get_random_rows_by_column.return_value = []
+        self.rdbms_client.get_random_rows_by_columns.return_value = []
         task = ReferenceTask(self.statement)
 
         with self.assertRaises(ValueError) as context:
@@ -66,7 +69,7 @@ class TestReferenceTask(unittest.TestCase):
         """Test execution with unique values requirement."""
         self.statement.unique = True
         dataset = [1, 2, 3, 4, 5]
-        self.rdbms_client.get_random_rows_by_column.return_value = dataset
+        self.rdbms_client.get_random_rows_by_columns.return_value = [(v,) for v in dataset]
         task = ReferenceTask(self.statement, self.pagination)
 
         # First execution
@@ -82,7 +85,7 @@ class TestReferenceTask(unittest.TestCase):
         """Test execution without unique values requirement."""
         self.statement.unique = False
         dataset = [1, 2, 3]
-        self.rdbms_client.get_random_rows_by_column.return_value = dataset
+        self.rdbms_client.get_random_rows_by_columns.return_value = [(v,) for v in dataset]
         task = ReferenceTask(self.statement)
 
         result = task.execute(self.context)
@@ -93,7 +96,7 @@ class TestReferenceTask(unittest.TestCase):
         self.statement.unique = True
         self.pagination.limit = 5
         dataset = [1, 2, 3]  # Only 3 values available
-        self.rdbms_client.get_random_rows_by_column.return_value = dataset
+        self.rdbms_client.get_random_rows_by_columns.return_value = [(v,) for v in dataset]
         task = ReferenceTask(self.statement, self.pagination)
 
         with self.assertRaises(RuntimeError) as context:
@@ -109,7 +112,7 @@ class TestReferenceTask(unittest.TestCase):
         unique (rng.sample) and non-unique (rng.choice) paths.
         """
         dataset = list(range(20))
-        self.rdbms_client.get_random_rows_by_column.return_value = dataset
+        self.rdbms_client.get_random_rows_by_columns.return_value = [(v,) for v in dataset]
 
         def _collect(unique: bool) -> list:
             self.statement.unique = unique
@@ -129,7 +132,7 @@ class TestReferenceTask(unittest.TestCase):
         """Test execution with context that supports field addition."""
         self.statement.unique = False
         dataset = [42]
-        self.rdbms_client.get_random_rows_by_column.return_value = dataset
+        self.rdbms_client.get_random_rows_by_columns.return_value = [(v,) for v in dataset]
         self.context.add_current_product_field = MagicMock()
 
         task = ReferenceTask(self.statement)

--- a/tests_ce/unit_tests/tasks/test_reference_task.py
+++ b/tests_ce/unit_tests/tasks/test_reference_task.py
@@ -28,10 +28,13 @@ class TestReferenceTask(unittest.TestCase):
         self.statement.name = "test_name"
         self.pagination = MagicMock(spec=DataSourcePagination)
         self.pagination.limit = 2
+        self.pagination.skip = 0
         self.context = MagicMock(spec=GenIterContext)
         # ReferenceTask reads ctx.rng directly; the random module exposes the
         # same callable API as a Random instance, so it works as a drop-in.
         self.context.rng = random
+        # unique selection routes via DataSourceRegistry.get_unique_data (seed-driven).
+        self.context.root.get_distribution_seed.return_value = 42
         self.rdbms_client = MagicMock(spec=RdbmsClient)
         self.context.root.clients.get.return_value = self.rdbms_client
 
@@ -99,10 +102,10 @@ class TestReferenceTask(unittest.TestCase):
         self.rdbms_client.get_random_rows_by_columns.return_value = [(v,) for v in dataset]
         task = ReferenceTask(self.statement, self.pagination)
 
-        with self.assertRaises(RuntimeError) as context:
+        with self.assertRaises(ValueError) as context:
             task.execute(self.context)
 
-        self.assertIn("Cannot generate 5 unique values - only 3 available", str(context.exception))
+        self.assertIn("Cannot generate 5 unique values", str(context.exception))
 
     def test_seeded_rng_makes_reference_replay_identically(self):
         """<reference> picks must replay byte-identically when ctx.rng is seeded.

--- a/tests_ce/unit_tests/tasks/test_single_process_policy.py
+++ b/tests_ce/unit_tests/tasks/test_single_process_policy.py
@@ -1,0 +1,75 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# See LICENSE file for the full text of the license.
+
+"""Central single-process policy: every feature CE serialises hits the one registry path
+(decision + log). Covers the merged unique features (<generate/variable/key ... unique>),
+composite <reference>, and delete — so the policy/log is asserted in one place."""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from datamimic_ce.statements.generate_statement import GenerateStatement
+from datamimic_ce.statements.key_statement import KeyStatement
+from datamimic_ce.statements.reference_statement import ReferenceStatement
+from datamimic_ce.statements.variable_statement import VariableStatement
+from datamimic_ce.tasks.single_process_policy import resolve_single_process
+
+
+def _gen(children=(), unique=False, targets=()) -> MagicMock:
+    g = MagicMock(spec=GenerateStatement)
+    g.name, g.unique, g.sub_statements, g.targets = "g", unique, list(children), list(targets)
+    return g
+
+
+def _child(spec, unique=False, is_composite=False) -> MagicMock:
+    c = MagicMock(spec=spec)
+    c.unique = unique
+    if spec is ReferenceStatement:
+        c.is_composite = is_composite
+    return c
+
+
+@pytest.mark.parametrize(
+    "stmt",
+    [
+        _gen(unique=True),  # <generate source unique>
+        _gen(children=[_child(KeyStatement, unique=True)]),  # <key values|source unique>
+        _gen(children=[_child(VariableStatement, unique=True)]),  # <variable values|source unique>
+        _gen(children=[_child(ReferenceStatement, unique=True)]),  # <reference unique>
+        _gen(children=[_child(ReferenceStatement, is_composite=True)]),  # composite <reference>
+        _gen(targets=["mytable.delete"]),  # delete operation
+    ],
+)
+def test_policy_forces_single_process(stmt):
+    assert resolve_single_process(stmt, requested_workers=4) == 1
+
+
+def test_no_constraint_keeps_requested_workers():
+    plain = _gen(children=[_child(KeyStatement, unique=False)])
+    assert resolve_single_process(plain, requested_workers=4) is None
+
+
+def test_logs_once_on_override_with_ee_hint():
+    messages: list[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            messages.append(record.getMessage())
+
+    handler = _Capture()
+    log = logging.getLogger("DATAMIMIC")
+    prev_level = log.level
+    log.setLevel(logging.INFO)  # bare unit test: engine isn't here to set the visible level
+    log.addHandler(handler)
+    try:
+        resolve_single_process(_gen(unique=True), requested_workers=4)  # override -> logs
+        resolve_single_process(_gen(unique=True), requested_workers=1)  # no MP asked -> silent
+    finally:
+        log.removeHandler(handler)
+        log.setLevel(prev_level)
+
+    assert sum("single-process" in m for m in messages) == 1
+    assert any("Enterprise" in m for m in messages)  # EE recommendation on the scalable feature


### PR DESCRIPTION
## Summary

This PR ports DATAMIMIC EE's **composite `<reference>`** concept and syntax to CE, and — while
hardening it — fixes a **pre-existing cross-page correctness bug** that silently affected the
already-shipped `<variable source distribution="random|cumulated|...">` and `unique` features.

Three themes:

1. **Feature** — `<reference>` may now carry multiple `<field>` children, drawing a *tuple* from
   one source row (referential integrity across the whole key, not per column).
2. **Policy** — a central, single-source-of-truth registry for the features CE runs
   single-process (`unique`/`composite`/`delete`), with a user-facing log and EE upsell hint.
3. **Correctness** — a unified fix so paginated source selection (`random`/`cumulated`/`unique`)
   stays globally consistent across pages, via a stable per-statement distribution seed.

> **EE note:** EE must gain the composite `<reference>` feature *and* the cross-page seed fix.
> Sections below are written so the EE port can be done from this description alone. EE's RDBMS
> layer is richer (query builders / streaming / projection), so the CE-specific shortcuts are
> called out explicitly.

---

## 1. Composite `<reference>` with `<field>` children (EE concept → CE)

### Concept & syntax

A composite foreign key references a **multi-column** parent key. Referential integrity holds
across the *tuple*, not either column alone — a producer that generates the columns independently
silently emits rows that don't exist in the parent. A `<reference>` therefore pulls a **whole row
tuple** from the source and distributes it to multiple target fields.

```xml
<!-- Legacy single-field form (unchanged) -->
<reference name="customer_id" source="db" sourceType="CUSTOMER" sourceKey="id" unique="true"/>

<!-- New composite form: distinct (aisle, bin) tuple from ONE source row -->
<reference name="slot" source="db" sourceType="slots" unique="true">
  <field target="aisle" sourceKey="aisle"/>
  <field target="bin"   sourceKey="bin"/>
</reference>
```

- `<field target=… sourceKey=…>` maps a **source column** (`sourceKey`) to a **target field**
  (`target`) on the generated entity.
- `sourceKey` (the attribute) is the **legacy single-field shortcut**, **XOR** with `<field>`
  children (validated; duplicate `sourceKey`s rejected).
- `unique="true"` → **distinct multi-column tuples** (no-replacement). Without it → with
  replacement (a FK may legitimately repeat the same parent row → one-to-many fan-out).

### Semantics

- **Tuple integrity:** all target fields come from the *same* source row. Proven against a
  *sparse* parent (only specific combos exist) — never invents a cross-product row.
- **unique:** distinct combinations, strict (raises on exhaustion rather than under-generating).
- **non-unique:** with replacement (`rng.choice`), count may exceed the distinct pool.

### Architecture (mirrors `<key>`/`<variable>`)

| Layer | File | Change |
|---|---|---|
| element const | `constants/element_constants.py` | `EL_FIELD = "field"` |
| model | `model/reference_field_model.py` (new) | `ReferenceFieldModel(target, source_key)` + attr validation |
| model | `model/reference_model.py` | `source_key` now optional (composite uses `<field>`) |
| statement | `statements/reference_statement.py` | `ReferenceField(target, source_key)` dataclass; `ReferenceStatement.fields/targets/source_keys/is_composite`; legacy `sourceKey` normalised to one field |
| parser | `parsers/reference_parser.py` | parse `<field>` children, `sourceKey` XOR `<field>`, **receives parent_stmt** (see §5) |
| parser dispatch | `parsers/parser_util.py` | `<reference>` accepts `<field>`; reference parsed **with** parent |
| task | `tasks/reference_task.py` | fetch column tuples → `{target: value}` records → sample; sets all targets |
| client | `clients/rdbms_client.py` | `get_random_rows_by_columns(table, columns)` → row tuples |

- `reference_task` returns the scalar for legacy single-field (back-compat), the record for
  composite.
- The old single-column `get_random_rows_by_column` was removed (it limited *before* dedupe,
  under-counting the distinct pool — a latent bug; now dead).
- `get_random_rows_by_columns` `ORDER BY`s the selected columns for a **stable input order** so the
  seeded shuffle is reproducible run-to-run. (NOT `ORDER BY random()` — that would defeat
  `ctx.rng` reproducibility.) It fetches the full column set; sampling happens in the task via
  `ctx.rng` / `DataSourceRegistry`, **not** in SQL — this is deliberate (determinism-first).

> **EE port:** EE already has `ReferenceFieldModel`, `ReferenceField`, and
> `get_random_rows_by_columns`. The CE additions to mirror are: the parser `<field>` XOR
> `sourceKey` validation, the task's record-mapping + multi-target set, and the SPOT routing in §3.
> EE's richer RDBMS layer can keep its query-builder/streaming path; ensure it also avoids
> limit-before-dedupe and uses a stable order.

---

## 2. CE single-process policy — central registry (`tasks/single_process_policy.py`, new)

`unique` and `composite` are **global cross-row constraints** (no value/tuple repeats across the
whole run). Parallel workers would each restart the constraint and emit overlaps, so **CE
serialises them**; multiprocess scaling of these is an **Enterprise feature**.

This is now a **single source of truth** — one registry of the features CE runs single-process,
each with its detection, user-facing reason, and EE-scalability flag:

```python
POLICIES = (
  SingleProcessPolicy("unique/composite", _uses_global_constraint, "...global cross-row constraint", ee_scalable=True),
  SingleProcessPolicy("delete",           _has_delete_target,       "delete operations run sequentially", ee_scalable=False),
)
```

- `resolve_single_process(stmt, requested_workers) -> int | None` — the only entry point; logs once
  (INFO, with the EE hint where `ee_scalable`) when it **overrides** a `numProcess>1` request.
- `delete` (previously a hard-coded early-return in `_determine_num_workers`) folded in, so all
  single-process enforcements + their messages live in one place.
- `GenerateTask._determine_num_workers` now just resolves the requested count and defers to the
  registry. Adding a future single-process feature = one registry entry, not scattered edits.

> **EE port:** EE offers the *opposite* default (scale these). EE does **not** need this registry;
> it is the CE freemium boundary. Keep the registry CE-only.

---

## 3. SPOT refactor — reference unique routes through `DataSourceRegistry`

`reference_task` no longer re-implements dedupe+shuffle+slice+strict — unique selection now goes
through `DataSourceRegistry.get_unique_data`, the **same SPOT** as `<variable>`/`<generate>`:

```
client (fetch tuples)  →  DataSourceRegistry (select/sample)  →  task (orchestrate, set fields)
```

Non-unique stays in the task: with-replacement FK selection has no registry counterpart.

---

## 4. Unified cross-page distribution correctness (the important architectural fix)

### The bug (pre-existing, shipped)

A **sub-task** (`<variable>`/`<reference>` source selection) is rebuilt **per page**, and each
build called `ctx.root.get_distribution_seed()` — which *advances* the run RNG, so it returned a
**different seed each page**. Result: distinctness/distribution held only *within* a page, not
across pages, whenever `count > pageSize` (i.e. `count > 10000`, or an explicit small `pageSize`):

| distribution | paged (before) | expected |
|---|---|---|
| `random` (no-replacement permutation) | 15/27 distinct | 27/27 |
| `cumulated` (bell) | per-page bell | global bell |
| `unique` (variable) | 4/5 distinct | 5/5 |
| `unique` (composite reference) | 5/6 distinct | 6/6 |

`<generate source>` (worker-level selection) was unaffected — its context resets per page, so its
seed was already stable. Only sub-tasks were broken.

### Root cause & fix

All three registry selectors (`get_shuffled_data_with_cyclic`, `get_cumulated_data`,
`get_unique_data`) are already page-correct **given a stable seed** — the bug was purely the
unstable per-page seed. Fix = make the seed stable per statement:

```python
# SetupContext
def stable_distribution_seed(self, key: str | None) -> int:
    if key not in self._distribution_seed_cache:
        self._distribution_seed_cache[key] = self.get_distribution_seed()  # computed ONCE
    return self._distribution_seed_cache[key]
```

`variable_task` and `reference_task` now use `stable_distribution_seed(stmt.full_name)` for **all**
load-all distributions (random/cumulated/unique). **Zero changes to the registry selectors** —
minimal duplication. Single-page behaviour is unchanged (seed computed once either way) → no
regression.

> **Why a seed cache, not a result cache:** caching the *seed* (one int) is uniform across all
> three distributions; a result cache doesn't generalise (cumulated is with-replacement / unbounded).
> An earlier commit in this branch used a unique-only result cache — superseded by the seed cache.

> **EE relevance — IMPORTANT:** EE has the same sub-task source-selection shape and likely the same
> latent bug. EE must add an equivalent **stable per-statement distribution seed** (cached by a
> unique statement key) for paginated random/cumulated/unique sub-tasks. EE's multiprocess path
> additionally needs the seed to be **stable across workers** (pickling-safe — a content/path key,
> not `id()`).

---

## 5. Reference parent → unique `full_name` (cache-key correctness)

The seed cache is keyed by `stmt.full_name`. `ReferenceStatement` was constructed with
`parent_stmt=None`, so its `full_name` was the **bare name** — two same-named references in
different `<generate>`s collided on one cache key and **shared a seed** (correlated selection).

Fix: the reference parser now passes `parent_stmt` (exactly like `<key>`/`<variable>`/`<nestedKey>`
already do), so `full_name` is a unique path (`orders|slot`, not `slot`). Verified distinct.

> The cache key must be: stable across pages (same statement instance / same path), unique per
> statement, and pickling-safe (a string path — not `id()`, which differs per worker). `full_name`
> satisfies all three. Hashing all attributes was considered and rejected as over-engineering —
> the path already uniquely identifies a statement's position; the only gap (same-name siblings) is
> an invalid model.

---

## Test coverage

**Composite reference** (`tests_ce/integration_tests/test_composite_reference/`, sqlite fixtures):
- distinct tuples + multiple targets + mixed types (TEXT/INT); seed-reproducible
- 3 fields / 3 types (TEXT/INT/REAL)
- unique exhaustion → error; non-unique with replacement; legacy single-field still works
- composite unique holds under `numProcess=4` (policy → single-process) and across pages (`pageSize<count`)
- single-process policy override **log** asserted
- **referential integrity vs a sparse parent**: 30 children all map to real pairs, EU never carries
  a US code and vice versa (columns not generated independently); unique = no double-booking

**Policy** (`tests_ce/unit_tests/tasks/test_single_process_policy.py`): parametrized — every feature
(unique generate/key/variable, unique/composite reference, delete) forces single-process; non-unique
keeps requested workers; override logs once with the EE hint.

**Cross-page** (`test_distribution_matrix`, `test_unique_source`): a paged twin
(`variable_csv_paged.xml`, `pageSize<count`) runs the existing distribution invariants
(permutation / bell) — proving random/cumulated paginate consistently; variable source-unique
distinct across pages.

Full suite: **652 passed**, ruff + mypy clean.

---

## Known limitations / EE-only / follow-ups

- **Weighted / skewed FK** (`weightColumn`): not supported by CE `<reference>` — **Enterprise
  feature**. Real-world FKs are often skewed.
- **Self-referential FKs** (e.g. employee→manager hierarchies): not addressed.
- **Parent generated in the same run:** CE `<reference>` reads from a DB source — the parent must
  already exist in the database.
- **`get_cumulated_data` paging cost:** O(start_idx + span) draws per page; fine for typical skips.

---

## Commit map

| Commit | What |
|---|---|
| `feat(dsl): composite <reference> with <field> children` | the feature (§1) |
| `feat(policy)` + `refactor(policy)` | single-process policy → central registry (§2) |
| `refactor(reference): route unique selection through DataSourceRegistry` | SPOT (§3) |
| `docs(rdbms)` | determinism rationale + fetch-all ceiling |
| `test(reference): composite-FK referential integrity against a sparse parent` | integrity tests |
| `fix(unique): hold distinctness across pages by caching the deduped pool once` | first cross-page approach (result cache — superseded) |
| `fix(unique): unified cross-page fix via stable per-statement seed + reference parent` | final cross-page fix (§4) + reference parent (§5) |
| `Merge origin/development` | resolves the `get_unique_data` overlap with #151 (typing) |
