### PR TITLE
fix(dsl): MemstoreStatement honors the Statement base contract

### DIFF
--- a/datamimic_ce/statements/memstore_statement.py
+++ b/datamimic_ce/statements/memstore_statement.py
@@ -10,6 +10,7 @@ from datamimic_ce.statements.statement import Statement
 
 class MemstoreStatement(Statement):
     def __init__(self, model: MemstoreModel):
+        super().__init__(name=model.id, parent_stmt=None)  # setup-level; honor the base contract (name = its id)
         self._id = model.id
 
     @property


### PR DESCRIPTION
Call super().__init__(name=id) so _name/_parent_stmt/_full_name exist — same latent base-contract gap as ExecuteStatement. A <memstore> is identified by its id, so name = id.