### PR TITLE
fix(dsl): reference distribution edge cases — nested rotation, explicit random

### DIFF
--- a/datamimic_ce/tasks/reference_task.py
+++ b/datamimic_ce/tasks/reference_task.py
@@ -4,6 +4,7 @@
 # See LICENSE file for the full text of the license.
 # For questions and support, contact: info@rapiddweller.com
 
+import itertools
 from collections.abc import Iterator
 from typing import Any
 
@@ -31,7 +32,18 @@ class ReferenceTask(GenSubTask):
     def execute(self, ctx: Context):
         """Generate a (composite) reference record from an RDBMS data source."""
         if self._iterator is None:
-            self._iterator = self._init_iterator(ctx)
+            if self._pagination is None and self._has_selection_modifier():
+                # Without a page window the task may be rebuilt per record (nested in
+                # <condition>/<while>), so the rotation lives in the root context — an endless
+                # cycle over the selected order — instead of dying with the task instance.
+                key = f"<reference>-cycle|{self._statement.full_name}"
+                shared = ctx.root.generators.get(key)
+                if shared is None:
+                    shared = itertools.cycle(self._init_iterator(ctx))
+                    ctx.root.generators[key] = shared
+                self._iterator = shared
+            else:
+                self._iterator = self._init_iterator(ctx)
         try:
             record = next(self._iterator)
         except StopIteration:
@@ -42,6 +54,15 @@ class ReferenceTask(GenSubTask):
                 ctx.add_current_product_field(target, value)
         # Legacy single-field references return the scalar; composite ones return the record.
         return record[self._statement.targets[0]] if not self._statement.is_composite else record
+
+    def _has_selection_modifier(self) -> bool:
+        """True when distribution/cyclic explicitly shape the selection (vs. the random default)."""
+        stmt = self._statement
+        if stmt.cyclic:
+            return True
+        return stmt.distribution is not None and SourceDistribution.coerce(stmt.distribution) is not (
+            SourceDistribution.RANDOM
+        )
 
     def _init_iterator(self, ctx: Context) -> Iterator[dict[str, Any]]:
         client = ctx.root.clients.get(self.statement.source)
@@ -65,21 +86,27 @@ class ReferenceTask(GenSubTask):
             # Stable per-statement seed so distinctness holds across pages, not just within one.
             seed = ctx.root.stable_distribution_seed(stmt.full_name)
             return DataSourceRegistry.get_unique_data(records, self._pagination, seed, f"<reference> '{stmt.name}'")
-        if stmt.distribution is not None or stmt.cyclic:
+        distribution = SourceDistribution.coerce(stmt.distribution)
+        if (stmt.distribution is not None and distribution is not SourceDistribution.RANDOM) or stmt.cyclic:
             seed = ctx.root.stable_distribution_seed(stmt.full_name)
-            distribution = SourceDistribution.coerce(stmt.distribution)
             # Bare cyclic="true" means Benerator's sequential wrap-around, i.e. ordered + cyclic.
             if distribution is SourceDistribution.ORDERED or (stmt.distribution is None and stmt.cyclic):
                 return self._ordered(records)
             return DataSourceRegistry.get_distributed_data(records, self._pagination, stmt.cyclic, seed, distribution)
+        # Default AND explicit distribution="random": pick with replacement (documented FK semantics).
         size = self._pagination.limit if self._pagination is not None else 1
         return [ctx.rng.choice(records) for _ in range(size)]
 
     def _ordered(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Rows in source order; cyclic wraps around, non-cyclic raises when the page outruns the
         pool (strict like unique — never silently under-generate)."""
-        start = self._pagination.skip if self._pagination is not None else 0
-        size = self._pagination.limit if self._pagination is not None else 1
+        if self._pagination is None:
+            # No page window (e.g. a reference nested in <if>/<while>): serve the full order; the
+            # iterator wraps on reset, so rotation still advances instead of pinning to row 0.
+            # Strictness needs a window, so the non-cyclic overrun check only runs when paginated.
+            return records
+        start = self._pagination.skip
+        size = self._pagination.limit
         if self._statement.cyclic:
             return [records[(start + i) % len(records)] for i in range(size)]
         if start + size > len(records):

--- a/tests_ce/integration_tests/test_reference_distribution/ref_cyclic_nested.xml
+++ b/tests_ce/integration_tests/test_reference_distribution/ref_cyclic_nested.xml
@@ -1,0 +1,13 @@
+<setup rngSeed="11">
+    <database id="refdb" database="ref_dist_db" dbms="sqlite"/>
+    <execute uri="script/setup_items.scr.sql" target="refdb"/>
+    <!-- reference nested in a condition gets no page window (pagination=None):
+         rotation must still advance instead of pinning to the first row -->
+    <generate name="events" count="6" target="">
+        <condition>
+            <if condition="True">
+                <reference name="fk" source="refdb" sourceType="items" sourceKey="id" cyclic="true"/>
+            </if>
+        </condition>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_reference_distribution/test_reference_distribution.py
+++ b/tests_ce/integration_tests/test_reference_distribution/test_reference_distribution.py
@@ -51,3 +51,9 @@ def test_cumulated_reference_bell_shaped_and_reproducible():
 def test_unique_with_cyclic_is_a_parse_error():
     with pytest.raises(Exception, match=r"unique.*cyclic|cyclic.*unique"):
         _run("ref_unique_cyclic_invalid.xml")
+
+
+def test_cyclic_reference_nested_in_condition_still_rotates():
+    # Nested tasks get pagination=None: rotation must advance, not pin to row 0.
+    ids = [r["fk"] for r in _run("ref_cyclic_nested.xml")]
+    assert ids == [1, 2, 3, 4, 1, 2]


### PR DESCRIPTION
Follow-up to #164 (the fix commit landed on the branch after the squash-merge).

## Fixes

1. **Rotation pinned to row 0 when nested.** A `<reference cyclic="true">` inside `<condition>`/`<while>` gets no page window and its task is rebuilt per record, so the iterator state died with each task instance — every record received the first row. The rotation now lives in the root context as an endless `itertools.cycle` over the selected order and survives task recreation.
2. **Explicit `distribution="random"` behaved differently from the default.** It silently switched to a shuffle permutation; it now behaves exactly like the documented default (with-replacement FK pick).

## Tests

New DSL case `ref_cyclic_nested.xml`: cyclic reference nested in a `<condition>` must yield `[1,2,3,4,1,2]` (was `[1,1,1,1,1,1]`). Full reference suites (27) green; ruff/format/mypy clean.