### PR TITLE
feat(reference): <reference> supports MongoDB sources (shop-mongo parity)


### DIFF
--- a/datamimic_ce/clients/mongodb_client.py
+++ b/datamimic_ce/clients/mongodb_client.py
@@ -112,6 +112,24 @@ class MongoDBClient(DatabaseClient):
                 raise ValueError(f"Syntax error: collection name '{collection_name}' not found")
             return list(collection.find({}))
 
+    def get_random_rows_by_columns(self, collection_name: str, column_names: list[str]) -> list[tuple]:
+        """Fetch the given fields for a <reference> in a stable order, preserving row-tuple
+        integrity (same contract as RdbmsClient.get_random_rows_by_columns). Sorted server-side
+        on the selected fields (BSON total order): MongoDB's own $sample stage is NOT seedable
+        and may repeat documents, so the reference task does the deterministic sampling itself
+        via the seeded engine RNG over this stable order. A field missing on a document maps to
+        None, like an SQL NULL."""
+        if collection_name is None or collection_name.isspace():
+            raise ValueError(f"Syntax error: collection name '{collection_name}' not found")
+        with self._create_connection() as conn:
+            collection = conn[self._credential.database][collection_name]
+            projection = dict.fromkeys(column_names, 1)
+            if "_id" not in column_names:
+                projection["_id"] = 0
+            sort_spec = [(name, 1) for name in column_names]
+            docs = collection.find({}, projection).sort(sort_spec)
+            return [tuple(doc.get(name) for name in column_names) for doc in docs]
+
     def count(self, collection_name: str) -> int:
         """
         Count number of documents in collection

--- a/datamimic_ce/tasks/reference_task.py
+++ b/datamimic_ce/tasks/reference_task.py
@@ -8,6 +8,7 @@ import itertools
 from collections.abc import Iterator
 from typing import Any
 
+from datamimic_ce.clients.mongodb_client import MongoDBClient
 from datamimic_ce.clients.rdbms_client import RdbmsClient
 from datamimic_ce.contexts.context import Context
 from datamimic_ce.contexts.geniter_context import GenIterContext
@@ -30,7 +31,7 @@ class ReferenceTask(GenSubTask):
         return self._statement
 
     def execute(self, ctx: Context):
-        """Generate a (composite) reference record from an RDBMS data source."""
+        """Generate a (composite) reference record from an RDBMS or MongoDB data source."""
         if self._iterator is None:
             if self._pagination is None and self._has_selection_modifier():
                 # Without a page window the task may be rebuilt per record (nested in
@@ -66,8 +67,11 @@ class ReferenceTask(GenSubTask):
 
     def _init_iterator(self, ctx: Context) -> Iterator[dict[str, Any]]:
         client = ctx.root.clients.get(self.statement.source)
-        if not isinstance(client, RdbmsClient):
-            raise ValueError("Reference task currently only supports RDBMS data sources")
+        if not isinstance(client, RdbmsClient | MongoDBClient):
+            raise ValueError(
+                f"<reference> '{self._statement.name}': source '{self.statement.source}' is not a "
+                "<database> or <mongodb> client (RDBMS and MongoDB are supported)"
+            )
         rows = client.get_random_rows_by_columns(self.statement.source_type, self.statement.source_keys)
         if not rows:
             raise ValueError(f"No data found for reference {self._statement.name}")

--- a/tests_ce/external_service_tests/test_mongodb_reference/conf/environment.env.properties
+++ b/tests_ce/external_service_tests/test_mongodb_reference/conf/environment.env.properties
@@ -1,0 +1,31 @@
+#
+#  Copyright (c) 2024 Rapiddweller Asia Co., Ltd.
+#  All rights reserved.
+#
+#  This software and related documentation are provided under a license
+#  agreement containing restrictions on use and disclosure and are
+#  protected by intellectual property laws. Except as expressly permitted
+#  in your license agreement or allowed by law, you may not use, copy,
+#  reproduce, translate, broadcast, modify, license, transmit, distribute,
+#  exhibit, perform, publish, or display any part, in any form, or by any means.
+#
+#  This software is the confidential and proprietary information of
+#  Rapiddweller Asia Co., Ltd. ("Confidential Information"). You shall not
+#  disclose such Confidential Information and shall use it only in accordance
+#  with the terms of the license agreement you entered into with Rapiddweller Asia Co., Ltd.
+#
+#
+
+postgres.db.host=postgres
+postgres.db.port=5432
+postgres.db.database=rd-datamimic
+postgres.db.user=datamimic
+postgres.db.password=datamimic
+postgres.db.schema=simple
+postgres.db.dbms=postgresql
+
+mongodb.mongo.host=mongo
+mongodb.mongo.port=27017
+mongodb.mongo.database=datamimic
+mongodb.mongo.user=datamimic
+mongodb.mongo.password=datamimic

--- a/tests_ce/external_service_tests/test_mongodb_reference/conf/local.env.properties
+++ b/tests_ce/external_service_tests/test_mongodb_reference/conf/local.env.properties
@@ -1,0 +1,31 @@
+#
+#  Copyright (c) 2024 Rapiddweller Asia Co., Ltd.
+#  All rights reserved.
+#
+#  This software and related documentation are provided under a license
+#  agreement containing restrictions on use and disclosure and are
+#  protected by intellectual property laws. Except as expressly permitted
+#  in your license agreement or allowed by law, you may not use, copy,
+#  reproduce, translate, broadcast, modify, license, transmit, distribute,
+#  exhibit, perform, publish, or display any part, in any form, or by any means.
+#
+#  This software is the confidential and proprietary information of
+#  Rapiddweller Asia Co., Ltd. ("Confidential Information"). You shall not
+#  disclose such Confidential Information and shall use it only in accordance
+#  with the terms of the license agreement you entered into with Rapiddweller Asia Co., Ltd.
+#
+
+postgres.db.host=localhost
+postgres.db.port=45432
+postgres.db.database=rd-datamimic
+postgres.db.user=rdadm
+postgres.db.password=rdtest!
+postgres.db.schema=simple
+postgres.db.dbms=postgresql
+
+mongodb.mongo.host=localhost
+mongodb.mongo.port=47017
+mongodb.mongo.database=datamimic
+mongodb.mongo.user=datamimic
+mongodb.mongo.password=datamimic
+mongodb.mongo.authSource=admin

--- a/tests_ce/external_service_tests/test_mongodb_reference/reference_mongodb.xml
+++ b/tests_ce/external_service_tests/test_mongodb_reference/reference_mongodb.xml
@@ -1,0 +1,44 @@
+<!-- <reference> against a MongoDB collection: pull real foreign keys from documents.
+     Semantics mirror the RDBMS reference exactly (same task, same seeded selection):
+     default picks with replacement, ordered+cyclic wraps the stable key order,
+     unique draws distinct keys. MongoDB's own $sample stage is not seedable, so the
+     client fetches the key fields in a stable server-side sort and the seeded
+     engine RNG does the sampling. -->
+<setup rngSeed="7">
+    <memstore id="mem"/>
+    <mongodb id="mongodb"/>
+
+    <!-- reset the source collection -->
+    <generate name="cleanup" source="mongodb"
+              selector="find: 'ref_mongo_customers', filter: {}" target="mongodb.delete"/>
+
+    <!-- seed 7 customers with known keys -->
+    <generate name="ref_mongo_customers" target="mongodb" count="7">
+        <key name="customer_id" generator="IncrementGenerator"/>
+        <key name="tier" values="'retail','business'"/>
+    </generate>
+
+    <!-- default: pick with replacement, seeded -->
+    <generate name="orders_random" count="30" target="mem">
+        <key name="order_id" generator="IncrementGenerator"/>
+        <reference name="customer_id" source="mongodb" sourceType="ref_mongo_customers"
+                   sourceKey="customer_id"/>
+    </generate>
+    <generate name="check_random" distribution="ordered" type="orders_random" source="mem" target=""/>
+
+    <!-- ordered + cyclic: wrap the stable key order -->
+    <generate name="orders_cyclic" count="10" target="mem">
+        <key name="order_id" generator="IncrementGenerator"/>
+        <reference name="customer_id" source="mongodb" sourceType="ref_mongo_customers"
+                   sourceKey="customer_id" cyclic="true"/>
+    </generate>
+    <generate name="check_cyclic" distribution="ordered" type="orders_cyclic" source="mem" target=""/>
+
+    <!-- unique: distinct keys, pool covers the count -->
+    <generate name="orders_unique" count="7" target="mem">
+        <key name="order_id" generator="IncrementGenerator"/>
+        <reference name="customer_id" source="mongodb" sourceType="ref_mongo_customers"
+                   sourceKey="customer_id" unique="true"/>
+    </generate>
+    <generate name="check_unique" distribution="ordered" type="orders_unique" source="mem" target=""/>
+</setup>

--- a/tests_ce/external_service_tests/test_mongodb_reference/test_mongodb_reference.py
+++ b/tests_ce/external_service_tests/test_mongodb_reference/test_mongodb_reference.py
@@ -1,0 +1,48 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+"""<reference> on a MongoDB source: real FK values drawn from documents with the same
+seeded selection semantics as the RDBMS reference (random-with-replacement default,
+ordered+cyclic wrap, unique). Single-key references cover the shop-demo need
+(customer_id/order_id/...); composite <field> mapping shares the same tuple path."""
+
+from pathlib import Path
+
+from datamimic_ce.data_mimic_test import DataMimicTest
+
+_TEST_DIR = Path(__file__).resolve().parent
+_POOL = set(range(1, 8))  # seeded customer_ids 1..7
+
+
+def _run() -> dict:
+    engine = DataMimicTest(test_dir=_TEST_DIR, filename="reference_mongodb.xml", capture_test_result=True)
+    engine.test_with_timer()
+    return engine.capture_result()
+
+
+def test_mongodb_reference_semantics():
+    result = _run()
+
+    random_rows = result["check_random"]
+    assert len(random_rows) == 30
+    # every FK is a REAL seeded key (not invented, not None)
+    assert all(row["customer_id"] in _POOL for row in random_rows)
+    # with replacement over 30 draws from 7 keys, repeats are certain
+    assert len({row["customer_id"] for row in random_rows}) < 30
+
+    cyclic_rows = result["check_cyclic"]
+    # stable key order 1..7, wrapped: 1..7 then 1..3
+    assert [row["customer_id"] for row in cyclic_rows] == [1, 2, 3, 4, 5, 6, 7, 1, 2, 3]
+
+    unique_rows = result["check_unique"]
+    assert {row["customer_id"] for row in unique_rows} == _POOL  # all distinct, pool exhausted
+
+
+def test_mongodb_reference_is_deterministic():
+    first = _run()
+    second = _run()
+    for product in ("check_random", "check_cyclic", "check_unique"):
+        assert [r["customer_id"] for r in first[product]] == [r["customer_id"] for r in second[product]], product

--- a/tests_ce/unit_tests/tasks/test_reference_task.py
+++ b/tests_ce/unit_tests/tasks/test_reference_task.py
@@ -51,15 +51,17 @@ class TestReferenceTask(unittest.TestCase):
         task_with_pagination = ReferenceTask(self.statement, self.pagination)
         self.assertEqual(task_with_pagination._pagination, self.pagination)
 
-    def test_execute_non_rdbms_client(self):
-        """Test execution with non-RDBMS client."""
-        self.context.root.clients.get.return_value = MagicMock()  # Not an RdbmsClient
+    def test_execute_unsupported_client(self):
+        """A source that is neither an RDBMS nor a MongoDB client is rejected with a
+        message naming the reference and both supported client kinds."""
+        self.context.root.clients.get.return_value = MagicMock()  # neither Rdbms nor MongoDB
         task = ReferenceTask(self.statement)
 
         with self.assertRaises(ValueError) as context:
             task.execute(self.context)
 
-        self.assertEqual(str(context.exception), "Reference task currently only supports RDBMS data sources")
+        message = str(context.exception)
+        self.assertIn("RDBMS and MongoDB are supported", message)
 
     def test_execute_empty_dataset(self):
         """Test execution with empty dataset."""


### PR DESCRIPTION
ReferenceTask was RDBMS-only (reference_task.py raised for any other client);
the converted shop-mongo demo needs foreign keys drawn from Mongo collections
(customer_id, order_id, address_id, category_id).

- MongoDBClient.get_random_rows_by_columns(collection, fields) mirrors the
  RdbmsClient contract exactly: the key fields are fetched with a stable
  server-side sort (BSON total order) and returned as row tuples; a field
  missing on a document maps to None like an SQL NULL. MongoDB's own $sample
  stage is NOT seedable and may repeat documents (docs.mongodb.com), so the
  deterministic sampling stays in the reference task via the seeded engine
  RNG over this stable order - the same design the RDBMS path documents for
  ORDER BY random().
- reference_task dispatches on RdbmsClient | MongoDBClient; everything
  downstream (with-replacement default, ordered+cyclic wrap, unique via
  DataSourceRegistry, page windows, stable per-statement seeds) is shared
  untouched. Error message now names the reference and both supported kinds.

TDD trail (tests_ce/external_service_tests/test_mongodb_reference, real
MongoDB): red first with the literal "only supports RDBMS" error, then green:
random-with-replacement stays in the seeded key pool, ordered+cyclic wraps
[1..7,1,2,3], unique exhausts the pool distinctly, and two runs are identical
under rngSeed. The first failing run was the test's own bug - the memstore
read-backs lacked distribution="ordered" and DM301's RANDOM default shuffled
the assertion order; the linter flags exactly this (4x DM301).