### PR TITLE
feat(dsl): 'this' / 'parent' / 'root' scope aliases in scripts

### DIFF
--- a/datamimic_ce/contexts/context.py
+++ b/datamimic_ce/contexts/context.py
@@ -122,7 +122,8 @@ class Context(ABC):
             data_dict.update(current_context.root.properties)
 
         # Update data_dict with current context's variables and products
-        data_dict.update(self.get_content_variables_products(current_context))
+        content_tree = self.get_content_variables_products(current_context)
+        data_dict.update(content_tree)
 
         # Evaluate python expression, use dict of products and variables as local namespace
         # Convert namespace dict to dotable dict
@@ -130,11 +131,19 @@ class Context(ABC):
             if isinstance(value, dict):
                 data_dict[key] = DotableDict(value)
 
-        # `this` = the current content scope (this.field == field), so a script can address the record it
-        # belongs to explicitly. Mirrors the DATAMIMIC EE `this` alias; bound last so it always reflects the
-        # live current_variables/current_product (sibling fields generated so far are visible via this.*).
+        # Canonical scope aliases, mirroring DATAMIMIC EE (bound only when not already a user name):
+        #  - `this`: the current content scope, so `this.field` == bare `field` (essential in nested
+        #    scopes where a bare sibling name is wrapped under the scope name and does not resolve).
+        #  - `parent`: the immediate parent generate/nestedKey scope.
+        #  - `root`: the full merged content tree from the outermost scope down (root.<field> / root.<name>.<field>).
         if "this" not in data_dict:
             data_dict["this"] = DotableDict(self._current_scope())
+        if "parent" not in data_dict:
+            parent_scope = self._parent_scope()
+            if parent_scope:
+                data_dict["parent"] = DotableDict(parent_scope)
+        if "root" not in data_dict:
+            data_dict["root"] = DotableDict(dict(content_tree))
 
         # Evaluate expression
         try:
@@ -230,6 +239,18 @@ class Context(ABC):
             return {**self.current_variables, **self.current_product}
         if isinstance(self, SetupContext):
             return {**self.namespace, **self.global_variables}
+        return {}
+
+    def _parent_scope(self) -> dict:
+        """The immediate parent scope for the ``parent`` alias: the parent generate/nestedKey's
+        variables + products. Empty when there is no enclosing generate scope (top-level = setup parent)."""
+        from datamimic_ce.contexts.geniter_context import GenIterContext
+
+        if not isinstance(self, GenIterContext):
+            return {}
+        parent = self.parent
+        if isinstance(parent, GenIterContext):
+            return {**parent.current_variables, **parent.current_product}
         return {}
 
     @staticmethod

--- a/datamimic_ce/contexts/context.py
+++ b/datamimic_ce/contexts/context.py
@@ -130,6 +130,12 @@ class Context(ABC):
             if isinstance(value, dict):
                 data_dict[key] = DotableDict(value)
 
+        # `this` = the current content scope (this.field == field), so a script can address the record it
+        # belongs to explicitly. Mirrors the DATAMIMIC EE `this` alias; bound last so it always reflects the
+        # live current_variables/current_product (sibling fields generated so far are visible via this.*).
+        if "this" not in data_dict:
+            data_dict["this"] = DotableDict(self._current_scope())
+
         # Evaluate expression
         try:
             result = eval(expr, SAFE_GLOBALS, data_dict)
@@ -212,6 +218,19 @@ class Context(ABC):
         except Exception as e:
             #  Keep error reporting consistent; avoid extra stdout noise from traceback.print_exc()
             raise ValueError(f"Failed while evaluate '{expr}': {str(e)}") from e
+
+    def _current_scope(self) -> dict:
+        """The current content scope for the ``this`` alias: ``this.field`` resolves to the same value as
+        bare ``field``. In a generate/iterate that is the record's variables + products (products win on a
+        name clash); at setup level it is the setup namespace + global variables."""
+        from datamimic_ce.contexts.geniter_context import GenIterContext
+        from datamimic_ce.contexts.setup_context import SetupContext
+
+        if isinstance(self, GenIterContext):
+            return {**self.current_variables, **self.current_product}
+        if isinstance(self, SetupContext):
+            return {**self.namespace, **self.global_variables}
+        return {}
 
     @staticmethod
     def get_content_variables_products(current_context: Context) -> dict:

--- a/tests_ce/integration_tests/test_this_scope/test_this_nested.py
+++ b/tests_ce/integration_tests/test_this_scope/test_this_nested.py
@@ -11,28 +11,23 @@ def _run():
     return engine.capture_result()
 
 
-def test_this_binds_to_current_scope_at_every_nesting_level():
-    result = _run()
-    companies = result["company"]
+def test_scope_aliases_bind_at_every_nesting_level():
+    companies = _run()["company"]
     assert len(companies) == 2
 
     for c in companies:
-        # outermost <generate>: this = company scope
-        assert c["c_self"] == c["cid"]
+        # outermost <generate>: this and root both point at the top scope
+        assert c["c_self"] == c["cid"]  # this.cid
+        assert c["c_root"] == c["cid"]  # root.cid
 
-        # nestedKey(dict): this = dept scope (own sibling), and the flat outermost field stays visible
+        # nestedKey(dict): this = dept scope, parent = company, root = outermost company
         dept = c["dept"]
-        assert dept["d_self"] == dept["did"]
-        assert dept["d_from_company"] == c["cbase"]
+        assert dept["d_self"] == dept["did"]  # this.did
+        assert dept["d_parent"] == c["cbase"]  # parent.cbase (company)
+        assert dept["d_root"] == c["cbase"]  # root.cbase
 
-        # deeper nestedKey(dict): this = team scope; the outermost company field is still flat-visible
+        # deeper nestedKey(dict): this = team, parent = dept, root = outermost company
         team = dept["team"]
-        assert team["t_self"] == team["tid"] == 99
-        assert team["t_from_company"] == c["cbase"]
-
-    # nested <generate> (list stream): this = each staff row's own scope
-    staff = result["staff"]
-    assert len(staff) == 4
-    for s in staff:
-        assert s["slabel"] == s["sidx"] * 1000  # this.sidx in a nested generate
-        assert s["s_self"] == s["slabel"]  # this.slabel
+        assert team["t_self"] == team["tid"] == 99  # this.tid
+        assert team["t_parent"] == dept["did"]  # parent.did (dept)
+        assert team["t_root"] == c["cid"]  # root.cid (company)

--- a/tests_ce/integration_tests/test_this_scope/test_this_nested.py
+++ b/tests_ce/integration_tests/test_this_scope/test_this_nested.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+
+def _run():
+    engine = DataMimicTest(
+        test_dir=Path(__file__).resolve().parent, filename="this_nested.xml", capture_test_result=True
+    )
+    engine.test_with_timer()
+    return engine.capture_result()
+
+
+def test_this_binds_to_current_scope_at_every_nesting_level():
+    result = _run()
+    companies = result["company"]
+    assert len(companies) == 2
+
+    for c in companies:
+        # outermost <generate>: this = company scope
+        assert c["c_self"] == c["cid"]
+
+        # nestedKey(dict): this = dept scope (own sibling), and the flat outermost field stays visible
+        dept = c["dept"]
+        assert dept["d_self"] == dept["did"]
+        assert dept["d_from_company"] == c["cbase"]
+
+        # deeper nestedKey(dict): this = team scope; the outermost company field is still flat-visible
+        team = dept["team"]
+        assert team["t_self"] == team["tid"] == 99
+        assert team["t_from_company"] == c["cbase"]
+
+    # nested <generate> (list stream): this = each staff row's own scope
+    staff = result["staff"]
+    assert len(staff) == 4
+    for s in staff:
+        assert s["slabel"] == s["sidx"] * 1000  # this.sidx in a nested generate
+        assert s["s_self"] == s["slabel"]  # this.slabel

--- a/tests_ce/integration_tests/test_this_scope/test_this_scope.py
+++ b/tests_ce/integration_tests/test_this_scope/test_this_scope.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+
+def test_this_addresses_current_scope():
+    engine = DataMimicTest(
+        test_dir=Path(__file__).resolve().parent, filename="this_scope.xml", capture_test_result=True
+    )
+    engine.test_with_timer()
+    rows = engine.capture_result()["g"]
+    assert len(rows) == 4
+    for r in rows:
+        assert r["via_this"] == r["via_bare"]  # this.base == base
+        assert r["via_this"] == r["base"] * 10  # earlier sibling visible via this.*
+        assert r["var_via_this"] == 7  # this.<variable> resolves too

--- a/tests_ce/integration_tests/test_this_scope/this_nested.xml
+++ b/tests_ce/integration_tests/test_this_scope/this_nested.xml
@@ -1,0 +1,29 @@
+<setup rngSeed="13">
+    <!-- Deeply nested: generate > nestedKey(dict) > nestedKey(dict), and generate > generate(list).
+         In a NESTED scope, sibling fields are wrapped under the scope name and are NOT visible by bare
+         name - `this.<field>` is the clean way to address the current scope's own fields at every depth.
+         The outermost <generate> (setup parent) still exposes its fields flat. -->
+    <generate name="company" count="2" target="">
+        <key name="cid" generator="IncrementGenerator"/>
+        <key name="cbase" script="cid * 100"/>
+        <key name="c_self" script="this.cid"/>            <!-- this = company scope -->
+
+        <nestedKey name="dept" type="dict">
+            <key name="did" script="this.cbase_missing_ok if False else 1"/>  <!-- seed a field -->
+            <key name="d_self" script="this.did"/>        <!-- this = dept scope: own sibling -->
+            <key name="d_from_company" script="cbase"/>    <!-- outermost company field is flat-visible -->
+
+            <nestedKey name="team" type="dict">
+                <key name="tid" script="99"/>
+                <key name="t_self" script="this.tid"/>     <!-- this = team scope: own sibling -->
+                <key name="t_from_company" script="cbase"/> <!-- still sees the flat outermost field -->
+            </nestedKey>
+        </nestedKey>
+
+        <generate name="staff" count="2" target="">
+            <key name="sidx" generator="IncrementGenerator"/>
+            <key name="slabel" script="this.sidx * 1000"/>  <!-- nested generate: own sibling via this.* -->
+            <key name="s_self" script="this.slabel"/>       <!-- this = staff row scope -->
+        </generate>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_this_scope/this_nested.xml
+++ b/tests_ce/integration_tests/test_this_scope/this_nested.xml
@@ -1,29 +1,28 @@
 <setup rngSeed="13">
-    <!-- Deeply nested: generate > nestedKey(dict) > nestedKey(dict), and generate > generate(list).
-         In a NESTED scope, sibling fields are wrapped under the scope name and are NOT visible by bare
-         name - `this.<field>` is the clean way to address the current scope's own fields at every depth.
-         The outermost <generate> (setup parent) still exposes its fields flat. -->
+    <!-- Scope aliases at every depth:
+         this   = current scope (this.field == the current record's own field)
+         parent = the immediate enclosing generate/nestedKey scope
+         root   = the full tree from the outermost scope (root.<field> / root.<name>.<field>)
+         In a NESTED scope a bare sibling name is wrapped under the scope name and does NOT resolve,
+         so this./parent./root. are the way to reach fields across levels. -->
     <generate name="company" count="2" target="">
         <key name="cid" generator="IncrementGenerator"/>
         <key name="cbase" script="cid * 100"/>
         <key name="c_self" script="this.cid"/>            <!-- this = company scope -->
+        <key name="c_root" script="root.cid"/>            <!-- root at top == this here -->
 
         <nestedKey name="dept" type="dict">
-            <key name="did" script="this.cbase_missing_ok if False else 1"/>  <!-- seed a field -->
+            <key name="did" script="1"/>
             <key name="d_self" script="this.did"/>        <!-- this = dept scope: own sibling -->
-            <key name="d_from_company" script="cbase"/>    <!-- outermost company field is flat-visible -->
+            <key name="d_parent" script="parent.cbase"/>  <!-- parent = company scope -->
+            <key name="d_root" script="root.cbase"/>      <!-- root = outermost company -->
 
             <nestedKey name="team" type="dict">
                 <key name="tid" script="99"/>
-                <key name="t_self" script="this.tid"/>     <!-- this = team scope: own sibling -->
-                <key name="t_from_company" script="cbase"/> <!-- still sees the flat outermost field -->
+                <key name="t_self" script="this.tid"/>          <!-- this = team scope -->
+                <key name="t_parent" script="parent.did"/>      <!-- parent = dept scope -->
+                <key name="t_root" script="root.cid"/>          <!-- root = outermost company -->
             </nestedKey>
         </nestedKey>
-
-        <generate name="staff" count="2" target="">
-            <key name="sidx" generator="IncrementGenerator"/>
-            <key name="slabel" script="this.sidx * 1000"/>  <!-- nested generate: own sibling via this.* -->
-            <key name="s_self" script="this.slabel"/>       <!-- this = staff row scope -->
-        </generate>
     </generate>
 </setup>

--- a/tests_ce/integration_tests/test_this_scope/this_scope.xml
+++ b/tests_ce/integration_tests/test_this_scope/this_scope.xml
@@ -1,0 +1,10 @@
+<setup rngSeed="5">
+    <!-- `this` addresses the current content scope: this.field == field, incl. earlier sibling keys -->
+    <generate name="g" count="4" target="">
+        <key name="base" generator="IncrementGenerator"/>
+        <key name="via_bare" script="base * 10"/>
+        <key name="via_this" script="this.base * 10"/>
+        <variable name="v" script="7"/>
+        <key name="var_via_this" script="this.v"/>
+    </generate>
+</setup>


### PR DESCRIPTION
## What

Replicates the full DATAMIMIC **EE scope-alias set** in CE. In a `<key script>`/`<variable>`, three canonical names now address content by scope:

- **`this`** — the current scope (`this.field` == bare `field`).
- **`parent`** — the immediate enclosing generate/nestedKey scope.
- **`root`** — the full merged content tree from the outermost scope down (`root.<field>` / `root.<name>.<field>`).

## Why it matters

The Benerator path always required the generate name as a prefix: `<generate name="abc"><key name="j" script="abc.j">`. In DATAMIMIC you write bare `j` at the top — but in a **nested** `nestedKey(dict)`/`<generate>`, sibling fields are wrapped under the scope name and a bare name does **not** resolve. `this.`/`parent.`/`root.` are the clean way to reach fields across levels, so migrated and hand-written nested descriptors work natively.

## Implementation

- Bound in `evaluate_python_expression` only when the name isn't already a user variable (never shadows).
- `_current_scope()` / `_parent_scope()` dispatch by `isinstance` (`GenIterContext` → variables+product, `SetupContext` → namespace+globals) — no `getattr` duck-typing.
- `root` = DotableDict of the already-built merged content tree.

## Tests

`tests_ce/integration_tests/test_this_scope/`:
- `this_scope.xml` — `this.field == field`, siblings/variables via `this.*`.
- `this_nested.xml` — `generate > nestedKey(dict) > nestedKey(dict)`: asserts `this`/`parent`/`root` bind to the correct scope at company/dept/team depth (e.g. team's `parent.did` = dept, `root.cid` = company).

Full integration suite green (323 passed); mypy clean.