### PR TITLE
fix(clients): RdbmsClient forwards only real create_engine kwargs

### DIFF
--- a/datamimic_ce/clients/rdbms_client.py
+++ b/datamimic_ce/clients/rdbms_client.py
@@ -20,6 +20,38 @@ from datamimic_ce.connection_config.rdbms_connection_config import RdbmsConnecti
 from datamimic_ce.data_sources.data_source_pagination import DataSourcePagination
 from datamimic_ce.logger import logger
 
+# SQLAlchemy create_engine kwargs DATAMIMIC forwards (pooling/behavior). Anything else in the
+# connection config is either connection identity (see _CONNECTION_IDENTITY, used to build the URL)
+# or a vendor knob that create_engine would reject.
+_ENGINE_KWARGS = {
+    "echo",
+    "echo_pool",
+    "pool_size",
+    "max_overflow",
+    "pool_timeout",
+    "pool_recycle",
+    "pool_pre_ping",
+    "connect_args",
+    "isolation_level",
+    "execution_options",
+    "encoding",
+    "future",
+}
+# Connection identity used to build the URL (not passed as an engine kwarg) - dropping these is expected.
+_CONNECTION_IDENTITY = {
+    "dbms",
+    "database",
+    "host",
+    "port",
+    "user",
+    "password",
+    "db_schema",
+    "id",
+    "environment",
+    "system",
+    "none_as_null_col",
+}
+
 
 class RdbmsClient(DatabaseClient):
     def __init__(self, credential: RdbmsConnectionConfig, task_id: str | None = None):
@@ -27,23 +59,14 @@ class RdbmsClient(DatabaseClient):
         self._engine = None
         self._task_id = task_id
 
-        # Prepare sqlalchemy engine kwargs, also remove datamimic-specific kwargs
-        self._engine_kwargs = credential.get_connection_config()
-        # Remove datamimic-specific kwargs
-        not_engine_kwargs = [
-            "dbms",
-            "database",
-            "host",
-            "port",
-            "user",
-            "password",
-            "db_schema",
-            "id",
-            "environment",
-            "system",
-            "none_as_null_col",
-        ]
-        self._engine_kwargs = {k: v for k, v in self._engine_kwargs.items() if k not in not_engine_kwargs}
+        # Keep only real SQLAlchemy create_engine kwargs. The connection config allows extra keys
+        # (env files carry connection identity like dbms/host plus vendor knobs such as Benerator's
+        # clean/catalog/quoteTableNames); anything not a create_engine parameter would raise, so allowlist.
+        all_config = credential.get_connection_config()
+        self._engine_kwargs = {k: v for k, v in all_config.items() if k in _ENGINE_KWARGS}
+        dropped = set(all_config) - set(self._engine_kwargs) - _CONNECTION_IDENTITY
+        if dropped:
+            logger.debug(f"Ignored non-engine connection keys: {', '.join(sorted(dropped))}")
         # Set default values for some kwargs
         self._engine_kwargs["echo"] = self._engine_kwargs.get("echo", False)
         self._engine_kwargs["pool_size"] = self._engine_kwargs.get("pool_size", 20)

--- a/tests_ce/integration_tests/test_rdbms_unknown_kwargs/test_rdbms_unknown_kwargs.py
+++ b/tests_ce/integration_tests/test_rdbms_unknown_kwargs/test_rdbms_unknown_kwargs.py
@@ -1,0 +1,16 @@
+import shutil
+from pathlib import Path
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+_DIR = Path(__file__).resolve().parent
+
+
+def test_unknown_connection_knobs_do_not_reach_create_engine():
+    shutil.rmtree(_DIR / "db", ignore_errors=True)
+    try:
+        engine = DataMimicTest(test_dir=_DIR, filename="unknown_kwarg.xml", capture_test_result=True)
+        engine.test_with_timer()  # must not raise "Invalid argument(s) 'clean' sent to create_engine"
+        assert engine.capture_result()["g"][0]["v"] == 5
+    finally:
+        shutil.rmtree(_DIR / "db", ignore_errors=True)

--- a/tests_ce/integration_tests/test_rdbms_unknown_kwargs/unknown_kwarg.xml
+++ b/tests_ce/integration_tests/test_rdbms_unknown_kwargs/unknown_kwarg.xml
@@ -1,0 +1,10 @@
+<setup>
+    <!-- 'clean' is a Benerator connection knob carried in from a migrated env file;
+         it must not reach SQLAlchemy's create_engine -->
+    <database id="db" database="unknown_kwarg_db" dbms="sqlite" clean="true" quoteTableNames="true"/>
+    <execute type="sql" target="db">DROP TABLE IF EXISTS t; CREATE TABLE t (n INTEGER); INSERT INTO t VALUES (5);</execute>
+    <generate name="g" count="1" target="">
+        <variable name="row" source="db" selector="SELECT n FROM t"/>
+        <key name="v" script="row.n"/>
+    </generate>
+</setup>


### PR DESCRIPTION
## Problem

`RdbmsConnectionConfig` is `extra="allow"`, so any key from a migrated env or `<database>` element flows into the engine kwargs. Benerator connection knobs (`clean`, `catalog`, `quoteTableNames`, `readOnly`, `batch`) — or any unknown key — reached SQLAlchemy's `create_engine` and raised:

```
TypeError: Invalid argument(s) 'clean','quoteTableNames' sent to create_engine()
```

The old fix was a blocklist of datamimic-specific keys — fragile, since every new vendor knob is a fresh crash.

## Fix

Allowlist the pooling/behavior kwargs DATAMIMIC actually forwards (`echo`, `pool_size`, `pool_pre_ping`, `connect_args`, `isolation_level`, …). Connection-identity keys (`dbms`/`host`/`port`/…) build the URL as before; anything else is dropped with a debug log. Root-cause fix — handles `clean` and any future unknown key.

## Why

The Benerator migration corpus carries these knobs in every shop/dbenv env file; this unblocks the DB-backed demos past the connection layer.

## Tests

TDD: a `<database clean="true" quoteTableNames="true">` (the exact failing shape) now connects and round-trips a value. db-backed regression (execute-inline, sql-crud) green. mypy clean.