### PR TITLE
fix(determinism): thread <setup rngSeed> into DateTimeGenerator

### DIFF
--- a/datamimic_ce/domains/common/literal_generators/generator_util.py
+++ b/datamimic_ce/domains/common/literal_generators/generator_util.py
@@ -201,6 +201,11 @@ class GeneratorUtil:
                                 logger.warning(
                                     f"Positional args are not processed for DateTimeGenerator string: {generator_str}"
                                 )
+                            # Seed at construction under <setup rngSeed> (this branch bypasses the eval-path
+                            # rng binding below), unless the DSL already pinned seed=/rng= explicitly.
+                            dt_rng = self._context.root.derive_seeded_rng()
+                            if dt_rng is not None and not {"rng", "seed"} & parsed_constructor_args.keys():
+                                parsed_constructor_args["rng"] = dt_rng
                             result = cls(**parsed_constructor_args)
                             # Use unified cache key for consistency with global cache
                             self._context.root.generators[cache_key] = result

--- a/tests_ce/integration_tests/test_seeded_determinism/datetime_generator.xml
+++ b/tests_ce/integration_tests/test_seeded_determinism/datetime_generator.xml
@@ -1,0 +1,3 @@
+<setup rngSeed="7"><generate name="g" count="8" numProcess="1" target="">
+    <key name="d" generator="DateTimeGenerator(min='2000-01-01 00:00:00', max='2020-12-31 23:59:59')"/>
+</generate></setup>

--- a/tests_ce/integration_tests/test_seeded_determinism/test_seeded_determinism.py
+++ b/tests_ce/integration_tests/test_seeded_determinism/test_seeded_determinism.py
@@ -46,6 +46,7 @@ def _run_twice(filename: str, keys: list[str]) -> tuple[list, list]:
         ("source_random.xml", ["v"]),  # shuffled <generate source>
         ("entity_values.xml", ["v"]),  # entity field (<key values>)
         ("domain_generators.xml", ["given", "email", "phone"]),  # domain generators (names/email/phone)
+        ("datetime_generator.xml", ["d"]),  # DateTimeGenerator (seed threaded through its special parsing)
     ],
 )
 def test_seeded_model_is_reproducible_across_two_runs(filename, keys):
@@ -132,6 +133,7 @@ def test_seeded_domain_generators_reproducible_and_core_count_independent():
         ("unseeded_domain.xml", ["given", "email"]),  # domain generators (names/emails)
         ("unseeded_entity.xml", ["v"]),  # entity field (<key values>)
         ("unseeded_source.xml", ["v"]),  # shuffled <generate source>
+        ("unseeded_datetime.xml", ["d"]),  # DateTimeGenerator without a seed
     ],
 )
 def test_unseeded_generation_is_random(filename, keys):

--- a/tests_ce/integration_tests/test_seeded_determinism/unseeded_datetime.xml
+++ b/tests_ce/integration_tests/test_seeded_determinism/unseeded_datetime.xml
@@ -1,0 +1,1 @@
+<setup><generate name="g" count="10" numProcess="1" target=""><key name="d" generator="DateTimeGenerator(min='2000-01-01 00:00:00', max='2020-12-31 23:59:59')"/></generate></setup>


### PR DESCRIPTION
DateTimeGenerator accepts rng=/seed=, but create_generator's special DateTimeGenerator parsing branch built it with cls(**parsed_args) and returned before the eval-path rng binding ran — so a seeded <setup rngSeed> was ignored and dates were wall-clock random even under a seed. Derive the seeded rng inside that branch and pass it (unless the DSL pinned seed=/rng= explicitly).

Verified by the run-twice principle in the canonical suite: datetime_generator.xml (seeded) replays identically across two runs and still varies; unseeded_datetime.xml differs across two runs. 20 tests pass.