### PR TITLE
feat(converter): Substring(start[, end]) — python slice semantics

### DIFF
--- a/datamimic_ce/converter/substring_converter.py
+++ b/datamimic_ce/converter/substring_converter.py
@@ -1,0 +1,31 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+from typing import Any
+
+from datamimic_ce.converter.converter import Converter
+
+
+class SubstringConverter(Converter):
+    """Extract value[start:end] with python slice semantics (negatives count from the end).
+
+    ``Substring(-4)`` = the last four characters — the classic anonymization tail-extract
+    (Benerator's ``SubstringExtractor(from, to)`` counterpart).
+    """
+
+    def __init__(self, start: int, end: int | None = None):
+        if not isinstance(start, int) or (end is not None and not isinstance(end, int)):
+            raise ValueError(f"Converter Substring expects integer bounds, got start={start!r}, end={end!r}")
+        self._start = start
+        self._end = end
+
+    def convert(self, value: Any) -> str:
+        if not isinstance(value, str):
+            raise ValueError(
+                f"Converter Substring expects datatype 'string', but got value {value} "
+                f"with invalid datatype {type(value)}"
+            )
+        return value[self._start : self._end]

--- a/datamimic_ce/enums/converter_enums.py
+++ b/datamimic_ce/enums/converter_enums.py
@@ -14,6 +14,7 @@ class ConverterEnum(Enum):
     Mask = "Mask"
     MiddleMask = "MiddleMask"
     CutLength = "CutLength"
+    Substring = "Substring"
     Append = "Append"
     Hash = "Hash"
     Timestamp2Date = "Timestamp2Date"

--- a/datamimic_ce/tasks/task_util.py
+++ b/datamimic_ce/tasks/task_util.py
@@ -32,6 +32,7 @@ from datamimic_ce.converter.lower_case_converter import LowerCaseConverter
 from datamimic_ce.converter.mask_converter import MaskConverter
 from datamimic_ce.converter.middle_mask_converter import MiddleMaskConverter
 from datamimic_ce.converter.remove_none_or_empty_element_converter import RemoveNoneOrEmptyElementConverter
+from datamimic_ce.converter.substring_converter import SubstringConverter
 from datamimic_ce.converter.timestamp2date_converter import Timestamp2DateConverter
 from datamimic_ce.converter.upper_case_converter import UpperCaseConverter
 from datamimic_ce.data_sources.data_source_pagination import DataSourcePagination
@@ -269,6 +270,7 @@ class TaskUtil:
                             ConverterEnum.Mask.value: MaskConverter,
                             ConverterEnum.MiddleMask.value: MiddleMaskConverter,
                             ConverterEnum.CutLength.value: CutLengthConverter,
+                            ConverterEnum.Substring.value: SubstringConverter,
                             ConverterEnum.Append.value: AppendConverter,
                             ConverterEnum.Hash.value: HashConverter,
                             ConverterEnum.JavaHash.value: JavaHashConverter,

--- a/tests_ce/integration_tests/test_substring_converter/substring.xml
+++ b/tests_ce/integration_tests/test_substring_converter/substring.xml
@@ -1,0 +1,10 @@
+<setup>
+    <!-- Substring(start[, end]) - python slice semantics, negatives count from the end.
+         Substring(-4) = last four characters: the classic anonymization tail-extract. -->
+    <generate name="g" count="1" target="">
+        <key name="full" constant="0049-171-2635861"/>
+        <key name="last4" script="full" converter="Substring(-4)"/>
+        <key name="area" script="full" converter="Substring(5, 8)"/>
+        <key name="from2" script="full" converter="Substring(2)"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_substring_converter/substring_invalid.xml
+++ b/tests_ce/integration_tests/test_substring_converter/substring_invalid.xml
@@ -1,0 +1,5 @@
+<setup>
+    <generate name="g" count="1" target="">
+        <key name="v" script="123" converter="Substring(1)"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_substring_converter/test_substring_converter.py
+++ b/tests_ce/integration_tests/test_substring_converter/test_substring_converter.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+import pytest
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+_DIR = Path(__file__).resolve().parent
+
+
+def _run(filename: str) -> list[dict]:
+    engine = DataMimicTest(test_dir=_DIR, filename=filename, capture_test_result=True)
+    engine.test_with_timer()
+    return engine.capture_result()["g"]
+
+
+def test_substring_slices_like_python():
+    row = _run("substring.xml")[0]
+    assert row["last4"] == "5861"  # Substring(-4): tail extract
+    assert row["area"] == "171"  # Substring(5, 8): window
+    assert row["from2"] == "49-171-2635861"  # Substring(2): from index to end
+
+
+def test_substring_rejects_non_string():
+    with pytest.raises(Exception, match=r"Substring.*string"):
+        _run("substring_invalid.xml")


### PR DESCRIPTION
## What

`converter="Substring(start[, end])"` extracts `value[start:end]` with python slice semantics — negative bounds count from the end.

```xml
<key name="last4" script="phone" converter="Substring(-4)"/>
<key name="area"  script="phone" converter="Substring(5, 8)"/>
```

## Why

The classic anonymization tail-extract (`Substring(-4)` = last four characters) had no DSL converter — users had to fall back to script slicing. It is also the direct counterpart of Benerator's `SubstringExtractor(from, to)` (flagged in the migration corpus, blocks the anon demo); the converter mapping follows on the converter branch.

## Semantics

- Python slicing, negatives from the end, `end` optional (to the end).
- Non-string value or non-integer bound raises — no silent coercion.

## Tests

TDD, DSL-driven: tail extract, window, from-index, non-string error. mypy clean.