### PR TITLE
test(dsl): error-path coverage for composite <reference> validation

### DIFF
--- a/tests_ce/integration_tests/test_composite_reference/ref_bare.xml
+++ b/tests_ce/integration_tests/test_composite_reference/ref_bare.xml
@@ -1,0 +1,5 @@
+<setup>
+    <generate name="x" count="1" target="">
+        <reference name="slot" source="refdb" sourceType="slots"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_composite_reference/ref_duplicate_sourcekey.xml
+++ b/tests_ce/integration_tests/test_composite_reference/ref_duplicate_sourcekey.xml
@@ -1,0 +1,8 @@
+<setup>
+    <generate name="x" count="1" target="">
+        <reference name="slot" source="refdb" sourceType="slots" unique="true">
+            <field target="aisle" sourceKey="aisle"/>
+            <field target="bin"   sourceKey="aisle"/>
+        </reference>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_composite_reference/ref_field_and_sourcekey.xml
+++ b/tests_ce/integration_tests/test_composite_reference/ref_field_and_sourcekey.xml
@@ -1,0 +1,7 @@
+<setup>
+    <generate name="x" count="1" target="">
+        <reference name="slot" source="refdb" sourceType="slots" sourceKey="id">
+            <field target="aisle" sourceKey="aisle"/>
+        </reference>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_composite_reference/test_composite_reference.py
+++ b/tests_ce/integration_tests/test_composite_reference/test_composite_reference.py
@@ -126,3 +126,16 @@ def test_policy_logs_single_process_override():
     finally:
         dm_logger.removeHandler(handler)
     assert any("single-process" in m and "Enterprise" in m for m in messages)
+
+
+@pytest.mark.parametrize(
+    "filename,match",
+    [
+        ("ref_field_and_sourcekey.xml", "sourceKey"),  # sourceKey attr XOR <field> children
+        ("ref_bare.xml", "sourceKey"),  # neither sourceKey nor <field>
+        ("ref_duplicate_sourcekey.xml", "duplicate"),  # two <field> share a sourceKey
+    ],
+)
+def test_composite_reference_invalid_raises(filename, match):
+    with pytest.raises(Exception, match=match):
+        _run(filename, gen="x")


### PR DESCRIPTION
Assert the parser guards that had no test: sourceKey attr together with <field> children, neither sourceKey nor <field>, and duplicate sourceKey across <field>. Parse-time failures, so no DB fixture needed. Mirrors test_composite_unique_exhaustion_raises.