### PR TITLE
feat(dsl): distribution + cyclic on <reference>

### DIFF
--- a/datamimic_ce/model/reference_model.py
+++ b/datamimic_ce/model/reference_model.py
@@ -8,12 +8,15 @@
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from datamimic_ce.constants.attribute_constants import (
+    ATTR_CYCLIC,
+    ATTR_DISTRIBUTION,
     ATTR_NAME,
     ATTR_SOURCE,
     ATTR_SOURCE_KEY,
     ATTR_SOURCE_TYPE,
     ATTR_UNIQUE,
 )
+from datamimic_ce.enums.distribution_enums import SourceDistribution
 from datamimic_ce.model.model_util import ModelUtil
 
 
@@ -24,6 +27,10 @@ class ReferenceModel(BaseModel):
     source_key: str | None = Field(default=None, alias=ATTR_SOURCE_KEY)
     source_type: str = Field(alias=ATTR_SOURCE_TYPE)
     unique: bool | None = None
+    # Row-selection shape, same vocabulary as <variable>/<generate>: random (default, with
+    # replacement), ordered (source order, strict unless cyclic), cumulated (bell). cyclic wraps.
+    distribution: str | None = None
+    cyclic: bool | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -36,8 +43,23 @@ class ReferenceModel(BaseModel):
                 ATTR_SOURCE_TYPE,
                 ATTR_SOURCE_KEY,
                 ATTR_UNIQUE,
+                ATTR_DISTRIBUTION,
+                ATTR_CYCLIC,
             },
         )
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_unique_constraints(cls, values: dict):
+        # unique implies distinct random order: incompatible with cyclic/ordered/cumulated.
+        return ModelUtil.check_unique_constraints(values=values)
+
+    @field_validator("distribution")
+    @classmethod
+    def validate_distribution(cls, value):
+        if value is not None:
+            SourceDistribution.coerce(value)  # unknown value -> ValueError at parse time
+        return value
 
     @field_validator("name", "source", "source_type")
     @classmethod

--- a/datamimic_ce/statements/reference_statement.py
+++ b/datamimic_ce/statements/reference_statement.py
@@ -26,6 +26,8 @@ class ReferenceStatement(Statement):
         self._source = model.source
         self._source_type = model.source_type
         self._unique = model.unique
+        self._distribution = model.distribution
+        self._cyclic = model.cyclic
         # Always >= 1: a legacy 'sourceKey' is normalised to a single field by the parser.
         self._fields = fields
 
@@ -45,6 +47,14 @@ class ReferenceStatement(Statement):
     @property
     def unique(self):
         return self._unique
+
+    @property
+    def distribution(self) -> str | None:
+        return self._distribution
+
+    @property
+    def cyclic(self) -> bool | None:
+        return self._cyclic
 
     @property
     def fields(self) -> list[ReferenceField]:

--- a/datamimic_ce/tasks/reference_task.py
+++ b/datamimic_ce/tasks/reference_task.py
@@ -12,6 +12,7 @@ from datamimic_ce.contexts.context import Context
 from datamimic_ce.contexts.geniter_context import GenIterContext
 from datamimic_ce.data_sources.data_source_pagination import DataSourcePagination
 from datamimic_ce.data_sources.data_source_registry import DataSourceRegistry
+from datamimic_ce.enums.distribution_enums import SourceDistribution
 from datamimic_ce.statements.reference_statement import ReferenceStatement
 from datamimic_ce.tasks.task import GenSubTask
 
@@ -55,14 +56,35 @@ class ReferenceTask(GenSubTask):
 
     def _select(self, records: list[dict[str, Any]], ctx: Context) -> list[dict[str, Any]]:
         """Distinct combinations route through the shared DataSourceRegistry.get_unique_data — the
-        same SPOT as <variable>/<generate> unique (dedupe + shuffle + page window + strict). A
-        non-unique reference picks with replacement (a foreign key may repeat the same row), which
-        has no registry counterpart, so it stays here."""
-        if self._statement.unique:
+        same SPOT as <variable>/<generate> unique (dedupe + shuffle + page window + strict). An
+        explicit distribution/cyclic routes through the shared distribution dispatch. The default
+        (no modifier) picks with replacement (a foreign key may repeat the same row), which has no
+        registry counterpart, so it stays here."""
+        stmt = self._statement
+        if stmt.unique:
             # Stable per-statement seed so distinctness holds across pages, not just within one.
-            seed = ctx.root.stable_distribution_seed(self._statement.full_name)
-            return DataSourceRegistry.get_unique_data(
-                records, self._pagination, seed, f"<reference> '{self._statement.name}'"
-            )
+            seed = ctx.root.stable_distribution_seed(stmt.full_name)
+            return DataSourceRegistry.get_unique_data(records, self._pagination, seed, f"<reference> '{stmt.name}'")
+        if stmt.distribution is not None or stmt.cyclic:
+            seed = ctx.root.stable_distribution_seed(stmt.full_name)
+            distribution = SourceDistribution.coerce(stmt.distribution)
+            # Bare cyclic="true" means Benerator's sequential wrap-around, i.e. ordered + cyclic.
+            if distribution is SourceDistribution.ORDERED or (stmt.distribution is None and stmt.cyclic):
+                return self._ordered(records)
+            return DataSourceRegistry.get_distributed_data(records, self._pagination, stmt.cyclic, seed, distribution)
         size = self._pagination.limit if self._pagination is not None else 1
         return [ctx.rng.choice(records) for _ in range(size)]
+
+    def _ordered(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Rows in source order; cyclic wraps around, non-cyclic raises when the page outruns the
+        pool (strict like unique — never silently under-generate)."""
+        start = self._pagination.skip if self._pagination is not None else 0
+        size = self._pagination.limit if self._pagination is not None else 1
+        if self._statement.cyclic:
+            return [records[(start + i) % len(records)] for i in range(size)]
+        if start + size > len(records):
+            raise ValueError(
+                f"<reference> '{self._statement.name}' distribution='ordered' needs {start + size} rows "
+                f'but the source has only {len(records)} (use cyclic="true" to wrap around)'
+            )
+        return records[start : start + size]

--- a/tests_ce/integration_tests/test_reference_distribution/ref_cumulated.xml
+++ b/tests_ce/integration_tests/test_reference_distribution/ref_cumulated.xml
@@ -1,0 +1,8 @@
+<setup rngSeed="11">
+    <database id="refdb" database="ref_dist_db" dbms="sqlite"/>
+    <execute uri="script/setup_items.scr.sql" target="refdb"/>
+    <!-- cumulated: bell-weighted selection with replacement (middle of the order favored) -->
+    <generate name="events" count="40" target="">
+        <reference name="fk" source="refdb" sourceType="items" sourceKey="id" distribution="cumulated"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_reference_distribution/ref_cyclic.xml
+++ b/tests_ce/integration_tests/test_reference_distribution/ref_cyclic.xml
@@ -1,0 +1,8 @@
+<setup rngSeed="11">
+    <database id="refdb" database="ref_dist_db" dbms="sqlite"/>
+    <execute uri="script/setup_items.scr.sql" target="refdb"/>
+    <!-- cyclic reference: rows in stable source order, wrapping around -->
+    <generate name="events" count="10" target="">
+        <reference name="fk" source="refdb" sourceType="items" sourceKey="id" cyclic="true"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_reference_distribution/ref_ordered.xml
+++ b/tests_ce/integration_tests/test_reference_distribution/ref_ordered.xml
@@ -1,0 +1,8 @@
+<setup rngSeed="11">
+    <database id="refdb" database="ref_dist_db" dbms="sqlite"/>
+    <execute uri="script/setup_items.scr.sql" target="refdb"/>
+    <!-- ordered, within the pool: the first 3 rows in stable source order -->
+    <generate name="events" count="3" target="">
+        <reference name="fk" source="refdb" sourceType="items" sourceKey="id" distribution="ordered"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_reference_distribution/ref_ordered_exhausted.xml
+++ b/tests_ce/integration_tests/test_reference_distribution/ref_ordered_exhausted.xml
@@ -1,0 +1,8 @@
+<setup rngSeed="11">
+    <database id="refdb" database="ref_dist_db" dbms="sqlite"/>
+    <execute uri="script/setup_items.scr.sql" target="refdb"/>
+    <!-- ordered without cyclic outruns the 4-row pool: must raise, never under-generate -->
+    <generate name="events" count="9" target="">
+        <reference name="fk" source="refdb" sourceType="items" sourceKey="id" distribution="ordered"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_reference_distribution/ref_unique_cyclic_invalid.xml
+++ b/tests_ce/integration_tests/test_reference_distribution/ref_unique_cyclic_invalid.xml
@@ -1,0 +1,8 @@
+<setup rngSeed="11">
+    <database id="refdb" database="ref_dist_db" dbms="sqlite"/>
+    <execute uri="script/setup_items.scr.sql" target="refdb"/>
+    <!-- unique (no-repeat) contradicts cyclic (repeat): parse error -->
+    <generate name="events" count="4" target="">
+        <reference name="fk" source="refdb" sourceType="items" sourceKey="id" unique="true" cyclic="true"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_reference_distribution/script/setup_items.scr.sql
+++ b/tests_ce/integration_tests/test_reference_distribution/script/setup_items.scr.sql
@@ -1,0 +1,7 @@
+-- reference-distribution fixture: 4 rows, stable fetch order = ORDER BY id -> 1,2,3,4.
+DROP TABLE IF EXISTS items;
+CREATE TABLE items (id INTEGER);
+INSERT INTO items (id) VALUES (3);
+INSERT INTO items (id) VALUES (1);
+INSERT INTO items (id) VALUES (4);
+INSERT INTO items (id) VALUES (2);

--- a/tests_ce/integration_tests/test_reference_distribution/test_reference_distribution.py
+++ b/tests_ce/integration_tests/test_reference_distribution/test_reference_distribution.py
@@ -1,0 +1,53 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# See LICENSE file for the full text of the license.
+
+"""<reference> distribution/cyclic: ordered rotation, cumulated bell selection —
+the Benerator reference modifiers, reusing the shared SourceDistribution dispatch."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+_TEST_DIR = Path(__file__).resolve().parent
+
+
+def _run(filename: str) -> list[dict]:
+    engine = DataMimicTest(test_dir=_TEST_DIR, filename=filename, capture_test_result=True)
+    engine.test_with_timer()
+    return engine.capture_result()["events"]
+
+
+def test_cyclic_reference_rotates_in_source_order():
+    ids = [r["fk"] for r in _run("ref_cyclic.xml")]
+    assert ids == [1, 2, 3, 4, 1, 2, 3, 4, 1, 2]  # stable fetch order, wrapped
+    assert ids == [r["fk"] for r in _run("ref_cyclic.xml")]  # seeded-reproducible
+
+
+def test_ordered_reference_within_pool():
+    assert [r["fk"] for r in _run("ref_ordered.xml")] == [1, 2, 3]
+
+
+def test_ordered_reference_exhausted_raises():
+    with pytest.raises(Exception, match=r"ordered.*only has|only 4|cyclic"):
+        _run("ref_ordered_exhausted.xml")
+
+
+def test_cumulated_reference_bell_shaped_and_reproducible():
+    ids = [r["fk"] for r in _run("ref_cumulated.xml")]
+    assert len(ids) == 40
+    assert set(ids) <= {1, 2, 3, 4}
+    counts = Counter(ids)
+    # Bell over indices 0..3 (mean 1.5): the middle rows must dominate the extremes combined-wise.
+    assert counts[2] + counts[3] > counts[1] + counts[4]
+    assert ids == [r["fk"] for r in _run("ref_cumulated.xml")]  # seeded-reproducible
+
+
+def test_unique_with_cyclic_is_a_parse_error():
+    with pytest.raises(Exception, match=r"unique.*cyclic|cyclic.*unique"):
+        _run("ref_unique_cyclic_invalid.xml")

--- a/tests_ce/unit_tests/tasks/test_reference_task.py
+++ b/tests_ce/unit_tests/tasks/test_reference_task.py
@@ -26,6 +26,9 @@ class TestReferenceTask(unittest.TestCase):
         self.statement.targets = ["test_name"]
         self.statement.is_composite = False
         self.statement.name = "test_name"
+        # No selection modifier: default with-replacement path (spec-mocked attrs are truthy otherwise).
+        self.statement.distribution = None
+        self.statement.cyclic = None
         self.pagination = MagicMock(spec=DataSourcePagination)
         self.pagination.limit = 2
         self.pagination.skip = 0


### PR DESCRIPTION
## What

`<reference sourceType="items" sourceKey="id" distribution="ordered|cumulated" cyclic="true"/>`

- **ordered**: rows in the stable fetch order; strict error when the page outruns the pool — unless `cyclic="true"` wraps around. Bare `cyclic="true"` = ordered wrap (Benerator semantics).
- **cumulated**: seeded bell-weighted selection (shared `get_cumulated_data`).
- Default stays exactly as today (with-replacement random pick) — no behavior change without a modifier.
- `unique` remains random-only via the shared `check_unique_constraints` (unique+cyclic → parse error).

Reuses the existing `SourceDistribution` dispatch used by `<variable>`/`<generate>`/`<nestedKey>` — no new sampler.

## Why

Closes the `<reference>`-modifier migration gap (56 corpus occurrences in the Benerator→DATAMIMIC converter sweep); equally useful for hand-written FK models (round-robin FK assignment, realistic middle-heavy FK usage).

## Tests

`tests_ce/integration_tests/test_reference_distribution/` — 5 DSL-XML cases: cyclic rotation (seeded-reproducible), ordered within pool, ordered exhausted raises, cumulated bell + reproducible, unique+cyclic parse error. Full reference suites (18) green; mypy unchanged (pre-existing optional ray stubs only).