### PR TITLE
fix(engine): data-source length cache keyed by (statement, source), n…

### DIFF
--- a/datamimic_ce/data_sources/data_source_registry.py
+++ b/datamimic_ce/data_sources/data_source_registry.py
@@ -21,9 +21,11 @@ from datamimic_ce.data_sources.data_source_pagination import DataSourcePaginatio
 from datamimic_ce.enums.distribution_enums import SourceDistribution
 from datamimic_ce.logger import logger
 from datamimic_ce.statements.generate_statement import GenerateStatement
+from datamimic_ce.statements.nested_key_statement import NestedKeyStatement
 from datamimic_ce.statements.reference_statement import ReferenceStatement
 from datamimic_ce.statements.statement import Statement
 from datamimic_ce.statements.statement_util import StatementUtil
+from datamimic_ce.statements.variable_statement import VariableStatement
 from datamimic_ce.utils.distribution_sampling import cumulated_index
 from datamimic_ce.utils.file_content_storage import FileContentStorage
 from datamimic_ce.utils.file_util import FileUtil
@@ -58,6 +60,17 @@ class DataSourceRegistry:
             raise ValueError(f"Data source '{key}' is not supported is not handled by DataSourceRegistry")
 
     @staticmethod
+    def data_source_cache_key(stmt: Statement) -> tuple[str | None, str | None]:
+        """Cache key for a statement's data-source length. Statements may SHARE a name (e.g. three
+        <iterate name='db_product'> feeding one table from different sources), so the key must
+        include the source - keyed by name alone, the second statement inherits the first one's
+        length and silently truncates its rows. A tuple key on real statement types, no string
+        concatenation, no duck-typing."""
+        if isinstance(stmt, GenerateStatement | VariableStatement | NestedKeyStatement):
+            return (stmt.full_name, stmt.source)
+        return (stmt.full_name, None)
+
+    @staticmethod
     def set_data_source_length(ctx: SetupContext | GenIterContext, stmt: Statement) -> None:
         """
         Calculate length of data source then save into context
@@ -70,7 +83,7 @@ class DataSourceRegistry:
             return
 
         root_ctx = ctx.root
-        source_id: str | None = stmt.full_name
+        source_id: tuple[str | None, str | None] = DataSourceRegistry.data_source_cache_key(stmt)
         ds_len: int = 0
 
         # Check if data source length is already set

--- a/datamimic_ce/tasks/generate_task.py
+++ b/datamimic_ce/tasks/generate_task.py
@@ -90,7 +90,7 @@ class GenerateTask(CommonSubTask):
                         "Using selector without count only supports DatabaseClient (MongoDB, Relational Database)"
                     )
             else:
-                count = root_context.data_source_len[self.statement.full_name]
+                count = root_context.data_source_len[DataSourceRegistry.data_source_cache_key(self.statement)]
 
         # Check if there is a special consumer (e.g., mongodb_upsert)
         if count == 0 and self.statement.contain_mongodb_upsert(root_context):
@@ -117,7 +117,7 @@ class GenerateTask(CommonSubTask):
             or stmt.distribution == SourceDistribution.CUMULATED
         ):
             return
-        ds_len = context.root.data_source_len.get(stmt.full_name)
+        ds_len = context.root.data_source_len.get(DataSourceRegistry.data_source_cache_key(stmt))
         if ds_len is not None and count > ds_len:
             logger.warning(
                 f"<generate> '{stmt.name}': count={count} exceeds the {ds_len} rows available from "

--- a/datamimic_ce/tasks/variable_task.py
+++ b/datamimic_ce/tasks/variable_task.py
@@ -131,7 +131,7 @@ class VariableTask(KeyVariableTask, CommonSubTask):
                             file_data = client.get_by_page_with_query(selector)
                         # Get data source with pagination
                         else:
-                            len_data = ctx.data_source_len.get(statement.full_name)
+                            len_data = ctx.data_source_len.get(DataSourceRegistry.data_source_cache_key(statement))
                             if len_data is None:
                                 len_data = client.count_query_length(selector)
                             file_data = client.get_cyclic_data(

--- a/tests_ce/integration_tests/test_data_source_length_collision/collision.xml
+++ b/tests_ce/integration_tests/test_data_source_length_collision/collision.xml
@@ -1,0 +1,9 @@
+<!-- Two SAME-NAMED statements read different-length sources (the shop-demo shape:
+     several <iterate name="db_product"> fill one table from JSON, CSV, generate).
+     The data-source length cache must key on (statement, source): keyed by name
+     alone, the second statement inherits the first one's length (3) and silently
+     drops its 4th row (the Evian regression). -->
+<setup rngSeed="1">
+    <iterate name="products" source="data/products_a.csv" distribution="ordered" target=""/>
+    <iterate name="products" source="data/products_b.csv" distribution="ordered" target=""/>
+</setup>

--- a/tests_ce/integration_tests/test_data_source_length_collision/data/products_a.csv
+++ b/tests_ce/integration_tests/test_data_source_length_collision/data/products_a.csv
@@ -1,0 +1,4 @@
+id|name
+1|Alpha
+2|Beta
+3|Gamma

--- a/tests_ce/integration_tests/test_data_source_length_collision/data/products_b.csv
+++ b/tests_ce/integration_tests/test_data_source_length_collision/data/products_b.csv
@@ -1,0 +1,5 @@
+id|name
+1|Alpha
+2|Beta
+3|Gamma
+4|Evian

--- a/tests_ce/integration_tests/test_data_source_length_collision/test_data_source_length_collision.py
+++ b/tests_ce/integration_tests/test_data_source_length_collision/test_data_source_length_collision.py
@@ -1,0 +1,27 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+"""Same-named statements with different sources must not share a cached source length.
+Regression for the shop-demo truncation: the second <iterate name="products"> inherited
+the first one's cached length (3) and silently dropped its 4th row."""
+
+from pathlib import Path
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+_TEST_DIR = Path(__file__).resolve().parent
+
+
+def test_same_name_different_source_lengths_do_not_collide():
+    engine = DataMimicTest(test_dir=_TEST_DIR, filename="collision.xml", capture_test_result=True)
+    engine.test_with_timer()
+    rows = engine.capture_result()["products"]
+
+    # The 4th row of the SECOND source must survive; with a name-only cache key the
+    # second statement reads only 3 rows and 'Evian' never appears anywhere.
+    assert any(r["name"] == "Evian" for r in rows), (
+        f"second statement was truncated to the first statement's cached length; got {len(rows)} rows"
+    )


### PR DESCRIPTION
…ot name alone

set_data_source_length cached a source's length under stmt.full_name only. Statements may share a name (the shop demo fills db_product from three same-named statements: DbUnit JSON 3 rows, CSV 4 rows, generate 50) - the second statement inherited the first one's cached length and silently truncated its rows (the 4th CSV row never appeared), and the read-back iterate saw the stale length too.

The cache key is now a TUPLE (full_name, source) built by DataSourceRegistry.data_source_cache_key on real statement types (GenerateStatement | VariableStatement | NestedKeyStatement via isinstance; no string concatenation, no duck-typing), used at the write site and the three read sites (generate_task x2, variable_task x1).

TDD regression (tests_ce/integration_tests/test_data_source_length_collision): two same-named <iterate> over a 3-row and a 4-row CSV; the 4th row must survive. Proven red on the pre-fix code (6 captured rows, no 'Evian') and green with the fix; full suites 526 unit + 411 integration.