### PR TITLE
fix(dsl): a broken <echo> placeholder warns instead of killing the run

### DIFF
--- a/datamimic_ce/tasks/echo_task.py
+++ b/datamimic_ce/tasks/echo_task.py
@@ -26,9 +26,13 @@ class EchoTask(CommonSubTask):
         if re.search(r"{.*?}", _value):
             # if _value contain ' or " then add escaped character before it
             escaped_text = _value.replace("'", "\\'").replace('"', '\\"')
-            # evaluate echo value before logging
-            evaluated_value = ctx.evaluate_python_expression(f"f'{escaped_text}'")
-            logger.debug(f"Echo - {evaluated_value}")
+            try:
+                # evaluate echo value before logging
+                evaluated_value = ctx.evaluate_python_expression(f"f'{escaped_text}'")
+                logger.debug(f"Echo - {evaluated_value}")
+            except Exception as err:
+                # An <echo> is diagnostic output - a broken placeholder must never kill the run.
+                logger.warning(f"Echo - {_value} (placeholder not evaluated: {err})")
         else:
             logger.debug(f"Echo - {_value}")
 

--- a/tests_ce/integration_tests/test_echo_robust/echo_robust.xml
+++ b/tests_ce/integration_tests/test_echo_robust/echo_robust.xml
@@ -1,0 +1,7 @@
+<setup>
+    <!-- a broken echo placeholder (unknown name) must not kill the run -->
+    <echo>this references {does_not_exist} and must only warn</echo>
+    <generate name="g" count="2" target="">
+        <key name="v" constant="ok"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_echo_robust/test_echo_robust.py
+++ b/tests_ce/integration_tests/test_echo_robust/test_echo_robust.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+
+def test_broken_echo_placeholder_only_warns():
+    engine = DataMimicTest(
+        test_dir=Path(__file__).resolve().parent, filename="echo_robust.xml", capture_test_result=True
+    )
+    engine.test_with_timer()  # must not raise
+    assert [r["v"] for r in engine.capture_result()["g"]] == ["ok", "ok"]


### PR DESCRIPTION
`<echo>` is diagnostic output — an unresolvable `{placeholder}` (e.g. a Benerator-runtime name like `{context.defaultEncoding}` in a migrated descriptor) now logs the text verbatim with a warning instead of aborting the entire generation run.

Found via the migration corpus: `db/h2.multischema` died on a debug echo. DSL test: a descriptor with a broken echo placeholder still generates its records.