### PR TITLE
feat(dsl): <execute script=...> — run a dynamically assembled statement

### DIFF
--- a/datamimic_ce/model/execute_model.py
+++ b/datamimic_ce/model/execute_model.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from pydantic import BaseModel, field_validator, model_validator
 
-from datamimic_ce.constants.attribute_constants import ATTR_TARGET, ATTR_TYPE, ATTR_URI
+from datamimic_ce.constants.attribute_constants import ATTR_SCRIPT, ATTR_TARGET, ATTR_TYPE, ATTR_URI
 from datamimic_ce.model.model_util import ModelUtil
 
 # Inline/uri execution languages DATAMIMIC supports.
@@ -20,13 +20,15 @@ class ExecuteModel(BaseModel):
     uri: str | None = None
     target: str | None = None
     type: str | None = None
+    # An expression whose evaluated value IS the code to run (pairs with <variable string=.../>).
+    script: str | None = None
 
     @model_validator(mode="before")  # noqa: B023
     @classmethod
     def check_execute_valid_attributes(cls, values: dict[str, Any]) -> dict[str, Any]:
         return ModelUtil.check_valid_attributes(
             values=values,
-            valid_attributes={ATTR_URI, ATTR_TARGET, ATTR_TYPE},
+            valid_attributes={ATTR_URI, ATTR_TARGET, ATTR_TYPE, ATTR_SCRIPT},
         )
 
     @field_validator("type")  # noqa: B023

--- a/datamimic_ce/parsers/execute_parser.py
+++ b/datamimic_ce/parsers/execute_parser.py
@@ -25,9 +25,12 @@ class ExecuteParser(StatementParser):
         model = self.validate_attributes(ExecuteModel)
         code = self._element.text
         has_inline = bool(code and code.strip())
-        # Exactly one of a script file (uri) or inline code.
-        if bool(model.uri) == has_inline:
-            raise ValueError("<execute> requires exactly one of 'uri' (a script file) or inline code")
+        # Exactly one source of code: a script file (uri), inline code, or a script expression.
+        if [bool(model.uri), has_inline, bool(model.script)].count(True) != 1:
+            raise ValueError(
+                "<execute> requires exactly one of 'uri' (a script file), inline code, "
+                "or 'script' (an expression evaluating to the code)"
+            )
         exec_type = self._resolve_type(model)
         return ExecuteStatement(model, exec_type=exec_type, code=code if has_inline else None)
 

--- a/datamimic_ce/statements/execute_statement.py
+++ b/datamimic_ce/statements/execute_statement.py
@@ -15,6 +15,7 @@ class ExecuteStatement(Statement):
         self._target = model.target
         self._type = exec_type  # resolved: python | bash | sql
         self._code = code  # inline code (None when a uri script file is used)
+        self._script = model.script  # expression whose evaluated value is the code
 
     @property
     def uri(self):
@@ -31,3 +32,7 @@ class ExecuteStatement(Statement):
     @property
     def code(self) -> str | None:
         return self._code
+
+    @property
+    def script(self) -> str | None:
+        return self._script

--- a/datamimic_ce/tasks/execute_task.py
+++ b/datamimic_ce/tasks/execute_task.py
@@ -31,21 +31,32 @@ class ExecuteTask(SetupSubTask):
         if exec_type == "python":
             self._eval_python(ctx, code)
         elif exec_type == "sql":
-            self._run_sql(ctx, code)
+            # script= already produced the final statement - re-interpolating would mangle braces in it
+            self._run_sql(ctx, code, interpolate=self._statement.script is None)
         elif exec_type == "bash":
             self._run_bash(ctx, code)
 
     def _resolve_code(self, ctx: Context) -> str:
-        """Inline code, or the content of the uri script file (relative to the descriptor dir)."""
+        """Inline code, the content of the uri script file, or - with script= - the evaluated
+        expression itself (its value IS the code, e.g. a <variable string=\"...__var__...\"> DDL)."""
         if self._statement.uri:
             return (ctx.root.descriptor_dir / self._statement.uri).read_text()
+        if self._statement.script is not None:
+            value = ctx.evaluate_python_expression(self._statement.script)
+            if not isinstance(value, str):
+                raise ValueError(
+                    f"<execute script='{self._statement.script}'> must evaluate to a string of "
+                    f"{self._statement.type} code, got {type(value).__name__}"
+                )
+            return value
         return self._statement.code or ""
 
-    def _run_sql(self, ctx: Context, content: str) -> None:
-        # f-string interpolation so the SQL may reference descriptor variables (e.g. {table}).
-        escaped_text = content.replace("'", "\\'").replace('"', '\\"')
-        evaluated_content = ctx.evaluate_python_expression(f"f'''{escaped_text}'''")
-        ctx.root.clients[self._statement.target].execute_sql_script(evaluated_content)
+    def _run_sql(self, ctx: Context, content: str, interpolate: bool = True) -> None:
+        # f-string interpolation so inline SQL may reference descriptor variables (e.g. {table}).
+        if interpolate:
+            escaped_text = content.replace("'", "\\'").replace('"', '\\"')
+            content = ctx.evaluate_python_expression(f"f'''{escaped_text}'''")
+        ctx.root.clients[self._statement.target].execute_sql_script(content)
 
     def _run_bash(self, ctx: Context, code: str) -> None:
         """Run a shell command. VERBATIM — no variable interpolation, so no generated data flows into the

--- a/tests_ce/integration_tests/test_execute_script/execute_script_and_body.xml
+++ b/tests_ce/integration_tests/test_execute_script/execute_script_and_body.xml
@@ -1,0 +1,5 @@
+<setup>
+    <database id="db" database="exec_script_dup2_db" dbms="sqlite"/>
+    <variable name="ddl" constant="SELECT 1"/>
+    <execute type="sql" target="db" script="ddl">SELECT 2</execute>
+</setup>

--- a/tests_ce/integration_tests/test_execute_script/execute_script_and_uri.xml
+++ b/tests_ce/integration_tests/test_execute_script/execute_script_and_uri.xml
@@ -1,0 +1,5 @@
+<setup>
+    <database id="db" database="exec_script_dup_db" dbms="sqlite"/>
+    <variable name="ddl" constant="SELECT 1"/>
+    <execute type="sql" target="db" uri="setup.sql" script="ddl"/>
+</setup>

--- a/tests_ce/integration_tests/test_execute_script/execute_script_non_string.xml
+++ b/tests_ce/integration_tests/test_execute_script/execute_script_non_string.xml
@@ -1,0 +1,5 @@
+<setup>
+    <database id="db" database="exec_script_bad_db" dbms="sqlite"/>
+    <variable name="not_code" script="42"/>
+    <execute type="sql" target="db" script="not_code"/>
+</setup>

--- a/tests_ce/integration_tests/test_execute_script/execute_script_python.xml
+++ b/tests_ce/integration_tests/test_execute_script/execute_script_python.xml
@@ -1,0 +1,9 @@
+<setup>
+    <!-- a python snippet assembled via string interpolation, then executed: names land in the namespace -->
+    <variable name="the_answer" script="6 * 7"/>
+    <variable name="snippet" string="answer = __the_answer__"/>
+    <execute type="python" script="snippet"/>
+    <generate name="g" count="2" target="">
+        <key name="v" script="answer"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_execute_script/execute_script_sql.xml
+++ b/tests_ce/integration_tests/test_execute_script/execute_script_sql.xml
@@ -1,0 +1,9 @@
+<setup>
+    <!-- the schema-drop use case: describe the DDL with <variable string="...__var__..."> and
+         execute the assembled statement via <execute script=...> - no string concatenation -->
+    <database id="db" database="exec_script_db" dbms="sqlite"/>
+    <variable name="table_name" constant="tenant_orders"/>
+    <variable name="ddl" string="DROP TABLE IF EXISTS __table_name__; CREATE TABLE __table_name__ (id INTEGER PRIMARY KEY, note TEXT); INSERT INTO __table_name__ VALUES (1, 'a'), (2, 'b');"/>
+    <execute type="sql" target="db" script="ddl"/>
+    <generate name="rows" source="db" selector="SELECT id, note FROM tenant_orders ORDER BY id" distribution="ordered" target=""/>
+</setup>

--- a/tests_ce/integration_tests/test_execute_script/test_execute_script.py
+++ b/tests_ce/integration_tests/test_execute_script/test_execute_script.py
@@ -1,0 +1,55 @@
+"""<execute script="...">: the evaluated expression IS the code to run — the DSL-native way to
+execute dynamically assembled statements (paired with <variable string="...__var__..."/>).
+"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+_DIR = Path(__file__).resolve().parent
+
+
+def _run(filename: str) -> dict:
+    engine = DataMimicTest(test_dir=_DIR, filename=filename, capture_test_result=True)
+    engine.test_with_timer()
+    return engine.capture_result()
+
+
+def _clean():
+    shutil.rmtree(_DIR / "db", ignore_errors=True)
+
+
+def test_execute_script_runs_assembled_sql():
+    _clean()
+    try:
+        rows = _run("execute_script_sql.xml")["rows"]
+        assert [(r["id"], r["note"]) for r in rows] == [(1, "a"), (2, "b")]
+    finally:
+        _clean()
+
+
+def test_execute_script_runs_assembled_python():
+    rows = _run("execute_script_python.xml")["g"]
+    assert [r["v"] for r in rows] == [42, 42]
+
+
+def test_execute_script_non_string_value_raises():
+    _clean()
+    try:
+        with pytest.raises(Exception, match=r"script.*must evaluate to a string|evaluate[sd]? to.*int"):
+            _run("execute_script_non_string.xml")
+    finally:
+        _clean()
+
+
+def test_execute_script_plus_uri_is_a_parse_error():
+    with pytest.raises(Exception, match=r"exactly one of"):
+        _run("execute_script_and_uri.xml")
+
+
+def test_execute_script_plus_inline_body_is_a_parse_error():
+    with pytest.raises(Exception, match=r"exactly one of"):
+        _run("execute_script_and_body.xml")


### PR DESCRIPTION
## What does `<execute script=...>` do?

The evaluated expression **is** the code to run. Paired with the existing `<variable string="...__var__..."/>` interpolation, parameterized DDL/DML becomes a pure DSL description:

```xml
<database id="db" database="tenants" dbms="sqlite"/>
<variable name="table_name" constant="tenant_orders"/>
<variable name="ddl" string="DROP TABLE IF EXISTS __table_name__; CREATE TABLE __table_name__ (id INTEGER PRIMARY KEY, note TEXT);"/>
<execute type="sql" target="db" script="ddl"/>
```

Schema-per-environment setup, tenant-prefixed tables, and dynamic cleanup statements are described in the model — no Python glue. Works for `sql`, `python` and `bash`.

## Semantics

- Exactly **one** code source per `<execute>`: `uri` (script file), inline body, or `script` — anything else is a parse error.
- A `script` expression that does not evaluate to a string raises, naming the offending type — never a silent cast.
- `script`-provided SQL is **not** re-interpolated: the expression already produced the final statement, so braces inside it (JSON payloads, format strings) stay literal. Inline bodies keep their existing `{var}` interpolation unchanged.

## Why it helps the Benerator migration

Benerator descriptors template SQL inside `<execute>` bodies with FreeMarker (`{ftl:... ${var} ...}`). Those are flagged as manual work by the Benerator→DATAMIMIC converter today; `<variable string=...>` + `<execute script=...>` is the 1:1 conversion target (converter mapping follows in the converter branch).

## Tests (TDD — written first)

5 DSL-driven cases in `tests_ce/integration_tests/test_execute_script/`: assembled DDL through a real sqlite write-and-read-back, assembled Python whose names land in the namespace, non-string value error, `script`+`uri` and `script`+inline-body parse errors. mypy clean; execute/assert regression green.