### PR TITLE
fix(sources): empty CSV is an empty source, not an IndexError

### DIFF
--- a/datamimic_ce/utils/file_util.py
+++ b/datamimic_ce/utils/file_util.py
@@ -67,6 +67,8 @@ class FileUtil:
         Read data from csv and parse into list of dict
         """
         raw_data = FileUtil._read_raw_csv(file_path, separator, encoding)
+        if not raw_data:
+            return []  # an empty CSV is an empty source, not a crash
         header = raw_data[0]
         processed_data = [dict(zip(header, row, strict=False)) for row in raw_data[1:]]
         return processed_data

--- a/tests_ce/integration_tests/test_empty_csv_source/empty_csv_source.xml
+++ b/tests_ce/integration_tests/test_empty_csv_source/empty_csv_source.xml
@@ -1,0 +1,4 @@
+<setup>
+    <!-- an empty CSV is an empty source: zero records, not an IndexError -->
+    <generate name="g" source="empty.csv" target=""/>
+</setup>

--- a/tests_ce/integration_tests/test_empty_csv_source/test_empty_csv_source.py
+++ b/tests_ce/integration_tests/test_empty_csv_source/test_empty_csv_source.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+
+def test_empty_csv_source_yields_zero_records():
+    engine = DataMimicTest(
+        test_dir=Path(__file__).resolve().parent, filename="empty_csv_source.xml", capture_test_result=True
+    )
+    engine.test_with_timer()
+    assert engine.capture_result().get("g", []) == []


### PR DESCRIPTION
`read_csv_to_dict_list` crashed with `IndexError: list index out of range` on a zero-byte CSV (`header = raw_data[0]`). Iterating an empty CSV now yields zero records — matching Benerator's semantics for the same descriptor (found via the migration corpus: `demo/file/empty_csv`).

DSL test: `tests_ce/integration_tests/test_empty_csv_source/` — `<generate source="empty.csv">` over a zero-byte file yields `[]` and the run stays green.