### PR TITLE
fix(unique): finish the cross-page seed fix — generate_worker + varia…

### DIFF
--- a/datamimic_ce/tasks/variable_task.py
+++ b/datamimic_ce/tasks/variable_task.py
@@ -354,8 +354,10 @@ class VariableTask(KeyVariableTask, CommonSubTask):
                 return None
             file_data = ctx.evaluate_python_expression(self._statement.source)
             if loads_all:
+                # Stable per-statement seed (like __init__ above) so a paginated script source stays
+                # consistent across pages for random / cumulated / unique.
                 self._full_load_iterator = self._distributed_iter(
-                    file_data, self._pagination, ctx.root.get_distribution_seed()
+                    file_data, self._pagination, ctx.root.stable_distribution_seed(self._statement.full_name)
                 )
                 self._mode = self._FULL_LOAD_MODE
                 if self._full_load_iterator is None:

--- a/datamimic_ce/workers/generate_worker.py
+++ b/datamimic_ce/workers/generate_worker.py
@@ -182,7 +182,9 @@ class GenerateWorker:
         # Reorder loaded rows for random (shuffle) / cumulated (bell) / unique (distinct,
         # no replacement); ordered is left as-is. All page-window slicing lives in the registry.
         if loads_all:
-            seed = root_context.get_distribution_seed()
+            # Stable per-statement seed so random / cumulated / unique select the SAME global order on
+            # every page (and every worker) -> disjoint page windows -> consistent across pages.
+            seed = root_context.stable_distribution_seed(stmt.full_name)
             if stmt.unique:
                 source_data = DataSourceRegistry.get_unique_data(
                     source_data, pagination, seed, f"<generate> '{stmt.name}'"

--- a/tests_ce/integration_tests/test_distribution_matrix/generate_source_paged.xml
+++ b/tests_ce/integration_tests/test_distribution_matrix/generate_source_paged.xml
@@ -1,0 +1,13 @@
+<setup rngSeed="42" defaultSeparator=",">
+    <!-- Consumer coverage: <generate pageSize="10" source=CSV> honors all three distributions
+         (rows.csv, v = 0..26). Benerator's most common iteration pattern. -->
+    <generate pageSize="10" name="ordered" source="rows.csv" distribution="ordered" count="27" target="">
+        <key name="v" script="v"/>
+    </generate>
+    <generate pageSize="10" name="random" source="rows.csv" distribution="random" count="27" target="">
+        <key name="v" script="v"/>
+    </generate>
+    <generate pageSize="10" name="cumulated" source="rows.csv" distribution="cumulated" count="6000" target="">
+        <key name="v" script="v"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_distribution_matrix/test_distribution_matrix.py
+++ b/tests_ce/integration_tests/test_distribution_matrix/test_distribution_matrix.py
@@ -51,6 +51,9 @@ SOURCE_CASES = [
     ("variable_memstore.xml", 1),
     ("variable_lazy.xml", 0),
     ("generate_source.xml", 0),
+    # <generate source> paged (pageSize < count): the worker-level selection must use a stable
+    # per-statement seed too, else random/cumulated/unique repeat/miss values across pages.
+    ("generate_source_paged.xml", 0),
 ]
 
 


### PR DESCRIPTION
…ble lazy source

The earlier cross-page fix (stable per-statement seed) covered <variable>/<reference> __init__ but MISSED two paginated call sites that still used the advancing get_distribution_seed():
- generate_worker._generate_product_by_page_in_single_process (line 185): a <generate source> with random/cumulated/unique repeated/missed values across pages (empirically 4/5 distinct at pageSize<count).
- variable_task lazy/script-source path (execute, line 358): same bug for a paginated script source.

Both now use root.stable_distribution_seed(stmt.full_name), matching variable_task.__init__ and reference_task. Verified: <generate source unique|random> at pageSize<count is now 5/5 distinct and reproducible.

Not changed: nested_key_task uses get_distribution_seed() with pagination=None (no page window) — the advancing seed there gives deterministic per-parent-row variety, which is intended, not a bug.

Test: a paged <generate source> twin (generate_source_paged.xml) added to the distribution-matrix SOURCE_CASES, so the permutation/bell invariants now run across pages for the worker path too.

Found by a multi-agent consistency/SPOT audit.