### PR TITLE
feat(exporters): SQL update/upsert/delete dot-notation targets

### DIFF
--- a/datamimic_ce/clients/rdbms_client.py
+++ b/datamimic_ce/clients/rdbms_client.py
@@ -166,8 +166,11 @@ class RdbmsClient(DatabaseClient):
         :param data_list: List of dictionaries representing rows to be processed.
         :return: The transformed data list.
         """
-        # Get the list of columns where None values should be converted to NULL
-        none_as_null_col = [col.strip() for col in getattr(self._credential, "none_as_null_col", "").split(",")]
+        # Get the list of columns where None values should be converted to NULL.
+        # Filter empties: "".split(",") is [""] and would inject a bogus ''-keyed column into every row.
+        none_as_null_col = [
+            col.strip() for col in getattr(self._credential, "none_as_null_col", "").split(",") if col.strip()
+        ]
         # Convert None values to SQLAlchemy NULL
         if len(none_as_null_col) > 0:
             for idx, data_dict in enumerate(data_list):
@@ -393,6 +396,71 @@ class RdbmsClient(DatabaseClient):
                 connection.execute(table.insert(), data_list)
             except Exception as err:
                 raise RuntimeError(f"Error when writing data to RDBMS: {err}") from err
+
+    def _table_and_pk(self, engine, table_name: str):
+        """Reflected table + its primary-key column names. update/upsert/delete key on the PK;
+        a table without one is a configuration error (never silently fall back to insert)."""
+        table = self._get_metadata(engine).tables[self._get_actual_table_name(table_name)]
+        pk = [c.name for c in table.primary_key.columns]
+        if not pk:
+            raise ValueError(
+                f"Table '{table_name}' has no primary key - update/upsert/delete need one to match rows"
+            )
+        return table, pk
+
+    @staticmethod
+    def _pk_clause(table, row: dict, pk: list[str], table_name: str, operation: str):
+        missing = [k for k in pk if k not in row]
+        if missing:
+            raise ValueError(f"{operation} on '{table_name}' requires primary-key value(s) {missing} in each record")
+        return [table.c[k] == row[k] for k in pk]
+
+    def update(self, table_name: str, data_list: list) -> int:
+        """UPDATE each record by primary key; returns the number of matched rows.
+        Row-by-row statements: test-data volumes, not a bulk path."""
+        if not data_list:
+            return 0
+        engine = self._create_engine()
+        table, pk = self._table_and_pk(engine, table_name)
+        matched = 0
+        with engine.begin() as connection:
+            for row in self._apply_global_json_config(data_list):
+                values = {k: v for k, v in row.items() if k not in pk}
+                if not values:
+                    raise ValueError(f"update on '{table_name}' has no non-key columns to set")
+                clause = self._pk_clause(table, row, pk, table_name, "update")
+                matched += connection.execute(table.update().where(*clause).values(**values)).rowcount
+        return matched
+
+    def upsert(self, table_name: str, data_list: list) -> None:
+        """UPDATE by primary key, INSERT the rows that matched nothing."""
+        if not data_list:
+            return
+        engine = self._create_engine()
+        table, pk = self._table_and_pk(engine, table_name)
+        with engine.begin() as connection:
+            for row in self._apply_global_json_config(data_list):
+                clause = self._pk_clause(table, row, pk, table_name, "upsert")
+                values = {k: v for k, v in row.items() if k not in pk}
+                if values:
+                    exists = connection.execute(table.update().where(*clause).values(**values)).rowcount > 0
+                else:  # all-PK row: nothing to update, just ensure presence
+                    exists = connection.execute(select(table.c[pk[0]]).where(*clause)).first() is not None
+                if not exists:
+                    connection.execute(table.insert(), [row])
+
+    def delete(self, table_name: str, data_list: list) -> int:
+        """DELETE each record by primary key; returns the number of deleted rows."""
+        if not data_list:
+            return 0
+        engine = self._create_engine()
+        table, pk = self._table_and_pk(engine, table_name)
+        deleted = 0
+        with engine.begin() as connection:
+            for row in self._apply_global_json_config(data_list):
+                clause = self._pk_clause(table, row, pk, table_name, "delete")
+                deleted += connection.execute(table.delete().where(*clause)).rowcount
+        return deleted
 
     def _get_actual_table_name(self, table_name: str) -> str:
         """

--- a/datamimic_ce/exporters/database_exporter.py
+++ b/datamimic_ce/exporters/database_exporter.py
@@ -26,7 +26,27 @@ class DatabaseExporter(Exporter):
         if not data:
             return
 
-        if len(rest) > 0 and isinstance(rest[0], dict):
-            name = rest[0].get("type", name)
+        self._client.insert(self._table_name(name, rest), data)
 
-        self._client.insert(name, data)
+    def update(self, product: tuple) -> int:
+        """UPDATE rows by primary key (target="db.update"). Returns the matched-row count."""
+        name, data, *rest = product
+        return self._client.update(self._table_name(name, rest), data) if data else 0
+
+    def upsert(self, product: tuple) -> None:
+        """UPDATE by primary key, INSERT what matched nothing (target="db.upsert")."""
+        name, data, *rest = product
+        if data:
+            self._client.upsert(self._table_name(name, rest), data)
+
+    def delete(self, product: tuple) -> int:
+        """DELETE rows by primary key (target="db.delete"). Returns the deleted-row count."""
+        name, data, *rest = product
+        return self._client.delete(self._table_name(name, rest), data) if data else 0
+
+    @staticmethod
+    def _table_name(name: str, rest: list) -> str:
+        # A type="..." attribute overrides the generate name as the target table (same as consume).
+        if rest and isinstance(rest[0], dict):
+            return rest[0].get("type", name)
+        return name

--- a/tests_ce/integration_tests/test_sql_crud_targets/sql_delete.xml
+++ b/tests_ce/integration_tests/test_sql_crud_targets/sql_delete.xml
@@ -1,0 +1,15 @@
+<setup>
+    <database id="db" database="sql_crud_delete_db" dbms="sqlite"/>
+    <execute type="sql" target="db">
+        DROP TABLE IF EXISTS customers;
+        CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT, tier TEXT);
+        INSERT INTO customers VALUES (1, 'a', 'bronze');
+        INSERT INTO customers VALUES (2, 'b', 'bronze');
+        INSERT INTO customers VALUES (3, 'c', 'silver');
+        INSERT INTO customers VALUES (4, 'd', 'silver');
+        INSERT INTO customers VALUES (5, 'e', 'gold');
+    </execute>
+    <!-- delete the bronze rows by primary key -->
+    <generate name="customers" source="db" selector="SELECT id FROM customers WHERE tier = 'bronze'" target="db.delete"/>
+    <generate name="check" source="db" selector="SELECT id FROM customers ORDER BY id" distribution="ordered" target=""/>
+</setup>

--- a/tests_ce/integration_tests/test_sql_crud_targets/sql_update.xml
+++ b/tests_ce/integration_tests/test_sql_crud_targets/sql_update.xml
@@ -1,0 +1,15 @@
+<setup>
+    <database id="db" database="sql_crud_update_db" dbms="sqlite"/>
+    <execute type="sql" target="db">
+        DROP TABLE IF EXISTS customers;
+        CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT, tier TEXT);
+        INSERT INTO customers VALUES (1, 'a', 'bronze');
+        INSERT INTO customers VALUES (2, 'b', 'bronze');
+        INSERT INTO customers VALUES (3, 'c', 'silver');
+    </execute>
+    <!-- read every row, change its tier, write back via UPDATE (row count must stay 3) -->
+    <generate name="customers" source="db" selector="SELECT id, name, tier FROM customers" target="db.update">
+        <key name="tier" constant="gold"/>
+    </generate>
+    <generate name="check" source="db" selector="SELECT id, name, tier FROM customers ORDER BY id" distribution="ordered" target=""/>
+</setup>

--- a/tests_ce/integration_tests/test_sql_crud_targets/sql_update_no_pk.xml
+++ b/tests_ce/integration_tests/test_sql_crud_targets/sql_update_no_pk.xml
@@ -1,0 +1,12 @@
+<setup>
+    <database id="db" database="sql_crud_nopk_db" dbms="sqlite"/>
+    <execute type="sql" target="db">
+        DROP TABLE IF EXISTS logs;
+        CREATE TABLE logs (msg TEXT);
+        INSERT INTO logs VALUES ('x');
+    </execute>
+    <!-- no primary key: update must fail loudly, never silently insert -->
+    <generate name="logs" source="db" selector="SELECT msg FROM logs" target="db.update">
+        <key name="msg" constant="rewritten"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_sql_crud_targets/sql_upsert.xml
+++ b/tests_ce/integration_tests/test_sql_crud_targets/sql_upsert.xml
@@ -1,0 +1,17 @@
+<setup>
+    <database id="db" database="sql_crud_upsert_db" dbms="sqlite"/>
+    <execute type="sql" target="db">
+        DROP TABLE IF EXISTS customers;
+        CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT, tier TEXT);
+        INSERT INTO customers VALUES (1, 'a', 'bronze');
+        INSERT INTO customers VALUES (2, 'b', 'bronze');
+        INSERT INTO customers VALUES (3, 'c', 'silver');
+    </execute>
+    <!-- ids 1..5: 1-3 exist (updated), 4-5 do not (inserted) -->
+    <generate name="customers" count="5" target="db.upsert">
+        <key name="id" generator="IncrementGenerator"/>
+        <key name="name" script="'n' + str(id)"/>
+        <key name="tier" constant="upserted"/>
+    </generate>
+    <generate name="check" source="db" selector="SELECT id, name, tier FROM customers ORDER BY id" distribution="ordered" target=""/>
+</setup>

--- a/tests_ce/integration_tests/test_sql_crud_targets/test_sql_crud_targets.py
+++ b/tests_ce/integration_tests/test_sql_crud_targets/test_sql_crud_targets.py
@@ -1,0 +1,46 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# See LICENSE file for the full text of the license.
+
+"""SQL dot-notation targets: target="db.update|upsert|delete" keyed on the table's primary key —
+the SQL counterpart of the existing mongodb.update/upsert/delete targets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+_TEST_DIR = Path(__file__).resolve().parent
+
+
+def _run(filename: str) -> dict:
+    engine = DataMimicTest(test_dir=_TEST_DIR, filename=filename, capture_test_result=True)
+    engine.test_with_timer()
+    return engine.capture_result()
+
+
+def test_db_update_changes_rows_count_constant():
+    check = _run("sql_update.xml")["check"]
+    assert len(check) == 3  # UPDATE, not insert: row count unchanged
+    assert [r["tier"] for r in check] == ["gold", "gold", "gold"]
+    assert [r["name"] for r in check] == ["a", "b", "c"]  # untouched column preserved
+
+
+def test_db_upsert_updates_existing_and_inserts_new():
+    check = _run("sql_upsert.xml")["check"]
+    assert [r["id"] for r in check] == [1, 2, 3, 4, 5]
+    assert all(r["tier"] == "upserted" for r in check)
+    assert [r["name"] for r in check] == ["n1", "n2", "n3", "n4", "n5"]
+
+
+def test_db_delete_removes_rows_by_pk():
+    check = _run("sql_delete.xml")["check"]
+    assert [r["id"] for r in check] == [3, 4, 5]  # bronze rows (1, 2) deleted
+
+
+def test_db_update_without_primary_key_raises():
+    with pytest.raises(Exception, match=r"no primary key"):
+        _run("sql_update_no_pk.xml")


### PR DESCRIPTION
## What

`target="db.update"`, `target="db.upsert"`, `target="db.delete"` for RDBMS targets — the SQL counterpart of the existing `mongodb.update/upsert/delete` dot-notation (parser + dispatch were already generic; only the SQL side was missing).

- Rows are matched on the table's **reflected primary key**. A table without a PK, or a record missing a PK value, raises — never a silent insert fallback.
- `upsert` = UPDATE by PK, INSERT what matched nothing.
- `update`/`delete` return matched/deleted counts.
- Row-by-row statements — test-data volumes, not a bulk path.

## Bug fix included

`_apply_global_json_config` injected a bogus `''`-keyed column into every row when `none_as_null_col` was unset (`''.split(',') == ['']`). Harmless for insert's executemany, fatal for update's compiler. Fixed at the shared source.

## Why

Closes the update/insert-consumer migration gap (`db.updater()`, 15 corpus occurrences in the Benerator→DATAMIMIC converter) and gives hand-written descriptors DB-mutation flows (seed vs. update existing data).

## Tests

`tests_ce/integration_tests/test_sql_crud_targets/` — 4 DSL-XML cases against SQLite (same SQLAlchemy path as postgres/mysql): update keeps row count + untouched columns, upsert updates 3 + inserts 2, delete by PK, update without PK raises. Postgres-backed `test_functional_page_process` suite green under `RUNTIME_ENVIRONMENT=development` (insert path unaffected by the fix). mypy unchanged.