### PR TITLE
feat(dsl): dynamic <include uri> — f-string interpolation from context

### DIFF
--- a/datamimic_ce/statements/include_statement.py
+++ b/datamimic_ce/statements/include_statement.py
@@ -19,6 +19,10 @@ class IncludeStatement(Statement):
         return self._uri
 
     def early_execute(self, descriptor_dir):
+        # A dynamic uri ({var}/... f-string) cannot be resolved at parse time - defer it to the
+        # IncludeTask, which resolves it against the runtime context (dynamic include).
+        if "{" in self._uri:
+            return {}
         # Case 1: Check if uri is a properties file
         if self._uri.endswith(".properties"):
             # Import properties into context

--- a/datamimic_ce/tasks/include_task.py
+++ b/datamimic_ce/tasks/include_task.py
@@ -33,9 +33,11 @@ class IncludeTask(CommonSubTask):
         :return:
         """
         uri = self.statement.uri
-        # Evaluate uri if it is a python expression
-        if uri.startswith("{") and uri.endswith("}"):
-            uri = ctx.evaluate_python_expression(uri[1:-1])
+        # A dynamic uri interpolates {var} f-string style against the context (dynamic include), so
+        # a path like "{database}/shop.{database}.properties" resolves to "h2/shop.h2.properties".
+        if "{" in uri:
+            escaped = uri.replace("'", "\\'").replace('"', '\\"')
+            uri = ctx.evaluate_python_expression(f"f'''{escaped}'''")
 
         if isinstance(ctx, SetupContext):
             self._execute_with_setup_context(ctx, uri)

--- a/tests_ce/integration_tests/test_dynamic_include/dynamic_include.xml
+++ b/tests_ce/integration_tests/test_dynamic_include/dynamic_include.xml
@@ -1,0 +1,8 @@
+<setup>
+    <!-- the include path is assembled from a variable: {database}/shop.{database}.properties -->
+    <variable name="database" constant="h2"/>
+    <include uri="{database}/shop.{database}.properties"/>
+    <generate name="g" count="{product_count}" target="">
+        <key name="r" script="region"/>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_dynamic_include/h2/shop.h2.properties
+++ b/tests_ce/integration_tests/test_dynamic_include/h2/shop.h2.properties
@@ -1,0 +1,2 @@
+product_count=7
+region=EU

--- a/tests_ce/integration_tests/test_dynamic_include/test_dynamic_include.py
+++ b/tests_ce/integration_tests/test_dynamic_include/test_dynamic_include.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+
+def test_include_uri_is_resolved_from_a_variable():
+    engine = DataMimicTest(
+        test_dir=Path(__file__).resolve().parent, filename="dynamic_include.xml", capture_test_result=True
+    )
+    engine.test_with_timer()
+    rows = engine.capture_result()["g"]
+    assert len(rows) == 7  # product_count from the dynamically-included properties file
+    assert all(r["r"] == "EU" for r in rows)  # region from the same file


### PR DESCRIPTION
## What

An `<include>` path can be assembled from variables and resolved at runtime against the setup context — DATAMIMIC EE has this; ported to CE.

```xml
<variable name="database" constant="h2"/>
<include uri="{database}/shop.{database}.properties"/>   <!-- -> h2/shop.h2.properties -->
```

Previously CE only resolved an include uri that was a **whole** `{expr}` (e.g. `{stage}`); a path *template* with embedded `{var}` segments was loaded literally and failed. Now the uri is f-string-interpolated (multiple `{var}` in a path), matching EE.

## How

- `IncludeStatement.early_execute` (parse time) defers any uri containing `{` — a dynamic path cannot be resolved before the context exists.
- `IncludeTask.execute` (runtime) f-string-interpolates the uri against the context, then loads the `.properties`/`.xml` as before.

Mirrors EE's `is_dynamic_value` split: static includes resolve at parse time, dynamic ones at runtime.

## Why

The Benerator migration corpus templates include paths per environment (`{ftl:${database}/shop.${database}.properties}`), the single biggest blocker for the shop demo family. The converter rewrites the FTL to `{var}` f-string form; this makes CE resolve it.

## Tests

TDD, DSL-driven: an include path built from a `<variable>`, loading a properties file whose values then drive `count` and a field. Full integration suite green (one unrelated unseeded-random flake, passes standalone). mypy clean.