### PR TITLE
Feat/mongo decimal and nested ref

### DIFF
--- a/datamimic_ce/clients/mongodb_client.py
+++ b/datamimic_ce/clients/mongodb_client.py
@@ -62,6 +62,17 @@ class MongoDBClient(DatabaseClient):
         elif isinstance(value, Mapping) and parts[0] in value:
             yield from MongoDBClient._values_at_path(value[parts[0]], parts[1:])
 
+    @staticmethod
+    def _shell_to_json(query: str) -> str:
+        """A MongoDB-shell-style selector -> a JSON string ``json.loads`` accepts. Benerator's mongo
+        selectors use shell syntax: single-quoted or BAREWORD object keys ($-operators, ``_id``,
+        projection fields) and a trailing ``cursor: {}``. Wrap first so the leading key has a
+        preceding ``{``; promote single quotes so quoted keys/strings are protected; then quote every
+        remaining unquoted bareword key. A value like ``"$total_price"`` is preceded by ``:`` (not
+        ``{``/``,``) and already quoted, so it is left untouched."""
+        s = "{" + query.replace("'", '"') + "}"
+        return re.sub(r'([{,]\s*)([$A-Za-z_][\w$]*)\s*:', r'\1"\2":', s)
+
     def _create_connection(self) -> MongoClient:
         ars = {
             "host": self._credential.host,
@@ -350,12 +361,8 @@ class MongoDBClient(DatabaseClient):
         :return: dict-keys: find, filter, projection
         """
         self._validate_query_command(query)
-        # change mongodb query into JSON string
-        input_query = query.replace("'", '"')
-        input_query = re.sub(r"\s*find\s*:", r'"find":', input_query)
-        input_query = re.sub(r"\s*filter\s*:", r'"filter":', input_query)
-        input_query = re.sub(r"\s*projection\s*:", r'"projection":', input_query)
-        input_query = f"{{{input_query}}}"
+        # change mongodb-shell query into a JSON string (bareword keys, $-operators, projection fields)
+        input_query = self._shell_to_json(query)
         # check and return query as dict
         try:
             result = json.loads(input_query)
@@ -375,11 +382,8 @@ class MongoDBClient(DatabaseClient):
         :return: dict-keys:  name, pipeline
         """
         self._validate_query_command(query)
-        # change mongodb query into JSON string
-        input_query = query.replace("'", '"')
-        input_query = re.sub(r"(?<!\")\s*aggregate\s*:(?!\")", r'"aggregate":', input_query)
-        input_query = re.sub(r"(?<!\")\s*pipeline\s*:(?!\")", r'"pipeline":', input_query)
-        input_query = f"{{{input_query}}}"
+        # change mongodb-shell query into a JSON string (bareword $-operators, _id, trailing cursor:{})
+        input_query = self._shell_to_json(query)
         # check and return query as dict
         try:
             result = json.loads(input_query)

--- a/datamimic_ce/clients/mongodb_client.py
+++ b/datamimic_ce/clients/mongodb_client.py
@@ -7,8 +7,10 @@
 import json
 import re
 from collections.abc import Mapping
+from decimal import Decimal
 from typing import Any, cast
 
+from bson.decimal128 import Decimal128
 from pymongo import MongoClient, UpdateOne
 
 from datamimic_ce.clients.database_client import DatabaseClient
@@ -20,6 +22,45 @@ from datamimic_ce.data_sources.data_source_pagination import DataSourcePaginatio
 class MongoDBClient(DatabaseClient):
     def __init__(self, credential: MongoDBConnectionConfig):
         self._credential = credential
+
+    @staticmethod
+    def _to_bson(value: Any) -> Any:
+        """Recursively convert types BSON cannot encode. ``decimal.Decimal`` -> ``bson.Decimal128``
+        (MongoDB's native 128-bit decimal): lossless, unlike a float cast. Applied on every write so a
+        DATAMIMIC ``type="decimal"`` field round-trips through mongo."""
+        if isinstance(value, Decimal):
+            return Decimal128(value)
+        if isinstance(value, Mapping):
+            return {k: MongoDBClient._to_bson(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [MongoDBClient._to_bson(v) for v in value]
+        return value
+
+    @staticmethod
+    def _from_bson(value: Any) -> Any:
+        """Inverse of ``_to_bson``: ``bson.Decimal128`` -> ``decimal.Decimal`` on read, so a script that
+        does arithmetic on a stored decimal (``product.price * qty``) gets a Python Decimal, not a
+        Decimal128 (which has no numeric operators)."""
+        if isinstance(value, Decimal128):
+            return value.to_decimal()
+        if isinstance(value, Mapping):
+            return {k: MongoDBClient._from_bson(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [MongoDBClient._from_bson(v) for v in value]
+        return value
+
+    @staticmethod
+    def _values_at_path(value: Any, parts: list[str]):
+        """All values reachable by descending a dotted field path; lists along the way unwind
+        (one value per nested element). How a <reference> resolves an entity nested inside a
+        collection document (a converted Benerator <part>)."""
+        if isinstance(value, list):
+            for item in value:
+                yield from MongoDBClient._values_at_path(item, parts)
+        elif not parts:
+            yield value
+        elif isinstance(value, Mapping) and parts[0] in value:
+            yield from MongoDBClient._values_at_path(value[parts[0]], parts[1:])
 
     def _create_connection(self) -> MongoClient:
         ars = {
@@ -57,7 +98,7 @@ class MongoDBClient(DatabaseClient):
                     collection = db[collection_name]
                 else:
                     raise ValueError(f"Syntax error: collection name '{collection_name}' not found")
-                return list(collection.find(find_filter, find_projection))
+                return self._from_bson(list(collection.find(find_filter, find_projection)))
             elif query_type == "aggregate":
                 query_result = self._query_aggregate_handler(query=query, connection=conn)
                 return query_result
@@ -110,7 +151,7 @@ class MongoDBClient(DatabaseClient):
                 collection = db[collection_name]
             else:
                 raise ValueError(f"Syntax error: collection name '{collection_name}' not found")
-            return list(collection.find({}))
+            return self._from_bson(list(collection.find({})))
 
     def get_random_rows_by_columns(self, collection_name: str, column_names: list[str]) -> list[tuple]:
         """Fetch the given fields for a <reference> in a stable order, preserving row-tuple
@@ -121,14 +162,27 @@ class MongoDBClient(DatabaseClient):
         None, like an SQL NULL."""
         if collection_name is None or collection_name.isspace():
             raise ValueError(f"Syntax error: collection name '{collection_name}' not found")
+        # A dotted sourceKey descends into nested documents (lists unwind): a reference to an entity
+        # nested INSIDE a collection document. Unwinding several independent paths has no meaningful
+        # row pairing, so a dotted path only combines with a single sourceKey.
+        dotted = any("." in name for name in column_names)
+        if dotted and len(column_names) > 1:
+            raise ValueError("A dotted (nested) reference path only supports a single sourceKey")
         with self._create_connection() as conn:
             collection = conn[self._credential.database][collection_name]
-            projection = dict.fromkeys(column_names, 1)
-            if "_id" not in column_names:
+            projection = {name.split(".", 1)[0]: 1 for name in column_names}
+            if "_id" not in projection:
                 projection["_id"] = 0
-            sort_spec = [(name, 1) for name in column_names]
-            docs = collection.find({}, projection).sort(sort_spec)
-            return [tuple(doc.get(name) for name in column_names) for doc in docs]
+            docs = list(collection.find({}, projection))
+        docs = self._from_bson(docs)
+        if not dotted:
+            rows = [tuple(doc.get(name) for name in column_names) for doc in docs]
+        else:
+            parts = column_names[0].split(".")
+            rows = [(value,) for doc in docs for value in self._values_at_path(doc, parts)]
+        # Stable order so the reference task's seeded sampling is reproducible run-to-run
+        # (BSON has no Python-comparable total order across mixed types, so key on the repr).
+        return sorted(rows, key=lambda row: [str(v) for v in row])
 
     def count(self, collection_name: str) -> int:
         """
@@ -195,7 +249,7 @@ class MongoDBClient(DatabaseClient):
         if not isinstance(aggregate_pipeline, list):
             raise ValueError("Syntax error: pipeline must be a list")
         # execute and return result
-        return list(collection.aggregate(aggregate_pipeline))
+        return self._from_bson(list(collection.aggregate(aggregate_pipeline)))
 
     def count_table_length(self, table_name: str):
         pass
@@ -211,6 +265,7 @@ class MongoDBClient(DatabaseClient):
         with self._create_connection() as conn:
             db = conn[self._credential.database]
             collection = db[collection_name]
+            data = [self._to_bson(d) for d in data]
             inserted_ids = collection.insert_many(data).inserted_ids
             # Retrieve all the inserted data
             return list(collection.find({"_id": {"$in": inserted_ids}})) if is_update else None
@@ -240,7 +295,7 @@ class MongoDBClient(DatabaseClient):
             with self._create_connection() as conn:
                 db = conn[self._credential.database]
                 collection = db[collection_name]
-                operation = [UpdateOne({"_id": d["_id"]}, {"$set": d}) for d in data]
+                operation = [UpdateOne({"_id": d["_id"]}, {"$set": self._to_bson(d)}) for d in data]
                 result = collection.bulk_write(operation)
                 return result.matched_count
         else:
@@ -269,7 +324,7 @@ class MongoDBClient(DatabaseClient):
         # query = self._decompose_find_query(selector)
 
         # Merge updated_data and filter query
-        updated_data = [{**filter_query, **data} for data in updated_data]
+        updated_data = [self._to_bson({**filter_query, **data}) for data in updated_data]
 
         if collection_name is None or collection_name.isspace():
             raise ValueError(f"Syntax error: collection name '{collection_name}' not found")

--- a/datamimic_ce/clients/mongodb_client.py
+++ b/datamimic_ce/clients/mongodb_client.py
@@ -191,9 +191,18 @@ class MongoDBClient(DatabaseClient):
         else:
             parts = column_names[0].split(".")
             rows = [(value,) for doc in docs for value in self._values_at_path(doc, parts)]
-        # Stable order so the reference task's seeded sampling is reproducible run-to-run
-        # (BSON has no Python-comparable total order across mixed types, so key on the repr).
-        return sorted(rows, key=lambda row: [str(v) for v in row])
+        # Stable order so the reference task's seeded sampling is reproducible run-to-run.
+        # Numbers sort numerically (not lexicographically: "10" must stay after "2"), everything
+        # else falls back to its string form; None sorts last, like an SQL NULL.
+        return sorted(rows, key=lambda row: tuple(self._sort_key(v) for v in row))
+
+    @staticmethod
+    def _sort_key(value: Any) -> tuple:
+        if value is None:
+            return (2, "")
+        if isinstance(value, int | float | Decimal):
+            return (0, float(value))
+        return (1, str(value))
 
     def count(self, collection_name: str) -> int:
         """
@@ -279,7 +288,9 @@ class MongoDBClient(DatabaseClient):
             data = [self._to_bson(d) for d in data]
             inserted_ids = collection.insert_many(data).inserted_ids
             # Retrieve all the inserted data
-            return list(collection.find({"_id": {"$in": inserted_ids}})) if is_update else None
+            if not is_update:
+                return None
+            return self._from_bson(list(collection.find({"_id": {"$in": inserted_ids}})))
 
     def update(self, query: dict, data: list) -> int:
         """
@@ -352,7 +363,9 @@ class MongoDBClient(DatabaseClient):
                     update = {"$set": doc}
                     collection.update_one(filter, update, upsert=True)
                 # Return updated data
-                return list(collection.find({"_id": {"$in": [doc["_id"] for doc in updated_data]}}))
+                return self._from_bson(
+                    list(collection.find({"_id": {"$in": [doc["_id"] for doc in updated_data]}}))
+                )
 
     def _decompose_find_query(self, query: str) -> dict:
         """

--- a/tests_ce/external_service_tests/test_mongodb/test_mongodb_decimal.xml
+++ b/tests_ce/external_service_tests/test_mongodb/test_mongodb_decimal.xml
@@ -1,0 +1,36 @@
+<!-- Decimal128 round-trip through MongoDB, plus the two shell-selector shapes that used to
+     break the JSON decomposer: a bareword find projection ({_id: 0, field: 1}) and an
+     aggregate pipeline with an unquoted operator key ({$group: ...}) and a trailing cursor: {}. -->
+<setup rngSeed="11">
+    <mongodb id="mongodb"/>
+
+    <generate name="cleanup" source="mongodb" selector="find: 'mongo_decimal_items', filter: {}" target="mongodb.delete"/>
+
+    <generate name="mongo_decimal_items" target="mongodb" count="5">
+        <key name="item_id" generator="IncrementGenerator"/>
+        <key name="price" type="decimal" generator="FloatGenerator(min=1, max=100, granularity=0.01)"/>
+        <key name="qty" generator="IntegerGenerator(min=1, max=10)"/>
+    </generate>
+
+    <!-- bareword projection keys: _id, item_id, price, qty are all unquoted -->
+    <generate name="check_items" count="5" target="">
+        <variable name="item" source="mongodb"
+                  selector="find: 'mongo_decimal_items', filter: {}, projection: {_id: 0, item_id: 1, price: 1, qty: 1}"/>
+        <key name="item_id" script="item.item_id"/>
+        <key name="price" script="item.price"/>
+        <key name="qty" script="item.qty"/>
+        <!-- proves the read-back Decimal supports arithmetic (would raise on a stray Decimal128) -->
+        <key name="total" script="item.price * item.qty"/>
+    </generate>
+
+    <!-- unquoted $group/$project operator keys + trailing cursor: {} -->
+    <generate name="check_total_agg" count="1" target="">
+        <variable name="agg" source="mongodb"
+                  selector="aggregate: 'mongo_decimal_items',
+                            pipeline: [{$group: {_id: 1, grand_total: {$sum: '$price'}}}, {$project: {_id: 0, grand_total: 1}}],
+                            cursor: {}"/>
+        <key name="grand_total" script="agg.grand_total"/>
+    </generate>
+
+    <generate name="cleanup_after" source="mongodb" selector="find: 'mongo_decimal_items', filter: {}" target="mongodb.delete"/>
+</setup>

--- a/tests_ce/external_service_tests/test_mongodb/test_mongodb_functional.py
+++ b/tests_ce/external_service_tests/test_mongodb/test_mongodb_functional.py
@@ -5,6 +5,7 @@
 # For questions and support, contact: info@rapiddweller.com
 
 
+from decimal import Decimal
 from pathlib import Path
 
 from bson import ObjectId
@@ -210,3 +211,22 @@ class TestMongoDbFunction:
             assert "_id" in m
             assert isinstance(m["_id"], ObjectId)
         assert all(a["user_id"] == b for a, b in zip(mongo_selector_ordered, range_list, strict=False))
+
+    def test_mongodb_decimal_roundtrip(self):
+        """type="decimal" round-trips through mongo as Decimal128 and stays arithmetic-safe, and the
+        selector parser accepts bareword projection keys and an unquoted aggregate $group/$project."""
+        engine = DataMimicTest(test_dir=self._test_dir, filename="test_mongodb_decimal.xml", capture_test_result=True)
+        engine.test_with_timer()
+
+        result = engine.capture_result()
+
+        check_items = result["check_items"]
+        assert len(check_items) == 5
+        for row in check_items:
+            assert isinstance(row["price"], Decimal)
+            assert isinstance(row["total"], Decimal)
+            assert row["total"] == row["price"] * row["qty"]
+
+        grand_total = result["check_total_agg"][0]["grand_total"]
+        assert isinstance(grand_total, Decimal)
+        assert grand_total == sum((row["price"] for row in check_items), Decimal("0"))

--- a/tests_ce/external_service_tests/test_mongodb_reference/reference_mongodb.xml
+++ b/tests_ce/external_service_tests/test_mongodb_reference/reference_mongodb.xml
@@ -12,8 +12,9 @@
     <generate name="cleanup" source="mongodb"
               selector="find: 'ref_mongo_customers', filter: {}" target="mongodb.delete"/>
 
-    <!-- seed 7 customers with known keys -->
-    <generate name="ref_mongo_customers" target="mongodb" count="7">
+    <!-- seed 12 customers with known keys: crosses the single/double-digit boundary, so the cyclic
+         check below only passes under a numeric sort (a lexicographic sort puts 10/11/12 before 2). -->
+    <generate name="ref_mongo_customers" target="mongodb" count="12">
         <key name="customer_id" generator="IncrementGenerator"/>
         <key name="tier" values="'retail','business'"/>
     </generate>
@@ -27,7 +28,7 @@
     <generate name="check_random" distribution="ordered" type="orders_random" source="mem" target=""/>
 
     <!-- ordered + cyclic: wrap the stable key order -->
-    <generate name="orders_cyclic" count="10" target="mem">
+    <generate name="orders_cyclic" count="15" target="mem">
         <key name="order_id" generator="IncrementGenerator"/>
         <reference name="customer_id" source="mongodb" sourceType="ref_mongo_customers"
                    sourceKey="customer_id" cyclic="true"/>
@@ -35,10 +36,31 @@
     <generate name="check_cyclic" distribution="ordered" type="orders_cyclic" source="mem" target=""/>
 
     <!-- unique: distinct keys, pool covers the count -->
-    <generate name="orders_unique" count="7" target="mem">
+    <generate name="orders_unique" count="12" target="mem">
         <key name="order_id" generator="IncrementGenerator"/>
         <reference name="customer_id" source="mongodb" sourceType="ref_mongo_customers"
                    sourceKey="customer_id" unique="true"/>
     </generate>
     <generate name="check_unique" distribution="ordered" type="orders_unique" source="mem" target=""/>
+
+    <!-- nested reference: sourceKey descends into an embedded sub-document (a converted <part>).
+         address_id = customer_id * 10 + seq makes every nested id globally unique and deterministic
+         without depending on IncrementGenerator's reset behavior across nestedKey iterations. -->
+    <generate name="cleanup_nested" source="mongodb"
+              selector="find: 'ref_mongo_customers_nested', filter: {}" target="mongodb.delete"/>
+
+    <generate name="ref_mongo_customers_nested" target="mongodb" count="3">
+        <key name="customer_id" generator="IncrementGenerator"/>
+        <nestedKey name="addresses" type="list" count="2">
+            <key name="seq" generator="IncrementGenerator"/>
+            <key name="address_id" script="parent.customer_id * 10 + this.seq"/>
+        </nestedKey>
+    </generate>
+
+    <generate name="orders_nested" count="6" target="mem">
+        <key name="order_id" generator="IncrementGenerator"/>
+        <reference name="address_id" source="mongodb" sourceType="ref_mongo_customers_nested"
+                   sourceKey="addresses.address_id" cyclic="true"/>
+    </generate>
+    <generate name="check_nested" distribution="ordered" type="orders_nested" source="mem" target=""/>
 </setup>

--- a/tests_ce/external_service_tests/test_mongodb_reference/test_mongodb_reference.py
+++ b/tests_ce/external_service_tests/test_mongodb_reference/test_mongodb_reference.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from datamimic_ce.data_mimic_test import DataMimicTest
 
 _TEST_DIR = Path(__file__).resolve().parent
-_POOL = set(range(1, 8))  # seeded customer_ids 1..7
+_POOL = set(range(1, 13))  # seeded customer_ids 1..12 (crosses the single/double-digit boundary)
 
 
 def _run() -> dict:
@@ -30,12 +30,13 @@ def test_mongodb_reference_semantics():
     assert len(random_rows) == 30
     # every FK is a REAL seeded key (not invented, not None)
     assert all(row["customer_id"] in _POOL for row in random_rows)
-    # with replacement over 30 draws from 7 keys, repeats are certain
+    # with replacement over 30 draws from 12 keys, repeats are certain
     assert len({row["customer_id"] for row in random_rows}) < 30
 
     cyclic_rows = result["check_cyclic"]
-    # stable key order 1..7, wrapped: 1..7 then 1..3
-    assert [row["customer_id"] for row in cyclic_rows] == [1, 2, 3, 4, 5, 6, 7, 1, 2, 3]
+    # stable key order 1..12, wrapped: 1..12 then 1..3. Only holds under a numeric sort - a
+    # lexicographic sort would put 10/11/12 right after 1, before 2.
+    assert [row["customer_id"] for row in cyclic_rows] == [*range(1, 13), 1, 2, 3]
 
     unique_rows = result["check_unique"]
     assert {row["customer_id"] for row in unique_rows} == _POOL  # all distinct, pool exhausted
@@ -44,5 +45,16 @@ def test_mongodb_reference_semantics():
 def test_mongodb_reference_is_deterministic():
     first = _run()
     second = _run()
-    for product in ("check_random", "check_cyclic", "check_unique"):
-        assert [r["customer_id"] for r in first[product]] == [r["customer_id"] for r in second[product]], product
+    for product in ("check_random", "check_cyclic", "check_unique", "check_nested"):
+        key = "customer_id" if product != "check_nested" else "address_id"
+        assert [r[key] for r in first[product]] == [r[key] for r in second[product]], product
+
+
+def test_mongodb_reference_nested_path():
+    """A dotted sourceKey ('addresses.address_id') resolves a <reference> to an entity nested
+    inside a collection document (a converted Benerator <part>), unwinding the embedded list."""
+    result = _run()
+    nested_rows = result["check_nested"]
+    # 3 customers x 2 addresses = 6 real nested address ids; cyclic wraps the stable order exactly
+    # once since count == pool size.
+    assert [row["address_id"] for row in nested_rows] == [11, 12, 21, 22, 31, 32]

--- a/tests_ce/unit_tests/test_mongo_codec_and_nested_ref.py
+++ b/tests_ce/unit_tests/test_mongo_codec_and_nested_ref.py
@@ -61,3 +61,37 @@ class TestMongoNestedReferencePath:
 
     def test_missing_path_yields_nothing(self):
         assert list(MongoDBClient._values_at_path(self._DOC, ["nope", "id"])) == []
+
+
+class TestMongoShellToJson:
+    """Benerator mongo selectors use shell syntax (bareword keys, $-operators, single quotes)."""
+
+    def test_find_with_bareword_projection(self):
+        import json
+
+        q = "find: 'db_product', filter: {}, projection: {_id: 0, ean_code: 1, price: 1}"
+        r = json.loads(MongoDBClient._shell_to_json(q))
+        assert r["find"] == "db_product"
+        assert r["projection"] == {"_id": 0, "ean_code": 1, "price": 1}
+
+    def test_aggregate_pipeline_with_unquoted_project_and_trailing_cursor(self):
+        import json
+
+        q = (
+            "'aggregate': 'db_order_item', pipeline: ["
+            "{'$match': {'order_id': {'$eq': 1000}}}, "
+            "{'$group': {'_id': 1000, 'sum': {'$sum': '$total_price'}}}, "
+            "{$project: {_id: 0, sum: 1}}], cursor: {} "
+        )
+        r = json.loads(MongoDBClient._shell_to_json(q))
+        assert r["aggregate"] == "db_order_item"
+        assert len(r["pipeline"]) == 3
+        assert r["pipeline"][2] == {"$project": {"_id": 0, "sum": 1}}
+        # a field-reference value keeps its $ and is not mangled into a key
+        assert r["pipeline"][1]["$group"]["sum"]["$sum"] == "$total_price"
+
+    def test_already_quoted_keys_untouched(self):
+        import json
+
+        r = json.loads(MongoDBClient._shell_to_json("find: 'c', filter: {'x': 1}, projection: {'y': 1}"))
+        assert r["filter"] == {"x": 1} and r["projection"] == {"y": 1}

--- a/tests_ce/unit_tests/test_mongo_codec_and_nested_ref.py
+++ b/tests_ce/unit_tests/test_mongo_codec_and_nested_ref.py
@@ -1,0 +1,63 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+from decimal import Decimal
+
+from bson.decimal128 import Decimal128
+
+from datamimic_ce.clients.mongodb_client import MongoDBClient
+
+
+class TestMongoDecimalCodec:
+    """decimal.Decimal round-trips through mongo as the native Decimal128 (not a lossy float)."""
+
+    def test_encode_decimal_to_decimal128(self):
+        out = MongoDBClient._to_bson({"price": Decimal("60.09"), "qty": 3})
+        assert isinstance(out["price"], Decimal128)
+        assert out["price"].to_decimal() == Decimal("60.09")
+        assert out["qty"] == 3  # non-decimal untouched
+
+    def test_encode_is_recursive(self):
+        out = MongoDBClient._to_bson({"a": [{"b": Decimal("1.5")}], "c": {"d": Decimal("2.0")}})
+        assert isinstance(out["a"][0]["b"], Decimal128)
+        assert isinstance(out["c"]["d"], Decimal128)
+
+    def test_decode_decimal128_to_decimal(self):
+        out = MongoDBClient._from_bson({"price": Decimal128("60.09"), "name": "x"})
+        assert out["price"] == Decimal("60.09")
+        assert isinstance(out["price"], Decimal)
+        assert out["name"] == "x"
+
+    def test_roundtrip_supports_arithmetic(self):
+        # the shop demo does product.price * qty on a value read back from mongo
+        stored = MongoDBClient._to_bson({"price": Decimal("2.50")})
+        read = MongoDBClient._from_bson(stored)
+        assert read["price"] * 4 == Decimal("10.00")
+
+
+class TestMongoNestedReferencePath:
+    """A dotted reference sourceKey descends into nested documents; lists unwind."""
+
+    _DOC = {
+        "id": 1000,
+        "db_customer": [{"id": 1000, "db_address": [{"id": 7, "city": "Amory"}]}],
+    }
+
+    def test_plain_field(self):
+        assert list(MongoDBClient._values_at_path(self._DOC, ["id"])) == [1000]
+
+    def test_nested_single_level(self):
+        assert list(MongoDBClient._values_at_path(self._DOC, ["db_customer", "id"])) == [1000]
+
+    def test_nested_two_levels(self):
+        assert list(MongoDBClient._values_at_path(self._DOC, ["db_customer", "db_address", "id"])) == [7]
+
+    def test_list_unwinds_one_value_each(self):
+        doc = {"a": [{"b": 1}, {"b": 2}, {"c": 3}]}
+        assert list(MongoDBClient._values_at_path(doc, ["a", "b"])) == [1, 2]
+
+    def test_missing_path_yields_nothing(self):
+        assert list(MongoDBClient._values_at_path(self._DOC, ["nope", "id"])) == []

--- a/tests_ce/unit_tests/test_mongo_codec_and_nested_ref.py
+++ b/tests_ce/unit_tests/test_mongo_codec_and_nested_ref.py
@@ -95,3 +95,21 @@ class TestMongoShellToJson:
 
         r = json.loads(MongoDBClient._shell_to_json("find: 'c', filter: {'x': 1}, projection: {'y': 1}"))
         assert r["filter"] == {"x": 1} and r["projection"] == {"y": 1}
+
+
+class TestMongoReferenceSortKey:
+    """Reference row order must stay numeric, not lexicographic ("10" before "2")."""
+
+    def test_multi_digit_ints_sort_numerically(self):
+        rows = [(10,), (2,), (1,), (11,), (3,)]
+        assert sorted(rows, key=lambda row: tuple(MongoDBClient._sort_key(v) for v in row)) == [
+            (1,),
+            (2,),
+            (3,),
+            (10,),
+            (11,),
+        ]
+
+    def test_none_sorts_last(self):
+        rows = [(5,), (None,), (1,)]
+        assert sorted(rows, key=lambda row: tuple(MongoDBClient._sort_key(v) for v in row)) == [(1,), (5,), (None,)]


### PR DESCRIPTION
## Summary
Three MongoDB engine gaps surfaced by migrating the Benerator shop-mongo demo, on top of #187:

- **Decimal128 round-trip**: `type="decimal"` fields now encode as BSON's native `Decimal128` on write and decode back to `decimal.Decimal` on read (insert/update/upsert/find/aggregate), so stored decimals stay arithmetic-safe (`product.price * qty`).
- **Nested-document reference paths**: a `<reference>` can now target an entity nested inside a collection document (a converted `<part>`) via a dotted `sourceKey`, descending the document and unwinding lists.
- **Robust shell-to-JSON selector parsing**: a single `_shell_to_json` normalizer now quotes every unquoted bareword object key (not just the top-level keys), so real Mongo selectors with bareword projections (`{_id: 0, ean_code: 1}`) and aggregate operators (`{$project: {...}}`, trailing `cursor: {}`) parse correctly.

A third commit fixes two gaps found while reviewing the above before opening this PR:
- `get_random_rows_by_columns` had moved from MongoDB's server-side numeric sort to a Python-side sort keyed on `str(v)` — lexicographic, so multi-digit ids (`10`, `2`) sorted wrong. Now uses a numeric-aware sort key.
- `insert(is_update=True)` and `upsert()`'s update path returned raw `find()` results without the new `Decimal128 -> Decimal` conversion, leaking `Decimal128` back into exactly the flows the round-trip was meant to fix.

A fourth commit adds DATAMIMIC DSL end-to-end test coverage (real `.xml` descriptors run through the engine against a live MongoDB), since the original unit tests only exercised the internal codec/parser methods directly and couldn't catch an integration-level regression:
- `test_mongodb_reference/reference_mongodb.xml`: seeded pool widened 7 → 12 (crosses the single/double-digit boundary, so the cyclic-order assertion only passes under a numeric sort), plus a nested-document reference case (`<nestedKey type="list">` embedding addresses per customer) proving a dotted `sourceKey` resolves through an embedded array.
- `test_mongodb/test_mongodb_decimal.xml`: writes a `type="decimal"` field to mongo and reads it back via a bareword-projection `find` and an unquoted-`$group`/`$project` `aggregate` with a trailing `cursor: {}`, asserting the read-back Decimal still does arithmetic.

## Test plan
- [x] `pytest tests_ce/unit_tests/test_mongo_codec_and_nested_ref.py` — 14/14 passed
- [x] `RUNTIME_ENVIRONMENT=development pytest tests_ce/external_service_tests/test_mongodb_reference/ tests_ce/external_service_tests/test_mongodb/ tests_ce/external_service_tests/test_mongodb_error/ tests_ce/external_service_tests/test_integration_mongodb/ tests_ce/external_service_tests/test_demo/demo-mongodb/` — 44 passed, 1 skipped
- [x] `mypy datamimic_ce` — clean, full repo