### PR TITLE
feat(domains): tolerant entity field access (Benerator camelCase -> s…

### DIFF
--- a/datamimic_ce/domains/domain_core/base_entity.py
+++ b/datamimic_ce/domains/domain_core/base_entity.py
@@ -28,6 +28,28 @@ class BaseEntity(ABC):
     def field_cache(self):
         return self._field_cache
 
+    @classmethod
+    def _canonical_fields(cls) -> dict[str, str]:
+        """Map each public field, normalized (lowercased, separators removed), to its real name. Cached per
+        class. Lets ``givenName``/``given_name``/``GIVEN_NAME`` all resolve to the canonical ``given_name``."""
+        cache = cls.__dict__.get("_canonical_fields_cache")
+        if cache is None:
+            cache = {a.replace("_", "").lower(): a for a in dir(cls) if not a.startswith("_")}
+            cls._canonical_fields_cache = cache  # type: ignore[attr-defined]
+        return cache
+
+    def __getattr__(self, name: str) -> Any:
+        # Only runs when normal lookup misses: resolve a non-canonical field name (e.g. Benerator's camelCase
+        # ``person.givenName``) to the entity's real snake_case field. Zero cost on the canonical path.
+        if name.startswith("_"):
+            raise AttributeError(name)
+        fields = type(self)._canonical_fields()
+        real = fields.get(name.replace("_", "").lower())
+        if real is not None and real != name:
+            return getattr(self, real)
+        avail = sorted(fields.values())
+        raise AttributeError(f"'{type(self).__name__}' entity has no field '{name}'. Available: {avail}")
+
     @abstractmethod
     def to_dict(self) -> dict[str, Any]:
         """Convert the entity to a dictionary."""

--- a/tests_ce/integration_tests/test_entity_field_compat/entity_field_compat.xml
+++ b/tests_ce/integration_tests/test_entity_field_compat/entity_field_compat.xml
@@ -1,0 +1,11 @@
+<setup rngSeed="9">
+    <!-- Benerator-style camelCase field access on a DATAMIMIC entity resolves to the snake_case field -->
+    <generate name="g" count="5" target="">
+        <variable name="p" entity="Person"/>
+        <variable name="a" entity="Address"/>
+        <key name="given" script="p.givenName"/>
+        <key name="bday" script="p.birthDate"/>
+        <key name="full" script="p.givenName + ' ' + p.familyName"/>
+        <key name="house" script="a.houseNumber"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_entity_field_compat/test_entity_field_compat.py
+++ b/tests_ce/integration_tests/test_entity_field_compat/test_entity_field_compat.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+
+def _run():
+    engine = DataMimicTest(test_dir=Path(__file__).resolve().parent, filename="entity_field_compat.xml",
+                           capture_test_result=True)
+    engine.test_with_timer()
+    return engine.capture_result()["g"]
+
+
+def test_benerator_camelcase_fields_resolve_and_expressions_work():
+    rows = _run()
+    assert len(rows) == 5
+    assert all(r["given"] and r["house"] and r["bday"] for r in rows)  # givenName/houseNumber/birthDate
+    assert all(r["full"] == f"{r['given']} {r['full'].split(' ', 1)[1]}" for r in rows)  # expression evaluated
+
+
+def test_entity_field_compat_seeded_reproducible():
+    keys = ("given", "bday", "full", "house")
+    first = [tuple(r[k] for k in keys) for r in _run()]
+    second = [tuple(r[k] for k in keys) for r in _run()]
+    assert first == second


### PR DESCRIPTION
…nake_case)

Entity field access now resolves a non-canonical name to the entity's real field: person.givenName, person.birthDate, address.houseNumber all reach given_name / birthdate / house_number. BaseEntity.__getattr__ runs ONLY on a lookup miss (zero cost on the canonical path), matches case/separator-insensitively against the class's real fields (cached per class), and raises a helpful 'no field X, available: [...]' otherwise.

This is the clean target for migrating Benerator's composite generators: the converter only renames generator="AddressGenerator" -> entity="Address", and arbitrary script expressions (person.givenName + ' ' + person.familyName) pass through untouched — no Java-side script rewriting, and the field schema stays single-sourced in Python. 31 entity tests pass; camelCase access is seed-reproducible.