### PR TITLE
refactor(mongo): real depth-aware parser for selector type/duplicate detection

### DIFF
--- a/datamimic_ce/clients/mongodb_client.py
+++ b/datamimic_ce/clients/mongodb_client.py
@@ -419,8 +419,8 @@ class MongoDBClient(DatabaseClient):
         """
         # validate find
         query = query.strip()
-        find_match = re.findall(r"find\s*:", query)
-        aggregate_match = re.findall(r"aggregate\s*:", query)
+        find_match = re.findall(r"""['\"]?find['\"]?\s*:""", query)
+        aggregate_match = re.findall(r"""['\"]?aggregate['\"]?\s*:""", query)
         if find_match and aggregate_match:
             raise ValueError("Error syntax, only one query type allow but found both 'find' and 'aggregate'")
         if find_match:
@@ -454,8 +454,10 @@ class MongoDBClient(DatabaseClient):
         Currently only support 'find' and 'aggregate'
         :param query:
         """
-        find_pattern = r"^\s*find\s*:"
-        aggregate_pattern = r"^\s*aggregate\s*:"
+        # the command key may be bareword or quoted: find:/'find':/"find": (both forms appear
+        # across Benerator shell selectors), so tolerate an optional surrounding quote
+        find_pattern = r"""^\s*['\"]?find['\"]?\s*:"""
+        aggregate_pattern = r"""^\s*['\"]?aggregate['\"]?\s*:"""
         is_find = re.match(find_pattern, query) is not None
         is_aggregate = re.match(aggregate_pattern, query) is not None
         if is_find:

--- a/datamimic_ce/clients/mongodb_client.py
+++ b/datamimic_ce/clients/mongodb_client.py
@@ -410,6 +410,36 @@ class MongoDBClient(DatabaseClient):
             raise ValueError(f"Wrong mongodb selector syntax: {query}, error: {err}") from err
 
     @staticmethod
+    def _top_level_keys(query: str) -> list[str]:
+        """Depth-0 keys of a mongo shell-style selector, in order of appearance. A single
+        quote/brace/bracket-aware pass, not a regex guessing at quote style: a key is bareword,
+        single-, or double-quoted, uniformly; a value's own colons/commas/braces (inside a quoted
+        string, or nested one level down in a filter/pipeline) never leak into the top level, so a
+        field literally named 'find' inside a nested value is never mistaken for the command key."""
+        keys: list[str] = []
+        depth = 0
+        quote_char: str | None = None
+        segment_start = 0
+        for i, c in enumerate(query):
+            if quote_char:
+                if c == quote_char:
+                    quote_char = None
+            elif c in "'\"":
+                quote_char = c
+            elif c in "{[":
+                depth += 1
+            elif c in "}]":
+                depth -= 1
+            elif depth == 0 and c == ":":
+                raw_key = query[segment_start:i].strip().lstrip(",").strip()
+                if len(raw_key) >= 2 and raw_key[0] == raw_key[-1] and raw_key[0] in "'\"":
+                    raw_key = raw_key[1:-1]
+                keys.append(raw_key)
+            elif depth == 0 and c == ",":
+                segment_start = i
+        return keys
+
+    @staticmethod
     def _validate_query_command(query: str):
         """
         validate query string
@@ -417,33 +447,25 @@ class MongoDBClient(DatabaseClient):
         'aggregate' query have elements: 'aggregate', 'pipeline'
         :param query:
         """
-        # validate find
         query = query.strip()
-        find_match = re.findall(r"""['\"]?find['\"]?\s*:""", query)
-        aggregate_match = re.findall(r"""['\"]?aggregate['\"]?\s*:""", query)
-        if find_match and aggregate_match:
+        keys = MongoDBClient._top_level_keys(query)
+        find_count = keys.count("find")
+        aggregate_count = keys.count("aggregate")
+        if find_count and aggregate_count:
             raise ValueError("Error syntax, only one query type allow but found both 'find' and 'aggregate'")
-        if find_match:
-            find_count = len(find_match) if find_match else 0
+        if find_count:
             if find_count > 1:
                 raise ValueError(f"Error syntax, only 1 'find' allow but found {find_count}")
-            # validate filter
-            filter_match = re.findall(r"filter\s*:", query)
-            filter_count = len(filter_match) if filter_match else 0
+            filter_count = keys.count("filter")
             if filter_count > 1:
                 raise ValueError(f"Error syntax, only 1 'filter' allow but found {filter_count}")
-            # validate projection
-            projection_match = re.findall(r"projection\s*:", query)
-            projection_count = len(projection_match) if projection_match else 0
+            projection_count = keys.count("projection")
             if projection_count > 1:
                 raise ValueError(f"Error syntax, only 1 'projection' allow but found {projection_count}")
-        elif aggregate_match:
-            aggregate_count = len(aggregate_match) if aggregate_match else 0
+        elif aggregate_count:
             if aggregate_count > 1:
                 raise ValueError(f"Error syntax, only 1 'aggregate' allow but found {aggregate_count}")
-            # validate pipeline
-            pipeline_match = re.findall(r"pipeline\s*:", query)
-            pipeline_count = len(pipeline_match) if pipeline_match else 0
+            pipeline_count = keys.count("pipeline")
             if pipeline_count > 1:
                 raise ValueError(f"Error syntax, only 1 'pipeline' allow but found {pipeline_count}")
 
@@ -454,15 +476,11 @@ class MongoDBClient(DatabaseClient):
         Currently only support 'find' and 'aggregate'
         :param query:
         """
-        # the command key may be bareword or quoted: find:/'find':/"find": (both forms appear
-        # across Benerator shell selectors), so tolerate an optional surrounding quote
-        find_pattern = r"""^\s*['\"]?find['\"]?\s*:"""
-        aggregate_pattern = r"""^\s*['\"]?aggregate['\"]?\s*:"""
-        is_find = re.match(find_pattern, query) is not None
-        is_aggregate = re.match(aggregate_pattern, query) is not None
-        if is_find:
+        keys = MongoDBClient._top_level_keys(query)
+        first_key = keys[0] if keys else None
+        if first_key == "find":
             return "find"
-        elif is_aggregate:
+        elif first_key == "aggregate":
             return "aggregate"
         else:
             raise ValueError(

--- a/tests_ce/external_service_tests/test_mongodb/test_mongodb_decimal.xml
+++ b/tests_ce/external_service_tests/test_mongodb/test_mongodb_decimal.xml
@@ -1,6 +1,7 @@
-<!-- Decimal128 round-trip through MongoDB, plus the two shell-selector shapes that used to
-     break the JSON decomposer: a bareword find projection ({_id: 0, field: 1}) and an
-     aggregate pipeline with an unquoted operator key ({$group: ...}) and a trailing cursor: {}. -->
+<!-- Decimal128 round-trip through MongoDB, plus the shell-selector shapes that used to break:
+     a bareword find projection ({_id: 0, field: 1}), an aggregate pipeline with an unquoted
+     operator key ({$group: ...}) and a trailing cursor: {}, and - the mixed style the shop demo
+     actually uses - a quoted 'aggregate': command key sitting next to an unquoted find: below. -->
 <setup rngSeed="11">
     <mongodb id="mongodb"/>
 
@@ -23,10 +24,11 @@
         <key name="total" script="item.price * item.qty"/>
     </generate>
 
-    <!-- unquoted $group/$project operator keys + trailing cursor: {} -->
+    <!-- quoted 'aggregate': command key (the shop demo's actual style, inconsistent with the
+         unquoted find: selectors above) + unquoted $group/$project operator keys + trailing cursor: {} -->
     <generate name="check_total_agg" count="1" target="">
         <variable name="agg" source="mongodb"
-                  selector="aggregate: 'mongo_decimal_items',
+                  selector="'aggregate': 'mongo_decimal_items',
                             pipeline: [{$group: {_id: 1, grand_total: {$sum: '$price'}}}, {$project: {_id: 0, grand_total: 1}}],
                             cursor: {}"/>
         <key name="grand_total" script="agg.grand_total"/>

--- a/tests_ce/unit_tests/test_mongo_codec_and_nested_ref.py
+++ b/tests_ce/unit_tests/test_mongo_codec_and_nested_ref.py
@@ -134,3 +134,43 @@ class TestMongoQueryTypeDetection:
 
         with pytest.raises(ValueError, match="only support"):
             MongoDBClient._check_query_type("delete: 'c'")
+
+    def test_nested_field_named_find_is_not_the_command(self):
+        # a real parse only looks at depth-0 keys; a substring-count regex would see two 'find's
+        q = "aggregate: 'c', pipeline: [{'$project': {find: 1}}]"
+        assert MongoDBClient._check_query_type(q) == "aggregate"
+
+
+class TestMongoTopLevelKeys:
+    """A single depth-aware pass over the selector replaces three independent regexes
+    (type sniffing, duplicate-key counting) that each separately guessed at quote style."""
+
+    def test_bareword_keys(self):
+        assert MongoDBClient._top_level_keys("find: 'c', filter: {}, projection: {}") == [
+            "find",
+            "filter",
+            "projection",
+        ]
+
+    def test_single_and_double_quoted_keys(self):
+        assert MongoDBClient._top_level_keys("'find': 'c', \"filter\": {}") == ["find", "filter"]
+
+    def test_nested_keys_are_not_top_level(self):
+        # 'find' and 'filter' inside the pipeline value must not count as top-level keys
+        q = "aggregate: 'c', pipeline: [{'$match': {'find': 1, 'filter': 2}}]"
+        assert MongoDBClient._top_level_keys(q) == ["aggregate", "pipeline"]
+
+    def test_duplicate_top_level_key_regardless_of_quote_style(self):
+        assert MongoDBClient._top_level_keys("find: 'a', 'find': 'b', filter: {}") == ["find", "find", "filter"]
+
+    def test_colon_and_comma_inside_quoted_value_are_not_structural(self):
+        # a string value containing ':' and ',' must not be mistaken for a key boundary
+        q = "find: 'c', filter: {'name': 'a, b: c'}, projection: {}"
+        assert MongoDBClient._top_level_keys(q) == ["find", "filter", "projection"]
+
+    def test_bracket_pipeline_value_does_not_leak_keys(self):
+        assert MongoDBClient._top_level_keys("aggregate: 'c', pipeline: [], cursor: {}") == [
+            "aggregate",
+            "pipeline",
+            "cursor",
+        ]

--- a/tests_ce/unit_tests/test_mongo_codec_and_nested_ref.py
+++ b/tests_ce/unit_tests/test_mongo_codec_and_nested_ref.py
@@ -113,3 +113,24 @@ class TestMongoReferenceSortKey:
     def test_none_sorts_last(self):
         rows = [(5,), (None,), (1,)]
         assert sorted(rows, key=lambda row: tuple(MongoDBClient._sort_key(v) for v in row)) == [(1,), (5,), (None,)]
+
+
+class TestMongoQueryTypeDetection:
+    """The command key may be bareword OR quoted across Benerator selectors."""
+
+    def test_bareword_find(self):
+        assert MongoDBClient._check_query_type("find: 'c', filter: {}") == "find"
+
+    def test_quoted_aggregate(self):
+        # the shop-mongodb update selector single-quotes the key: 'aggregate': ...
+        q = "'aggregate': 'db_order_item', pipeline: [{'$match': {}}]"
+        assert MongoDBClient._check_query_type(q) == "aggregate"
+
+    def test_double_quoted_find(self):
+        assert MongoDBClient._check_query_type('"find": "c", filter: {}') == "find"
+
+    def test_unknown_command_rejected(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="only support"):
+            MongoDBClient._check_query_type("delete: 'c'")


### PR DESCRIPTION
## Summary
On top of #188: `_check_query_type` and `_validate_query_command` were three independent regexes, each separately guessing at quote style around the `find`/`aggregate` command key — the shop-mongo demo's selectors mix styles inconsistently (`find: ...` bareword next to `'aggregate': ...` single-quoted), which is what broke type detection originally.

The first commit here patched that by making the regexes quote-tolerant. On reflection, that's the second such patch after #188's bareword-projection/aggregate-operator fix — regex substring counting over what's really a small JS-object-literal grammar is a losing game: every new quoting/whitespace/nesting shape is a new edge case, and `_validate_query_command`'s unanchored `re.findall` would also miscount a field literally named `find`/`filter`/`pipeline` nested inside a value (a latent false-positive that predates this PR).

The second commit replaces both regexes with `_top_level_keys`: a single quote/brace/bracket-aware pass that extracts only the depth-0 keys of the selector, uniformly across bareword/single/double-quoted forms. `_check_query_type` and `_validate_query_command` now just inspect that key list instead of pattern-matching the raw string. `_shell_to_json`'s JSON-value normalization (already correct) is untouched.

## Test plan
- TDD: `TestMongoTopLevelKeys` + additional `TestMongoQueryTypeDetection` cases were written and run RED (`AttributeError` — no such method) before `_top_level_keys` existed, then GREEN after.
- Every existing error-message contract (`test_mongodb_error` suite: two-find, two-aggregate, find+aggregate ambiguity, two-filter, two-projection, two-pipeline, pipeline/filter-not-found, wrong-query-type) verified byte-for-byte unchanged.
- `test_mongodb_decimal.xml`'s quoted `'aggregate':` selector (added in the first commit) still passes end to end.
- `RUNTIME_ENVIRONMENT=development pytest` across all mongo external-service folders — 55 passed, 1 skipped.
- `mypy datamimic_ce` and `ruff check` — clean.

## Known pre-existing gap (not fixed here, out of scope)
`update()`'s `META_SELECTOR` branch always calls `_decompose_find_query(...)`, so it would raise if a `target="mongodb.update"` selector were aggregate-shaped. No existing test or DSL descriptor does that (the demo's total write-back uses a find selector / `targetEntity`), so this is unexercised and speculative — noted for the record, not fixed.