### PR TITLE
feat(generators): EANGenerator unique flag (Benerator parity)

### DIFF
--- a/datamimic_ce/domains/common/literal_generators/ean_generator.py
+++ b/datamimic_ce/domains/common/literal_generators/ean_generator.py
@@ -12,9 +12,33 @@ from datamimic_ce.domains.domain_core.base_literal_generator import BaseLiteralG
 
 
 class EANGenerator(BaseLiteralGenerator):
-    def __init__(self, locale: str | None = "en_US", rng: random.Random | None = None) -> None:
+    """EAN-13 codes via faker.
+
+    ``unique=True`` guarantees no repeated code across the generator's lifetime (Benerator
+    ``EANGenerator(unique)`` parity) - needed when the EAN is a primary key.
+    """
+
+    _UNIQUE_MAX_RETRIES = 100
+
+    def __init__(
+        self, locale: str | None = "en_US", unique: bool = False, rng: random.Random | None = None
+    ) -> None:
         super().__init__(rng=rng)
         self._gen = DataFakerGenerator(method="ean", locale=locale, rng=rng)
+        self._unique = unique
+        self._seen: set[Any] = set()
 
     def generate(self) -> Any:
-        return self._gen.generate()
+        value = self._gen.generate()
+        if not self._unique:
+            return value
+        # The EAN-13 space (~1e12) makes collisions vanishingly rare; a bounded retry loop is
+        # enough and still fails loudly instead of hanging if the space were ever exhausted.
+        for _ in range(self._UNIQUE_MAX_RETRIES):
+            if value not in self._seen:
+                self._seen.add(value)
+                return value
+            value = self._gen.generate()
+        raise ValueError(
+            f"EANGenerator(unique=True) found no fresh EAN after {self._UNIQUE_MAX_RETRIES} retries"
+        )

--- a/tests_ce/unit_tests/test_generator/test_ean_generator.py
+++ b/tests_ce/unit_tests/test_generator/test_ean_generator.py
@@ -1,0 +1,40 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+import random
+
+import pytest
+
+from datamimic_ce.domains.common.literal_generators.ean_generator import EANGenerator
+
+
+class TestEANGenerator:
+    def test_generates_ean13(self):
+        gen = EANGenerator(rng=random.Random(42))
+        value = gen.generate()
+        assert isinstance(value, str)
+        assert len(value) == 13
+        assert value.isdigit()
+
+    def test_default_allows_repeats(self):
+        gen = EANGenerator(rng=random.Random(1))
+        # not asserting a collision (space is huge) - only that generate() never tracks state
+        for _ in range(50):
+            gen.generate()
+        assert gen._seen == set()
+
+    def test_unique_never_repeats(self):
+        gen = EANGenerator(unique=True, rng=random.Random(7))
+        values = [gen.generate() for _ in range(500)]
+        assert len(values) == len(set(values))
+
+    def test_unique_retries_then_fails_loudly(self):
+        gen = EANGenerator(unique=True, rng=random.Random(3))
+        # exhaust the space artificially: make the underlying generator constant
+        gen._gen.generate = lambda: "4000000000000"  # type: ignore[method-assign]
+        assert gen.generate() == "4000000000000"
+        with pytest.raises(ValueError, match="no fresh EAN"):
+            gen.generate()


### PR DESCRIPTION
EANGenerator(unique=True) tracks emitted codes and retries (bounded, fails
loudly) so an EAN can serve as a primary key. Needed by the Benerator shop
demo migration, where ean_code is the db_product PK (EANGenerator(true)).
