### PR TITLE
feat(exporters): exportUri output-directory prefix for all file exporters (EE parity)

### DIFF
--- a/datamimic_ce/exporters/csv_exporter.py
+++ b/datamimic_ce/exporters/csv_exporter.py
@@ -29,6 +29,7 @@ class CSVExporter(UnifiedBufferedExporter):
         quoting: int | None,
         line_terminator: str | None,
         encoding: str | None,
+        export_uri: str | None = None,
     ):
         # Remove singleton pattern and initialize instance variables
         self.fieldnames = fieldnames or []
@@ -46,6 +47,7 @@ class CSVExporter(UnifiedBufferedExporter):
             product_name=product_name,
             chunk_size=chunk_size,
             encoding=encoding,
+            export_uri=export_uri,
         )
         logger.info(
             f"CSVExporter initialized with chunk size {chunk_size}, fieldnames '{fieldnames}', "

--- a/datamimic_ce/exporters/exporter_util.py
+++ b/datamimic_ce/exporters/exporter_util.py
@@ -282,6 +282,8 @@ class ExporterUtil:
         from datamimic_ce.statements.statement_util import StatementUtil
 
         product_name = StatementUtil.resolve_target_entity(gen_stmt.target_entity, None, gen_stmt.name)
+        # exportUri (validated at parse time) is the output-directory prefix for file exporters.
+        export_uri = gen_stmt.export_uri
 
         if name is None or name == "":
             return None
@@ -307,7 +309,7 @@ class ExporterUtil:
         elif name == EXPORTER_LOG_EXPORTER:
             return LogExporter()
         elif name == EXPORTER_JSON:
-            return JsonExporter(setup_context, product_name, chunk_size, use_ndjson, encoding)
+            return JsonExporter(setup_context, product_name, chunk_size, use_ndjson, encoding, export_uri=export_uri)
         elif name == EXPORTER_CSV:
             return CSVExporter(
                 setup_context,
@@ -319,14 +321,19 @@ class ExporterUtil:
                 quoting,
                 line_terminator,
                 encoding,
+                export_uri=export_uri,
             )
         elif name == EXPORTER_XML:
-            return XMLExporter(setup_context, product_name, chunk_size, root_element, item_element, encoding)
+            return XMLExporter(
+                setup_context, product_name, chunk_size, root_element, item_element, encoding, export_uri=export_uri
+            )
         elif name == EXPORTER_XLSX:
             sheet_name = exporter_params_dict.get("sheet_name")
-            return XLSXExporter(setup_context, product_name, chunk_size, sheet_name, encoding)
+            return XLSXExporter(setup_context, product_name, chunk_size, sheet_name, encoding, export_uri=export_uri)
         elif name == EXPORTER_TXT:
-            return TXTExporter(setup_context, product_name, chunk_size, delimiter, line_terminator, encoding)
+            return TXTExporter(
+                setup_context, product_name, chunk_size, delimiter, line_terminator, encoding, export_uri=export_uri
+            )
         elif name == EXPORTER_TEST_RESULT_EXPORTER:
             return setup_context.test_result_exporter
         elif name in setup_context.clients:

--- a/datamimic_ce/exporters/json_exporter.py
+++ b/datamimic_ce/exporters/json_exporter.py
@@ -38,10 +38,13 @@ class JsonExporter(UnifiedBufferedExporter):
         chunk_size: int | None,
         use_ndjson: bool | None,
         encoding: str | None,
+        export_uri: str | None = None,
     ):
         self.use_ndjson = use_ndjson
         self._task_id = setup_context.task_id
-        super().__init__("json", setup_context, product_name, chunk_size=chunk_size, encoding=encoding)
+        super().__init__(
+            "json", setup_context, product_name, chunk_size=chunk_size, encoding=encoding, export_uri=export_uri
+        )
 
         logger.info(f"JsonExporter initialized with chunk size {chunk_size} and NDJSON format: {use_ndjson}")
 

--- a/datamimic_ce/exporters/txt_exporter.py
+++ b/datamimic_ce/exporters/txt_exporter.py
@@ -35,6 +35,7 @@ class TXTExporter(UnifiedBufferedExporter):
         separator: str | None,
         line_terminator: str | None,
         encoding: str | None,
+        export_uri: str | None = None,
     ):
         """
         Initializes the TXTExporter.
@@ -52,7 +53,9 @@ class TXTExporter(UnifiedBufferedExporter):
 
         # Pass encoding via kwargs to the base class
 
-        super().__init__("txt", setup_context, product_name, chunk_size=chunk_size, encoding=encoding)
+        super().__init__(
+            "txt", setup_context, product_name, chunk_size=chunk_size, encoding=encoding, export_uri=export_uri
+        )
         logger.info(
             f"TXTExporter initialized with chunk size {chunk_size}, separator '{self.separator}', "
             f"encoding '{self.encoding}', line terminator '{self.line_terminator}'"

--- a/datamimic_ce/exporters/unified_buffered_exporter.py
+++ b/datamimic_ce/exporters/unified_buffered_exporter.py
@@ -45,6 +45,7 @@ class UnifiedBufferedExporter(Exporter, ABC):
         product_name: str,
         chunk_size: int | None,
         encoding: str | None,
+        export_uri: str | None = None,
     ):
         if chunk_size is not None and chunk_size <= 0:
             raise ValueError("Chunk size must be a positive integer or None for unlimited size.")
@@ -56,6 +57,8 @@ class UnifiedBufferedExporter(Exporter, ABC):
         self._task_id = setup_context.task_id  # Task ID for tracking
         self._descriptor_dir = setup_context.descriptor_dir  # Directory for storing temp files
         self._chunk_size = chunk_size  # Max entities per chunk
+        # exportUri: a validated output-directory prefix; falls back to the task_id dir when unset.
+        self._export_uri = export_uri
 
     @property
     def encoding(self) -> str:
@@ -211,7 +214,9 @@ class UnifiedBufferedExporter(Exporter, ABC):
         """
         logger.info(f"Saving exported result for product {self.product_name}")
 
-        exporter_dir_path = self._descriptor_dir / "output" / self._task_id
+        # exportUri names the output subdirectory (EE parity: prefix replaces the task_id dir); default
+        # keeps the task_id dir so concurrent runs stay isolated.
+        exporter_dir_path = self._descriptor_dir / "output" / (self._export_uri or self._task_id)
 
         # Handle existing directory by adding version number
 

--- a/datamimic_ce/exporters/xlsx_exporter.py
+++ b/datamimic_ce/exporters/xlsx_exporter.py
@@ -31,6 +31,7 @@ class XLSXExporter(UnifiedBufferedExporter):
         chunk_size: int | None,
         sheet_name: str | None,
         encoding: str | None,
+        export_uri: str | None = None,
     ):
         self.sheet_name = sheet_name or "data"
         super().__init__(
@@ -39,6 +40,7 @@ class XLSXExporter(UnifiedBufferedExporter):
             product_name=product_name,
             chunk_size=chunk_size,
             encoding=encoding,
+            export_uri=export_uri,
         )
         logger.info(f"XLSXExporter initialized with chunk size {chunk_size}, sheet '{self.sheet_name}'")
 

--- a/datamimic_ce/exporters/xml_exporter.py
+++ b/datamimic_ce/exporters/xml_exporter.py
@@ -37,6 +37,7 @@ class XMLExporter(UnifiedBufferedExporter):
         root_element: str | None,
         item_element: str | None,
         encoding: str | None,
+        export_uri: str | None = None,
     ):
         """
         Initializes the XMLExporter.
@@ -57,6 +58,7 @@ class XMLExporter(UnifiedBufferedExporter):
             product_name=product_name,
             chunk_size=chunk_size,
             encoding=encoding,
+            export_uri=export_uri,
         )
         logger.info(
             f"XMLExporter initialized with chunk size {chunk_size}, root element '{self.root_element}', "

--- a/datamimic_ce/model/generate_model.py
+++ b/datamimic_ce/model/generate_model.py
@@ -142,6 +142,12 @@ class GenerateModel(BaseModel):
             raise ValueError(f"sourceEntity/targetEntity must be a plain entity name, not a path: '{stripped}'")
         return stripped
 
+    @field_validator("export_uri")
+    @classmethod
+    def _normalize_export_uri(cls, value: str | None) -> str | None:
+        """exportUri is a safe local output-directory prefix (see ModelUtil.normalize_export_uri)."""
+        return ModelUtil.normalize_export_uri(value)
+
     @model_validator(mode="before")
     @classmethod
     def validate_timeseries_window(cls, values: dict):

--- a/datamimic_ce/model/model_util.py
+++ b/datamimic_ce/model/model_util.py
@@ -53,6 +53,30 @@ def _attr_true(value: object) -> bool:
 
 class ModelUtil:
     @staticmethod
+    def normalize_export_uri(value: str | None) -> str | None:
+        """Validate + normalize an exportUri into a safe local output-directory prefix.
+
+        Mirrors DATAMIMIC EE's exportUri policy (prefix only, never a full path/URL): a string,
+        no surrounding whitespace, not empty, no URL scheme, no backslash, no control chars - plus a
+        traversal guard ('..'), since CE resolves it under the local output/ directory and it must not
+        escape. Leading/trailing slashes are stripped. Returns None when unset.
+        """
+        if value is None:
+            return None
+        if value != value.strip() or not value.strip():
+            raise ValueError("exportUri must not be empty or padded with whitespace")
+        cleaned = value.strip()
+        if "://" in cleaned:
+            raise ValueError(f"exportUri must be a path prefix, not a URL: '{cleaned}'")
+        if "\\" in cleaned:
+            raise ValueError(f"exportUri must use '/' separators, not backslashes: '{cleaned}'")
+        if any(ord(ch) < 32 for ch in cleaned):
+            raise ValueError("exportUri must not contain control characters")
+        if ".." in cleaned.split("/"):
+            raise ValueError(f"exportUri must not traverse with '..': '{cleaned}'")
+        return cleaned.strip("/")
+
+    @staticmethod
     def check_valid_attributes(values: dict, valid_attributes: set[str]) -> dict:
         """
         Check if element's attributes are in valid attributes set

--- a/tests_ce/integration_tests/test_export_uri/csv_default.xml
+++ b/tests_ce/integration_tests/test_export_uri/csv_default.xml
@@ -1,0 +1,3 @@
+<setup>
+    <generate name="rows" count="3" target="CSV"><key name="n" constant="1"/></generate>
+</setup>

--- a/tests_ce/integration_tests/test_export_uri/csv_uri.xml
+++ b/tests_ce/integration_tests/test_export_uri/csv_uri.xml
@@ -1,0 +1,3 @@
+<setup>
+    <generate name="rows" count="3" target="CSV" exportUri="reports/2026"><key name="n" constant="1"/></generate>
+</setup>

--- a/tests_ce/integration_tests/test_export_uri/json_uri.xml
+++ b/tests_ce/integration_tests/test_export_uri/json_uri.xml
@@ -1,0 +1,3 @@
+<setup>
+    <generate name="rows" count="2" target="JSON" exportUri="out/json"><key name="n" constant="1"/></generate>
+</setup>

--- a/tests_ce/integration_tests/test_export_uri/test_export_uri.py
+++ b/tests_ce/integration_tests/test_export_uri/test_export_uri.py
@@ -1,0 +1,55 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+_DIR = Path(__file__).resolve().parent
+
+
+def _clean():
+    shutil.rmtree(_DIR / "output", ignore_errors=True)
+
+
+def _run(f):
+    DataMimicTest(test_dir=_DIR, filename=f, capture_test_result=True).test_with_timer()
+
+
+def test_exporturi_puts_the_file_under_that_prefix():
+    _clean()
+    try:
+        _run("csv_uri.xml")
+        under_prefix = list((_DIR / "output" / "reports" / "2026").glob("rows*.csv"))
+        assert under_prefix, f"no rows.csv under output/reports/2026 (tree: {[str(p.relative_to(_DIR)) for p in (_DIR/'output').rglob('*.csv')]})"
+    finally:
+        _clean()
+
+
+def test_without_exporturi_the_default_task_id_dir_is_unchanged():
+    _clean()
+    try:
+        _run("csv_default.xml")
+        # not under a 'reports' prefix; still lands somewhere under output/
+        assert list((_DIR / "output").rglob("rows*.csv"))
+        assert not (_DIR / "output" / "reports").exists()
+    finally:
+        _clean()
+
+
+@pytest.mark.parametrize("f,msg", [
+    ("uri_traversal.xml", r"path|traversal|\.\."),
+    ("uri_scheme.xml", r"scheme|://"),
+])
+def test_invalid_exporturi_is_rejected(f, msg):
+    with pytest.raises(Exception, match=msg):
+        _run(f)
+
+
+def test_exporturi_works_for_json_too():
+    _clean()
+    try:
+        _run("json_uri.xml")
+        assert list((_DIR / "output" / "out" / "json").glob("rows*.json"))
+    finally:
+        _clean()

--- a/tests_ce/integration_tests/test_export_uri/uri_scheme.xml
+++ b/tests_ce/integration_tests/test_export_uri/uri_scheme.xml
@@ -1,0 +1,3 @@
+<setup>
+    <generate name="rows" count="1" target="CSV" exportUri="s3://bucket"><key name="n" constant="1"/></generate>
+</setup>

--- a/tests_ce/integration_tests/test_export_uri/uri_traversal.xml
+++ b/tests_ce/integration_tests/test_export_uri/uri_traversal.xml
@@ -1,0 +1,3 @@
+<setup>
+    <generate name="rows" count="1" target="CSV" exportUri="../escape"><key name="n" constant="1"/></generate>
+</setup>

--- a/tests_ce/unit_tests/test_export_uri_validator.py
+++ b/tests_ce/unit_tests/test_export_uri_validator.py
@@ -1,0 +1,22 @@
+import pytest
+
+from datamimic_ce.model.model_util import ModelUtil
+
+
+def test_normalize_strips_slashes_and_passes_a_valid_prefix():
+    assert ModelUtil.normalize_export_uri("reports/2026") == "reports/2026"
+    assert ModelUtil.normalize_export_uri("/a/b/") == "a/b"
+    assert ModelUtil.normalize_export_uri(None) is None
+
+
+@pytest.mark.parametrize("bad,msg", [
+    ("  ", r"empty|whitespace"),
+    (" x", r"whitespace"),
+    ("s3://b", r"URL"),
+    ("a\\b", r"backslash"),
+    ("a/../b", r"traverse"),
+    ("a\tb", r"control"),
+])
+def test_normalize_rejects_bad_prefixes(bad, msg):
+    with pytest.raises(ValueError, match=msg):
+        ModelUtil.normalize_export_uri(bad)


### PR DESCRIPTION
## What

CE already had the `exportUri` DSL attribute but **ignored it** — every file exporter wrote to `output/<task_id>/`. Now `exportUri` names the output subdirectory for **all** buffered file exporters:

```xml
<generate name="rows" target="CSV" exportUri="reports/2026">…</generate>
<!-- -> output/reports/2026/rows.csv  (instead of output/<task_id>/rows.csv) -->
```

`exportUri` is a path **prefix**, orthogonal to `targetEntity` (the basename) — matching DATAMIMIC EE. One `UnifiedBufferedExporter` base-class change covers CSV/JSON/XML/XLSX/TXT (and DbUnit once #178 merges — same base class).

## Semantics (EE parity)

| | |
|---|---|
| `exportUri` set | `output/<exportUri>/<file>` |
| unset | `output/<task_id>/<file>` (unchanged, backward-compatible) |

## Validation (parse-time, EE policy + traversal guard)

`ModelUtil.normalize_export_uri`: non-empty unpadded prefix, **no URL scheme** (`://`), **no backslash**, **no control chars**, **no `..` traversal** (CE writes local FS); leading/trailing slashes stripped.

## Tests

TDD: CSV + JSON write under `output/<exportUri>/`; default dir unchanged (backward compat); invalid prefixes (traversal / `s3://` / backslash / empty / control char) rejected — unit-tested pure + DSL-driven. 796 passed, lint clean, mypy at baseline.

## Divergence from EE (documented)

EE reserves `exportUri` for object storage (policy-checked against `storageId`); CE has no object storage in scope, so it maps `exportUri` to a local output subdirectory — the sensible CE interpretation of the same attribute.