### PR TITLE
fix(engine): nested scope bare-variable resolution (narrowed to self)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,10 +37,14 @@ before data is written.
 
 ## The semantic rules that cause most authoring failures
 
-1. Scope: inside a nested `<generate>` or `<nestedKey>`, record-local names need
-   `this.` (`this.account_no`, `this.person.name`). Bare names resolve only at
-   the top level. `parent.field` reads the enclosing record, `root.field` the
-   outermost. See `examples/showcase/01-banking-core/`.
+1. Scope: inside a nested `<generate>` or `<nestedKey>`, a sibling in the SAME
+   scope resolves bare, same as `this.` (`this.account_no` and bare
+   `account_no` are equivalent there). An ANCESTOR scope's name still needs
+   `this.`/`parent.`/`root.` — it does not resolve bare from a descendant,
+   and if a descendant redeclares the same name, the ancestor's own bare
+   reference still wins (no silent shadowing). `parent.field` reads the
+   enclosing record, `root.field` the outermost. See
+   `examples/showcase/01-banking-core/`.
 2. `IncrementGenerator` counts per parent inside a nested `<generate>`, not
    globally. Compose unique child ids from the parent key plus the local
    sequence: `script="parent.customer_id * 10 + this.account_no"`.

--- a/datamimic_ce/contexts/context.py
+++ b/datamimic_ce/contexts/context.py
@@ -296,11 +296,11 @@ class Context(ABC):
             }
         # GenIterContext evaluate script
         else:
-            # 1) Nested wrapping tree (unchanged): each scope holds its child scope under the child's
-            #    name, so a qualified path like `orders.line_items.product.field` resolves; the
-            #    outermost scope's own vars land at the top level and the setup namespace/globals
-            #    merge in. `wrapped_scopes` collects the INNER scopes that got wrapped under a name.
-            wrapped_scopes: list = []
+            # Nested wrapping tree: each scope holds its child scope under the child's name, so a
+            # qualified path like `orders.line_items.product.field` resolves; the outermost scope's
+            # own vars land at the top level and the setup namespace/globals merge in.
+            self_context = current_context
+            self_is_outermost = False
             while isinstance(current_context, GenIterContext):
                 parent_context = current_context.parent
                 if isinstance(parent_context, SetupContext):
@@ -311,6 +311,7 @@ class Context(ABC):
                         **current_context.current_product,
                         **data_dict,
                     }
+                    self_is_outermost = current_context is self_context
                     break
                 data_dict = {
                     current_context.current_name: {
@@ -319,15 +320,15 @@ class Context(ABC):
                         **data_dict,
                     }
                 }
-                wrapped_scopes.append(current_context)
                 current_context = parent_context
-            # 2) Every wrapped inner scope's variables/products ALSO resolve by BARE name (the loop
-            #    only flattened the outermost). Applied outermost -> innermost so an inner scope
-            #    SHADOWS an outer one on a clash: a record-local name (a sibling <variable> feeding a
-            #    <key> script) resolves without a scope prefix at ANY nesting depth, exactly as it
-            #    does in a top-level <generate>. Qualified paths from step 1 stay intact.
-            for scope in reversed(wrapped_scopes):
-                data_dict = {**data_dict, **scope.current_variables, **scope.current_product}
+            # The scope evaluating THIS script also resolves its own variables/products by bare
+            # name, not only nested under its own scope name (mirrors what `this.` already exposes -
+            # a sibling <variable> feeding a <key> script in the same nested scope). Only self, not
+            # every ancestor: an ancestor's bare name still needs this./parent./root., so a name
+            # collision between scopes at different depths can't silently flip which value a bare
+            # reference resolves to.
+            if not self_is_outermost and isinstance(self_context, GenIterContext):
+                data_dict = {**data_dict, **self_context.current_variables, **self_context.current_product}
 
         return data_dict
 

--- a/datamimic_ce/contexts/context.py
+++ b/datamimic_ce/contexts/context.py
@@ -85,8 +85,8 @@ SAFE_GLOBALS = {
 # The number-one authoring trap: bare record-local names only resolve at the top level.
 # Appended to undefined-name errors so the failure itself teaches the scope rule.
 _SCOPE_GUIDANCE = (
-    "record-local names need this. inside nested <generate>/<nestedKey>; "
-    "use parent./root. for enclosing records"
+    "a same-scope sibling resolves bare (or via this.) - check the name; "
+    "an ANCESTOR scope's name needs parent./root., it does not resolve bare"
 )
 
 # List of special functions that define in SAFE_GLOBALS

--- a/datamimic_ce/contexts/context.py
+++ b/datamimic_ce/contexts/context.py
@@ -296,11 +296,14 @@ class Context(ABC):
             }
         # GenIterContext evaluate script
         else:
+            # 1) Nested wrapping tree (unchanged): each scope holds its child scope under the child's
+            #    name, so a qualified path like `orders.line_items.product.field` resolves; the
+            #    outermost scope's own vars land at the top level and the setup namespace/globals
+            #    merge in. `wrapped_scopes` collects the INNER scopes that got wrapped under a name.
+            wrapped_scopes: list = []
             while isinstance(current_context, GenIterContext):
                 parent_context = current_context.parent
-
                 if isinstance(parent_context, SetupContext):
-                    # Add current variable & product of outermost context
                     data_dict = {
                         **parent_context.namespace,
                         **parent_context.global_variables,
@@ -309,7 +312,6 @@ class Context(ABC):
                         **data_dict,
                     }
                     break
-                # Update current data_dict with current context variable & product
                 data_dict = {
                     current_context.current_name: {
                         **current_context.current_variables,
@@ -317,7 +319,15 @@ class Context(ABC):
                         **data_dict,
                     }
                 }
+                wrapped_scopes.append(current_context)
                 current_context = parent_context
+            # 2) Every wrapped inner scope's variables/products ALSO resolve by BARE name (the loop
+            #    only flattened the outermost). Applied outermost -> innermost so an inner scope
+            #    SHADOWS an outer one on a clash: a record-local name (a sibling <variable> feeding a
+            #    <key> script) resolves without a scope prefix at ANY nesting depth, exactly as it
+            #    does in a top-level <generate>. Qualified paths from step 1 stay intact.
+            for scope in reversed(wrapped_scopes):
+                data_dict = {**data_dict, **scope.current_variables, **scope.current_product}
 
         return data_dict
 

--- a/datamimic_ce/contexts/context.py
+++ b/datamimic_ce/contexts/context.py
@@ -323,12 +323,13 @@ class Context(ABC):
                 current_context = parent_context
             # The scope evaluating THIS script also resolves its own variables/products by bare
             # name, not only nested under its own scope name (mirrors what `this.` already exposes -
-            # a sibling <variable> feeding a <key> script in the same nested scope). Only self, not
-            # every ancestor: an ancestor's bare name still needs this./parent./root., so a name
-            # collision between scopes at different depths can't silently flip which value a bare
-            # reference resolves to.
+            # a sibling <variable> feeding a <key> script in the same nested scope). Self fills in
+            # names an ancestor doesn't already provide bare; an ancestor's own bare name always
+            # wins on a clash (`**data_dict` last), so a script combining an ancestor's and its own
+            # same-named variable (e.g. `id + simple_user.id`, a real fixture in this repo) keeps
+            # resolving bare `id` to the ancestor's, exactly as before this change.
             if not self_is_outermost and isinstance(self_context, GenIterContext):
-                data_dict = {**data_dict, **self_context.current_variables, **self_context.current_product}
+                data_dict = {**self_context.current_variables, **self_context.current_product, **data_dict}
 
         return data_dict
 

--- a/tests_ce/integration_tests/test_nested_scope_bare_variable/nested_scope.xml
+++ b/tests_ce/integration_tests/test_nested_scope_bare_variable/nested_scope.xml
@@ -25,4 +25,18 @@
             </nestedKey>
         </nestedKey>
     </generate>
+
+    <!-- Real fixture this exact collision broke: tests_ce/functional_tests/test_sqlite (id +
+         simple_user.id) declares its OWN "id" both in the outer scope and in a directly nested one,
+         combining the ancestor's bare id with the nested scope's own id via its qualified name. The
+         nested scope's own bare variable must fill gaps, never override a name the ancestor already
+         provides bare - otherwise every row silently collapses onto the same id. -->
+    <generate name="self_vs_ancestor" count="1" target="JSON">
+        <variable name="id" constant="outer_id"/>
+        <nestedKey name="child" type="list" count="1">
+            <variable name="id" constant="child_id"/>
+            <key name="bare_id" script="id"/>
+            <key name="qualified_id" script="child.id"/>
+        </nestedKey>
+    </generate>
 </setup>

--- a/tests_ce/integration_tests/test_nested_scope_bare_variable/nested_scope.xml
+++ b/tests_ce/integration_tests/test_nested_scope_bare_variable/nested_scope.xml
@@ -1,0 +1,14 @@
+<setup defaultDataset="US" defaultLocale="en_US">
+    <generate name="outer" count="1" target="JSON">
+        <variable name="tag" entity="Person"/>
+        <nestedKey name="inner" type="list" count="2">
+            <variable name="person" entity="Person"/>
+            <!-- BARE sibling variable in a nested scope must resolve (like a top-level generate) -->
+            <key name="salutation" script="person.salutation"/>
+            <!-- BARE access to an ANCESTOR scope variable must also resolve -->
+            <key name="outer_tag_family" script="tag.familyName"/>
+            <!-- QUALIFIED nested path via the wrapped scope must still resolve -->
+            <key name="qualified" script="inner.person.givenName"/>
+        </nestedKey>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_nested_scope_bare_variable/nested_scope.xml
+++ b/tests_ce/integration_tests/test_nested_scope_bare_variable/nested_scope.xml
@@ -11,4 +11,18 @@
             <key name="qualified" script="inner.person.givenName"/>
         </nestedKey>
     </generate>
+
+    <!-- A scope's own bare variable must NOT shadow a same-named ancestor variable for a scope
+         that does not declare it itself: bare resolution stays "outermost wins" unless the
+         evaluating scope has its own declaration (this. semantics), so a name collision between
+         scopes at different depths can't silently flip which value a bare reference resolves to. -->
+    <generate name="collision" count="1" target="JSON">
+        <variable name="v" constant="outer_val"/>
+        <nestedKey name="mid" type="list" count="1">
+            <variable name="v" constant="mid_val"/>
+            <nestedKey name="leaf" type="list" count="1">
+                <key name="bare_v" script="v"/>
+            </nestedKey>
+        </nestedKey>
+    </generate>
 </setup>

--- a/tests_ce/integration_tests/test_nested_scope_bare_variable/nested_scope_reach_up.xml
+++ b/tests_ce/integration_tests/test_nested_scope_bare_variable/nested_scope_reach_up.xml
@@ -1,0 +1,13 @@
+<setup defaultDataset="US" defaultLocale="en_US">
+    <!-- A middle scope's variable must stay invisible by bare name to a DEEPER scope that does not
+         declare it itself - only this./parent./root. reach an ancestor. A leaf script that typos a
+         bare name matching an unrelated ancestor's variable must fail loud, not silently resolve. -->
+    <generate name="a" count="1" target="JSON">
+        <nestedKey name="b" type="list" count="1">
+            <variable name="mid" constant="mid_val"/>
+            <nestedKey name="c" type="list" count="1">
+                <key name="bare_mid_from_c" script="mid"/>
+            </nestedKey>
+        </nestedKey>
+    </generate>
+</setup>

--- a/tests_ce/integration_tests/test_nested_scope_bare_variable/test_nested_scope_bare_variable.py
+++ b/tests_ce/integration_tests/test_nested_scope_bare_variable/test_nested_scope_bare_variable.py
@@ -6,6 +6,9 @@
 
 from pathlib import Path
 
+import pytest
+
+from datamimic_ce.data_mimic_test import DataMimicTest
 from datamimic_ce.factory.datamimic_test_factory import DataMimicTestFactory
 
 _dir = Path(__file__).resolve().parent
@@ -19,3 +22,21 @@ def test_bare_variable_resolves_in_nested_generate():
         assert row["salutation"], "bare sibling variable did not resolve in nested scope"
         assert row["outer_tag_family"], "bare ancestor variable did not resolve"
         assert row["qualified"], "qualified nested path did not resolve"
+
+
+def test_bare_variable_does_not_shadow_ancestor_across_depths():
+    """A scope's own bare variable resolution must not flip which ancestor value a deeper scope
+    sees: 'leaf' has no own 'v', so bare 'v' still resolves to the OUTERMOST declaration
+    ('outer_val'), not the nearer 'mid' one - a name collision between scopes at different depths
+    can't silently change what an unrelated bare reference means."""
+    collision = DataMimicTestFactory(_dir / "nested_scope.xml", "collision").create()
+    assert collision["mid"][0]["leaf"][0]["bare_v"] == "outer_val"
+
+
+def test_bare_variable_does_not_reach_up_past_self():
+    """A leaf script referencing a bare name that only a non-self ancestor declares ('mid', declared
+    two scopes up) must still fail loud with the scope-rule guidance, not silently resolve - the
+    same as before this fix, just scoped to the self-only bare resolution it adds."""
+    engine = DataMimicTest(_dir, "nested_scope_reach_up.xml", capture_test_result=True)
+    with pytest.raises(ValueError, match="not defined in this scope"):
+        engine.test_with_timer()

--- a/tests_ce/integration_tests/test_nested_scope_bare_variable/test_nested_scope_bare_variable.py
+++ b/tests_ce/integration_tests/test_nested_scope_bare_variable/test_nested_scope_bare_variable.py
@@ -40,3 +40,14 @@ def test_bare_variable_does_not_reach_up_past_self():
     engine = DataMimicTest(_dir, "nested_scope_reach_up.xml", capture_test_result=True)
     with pytest.raises(ValueError, match="not defined in this scope"):
         engine.test_with_timer()
+
+
+def test_own_bare_variable_does_not_override_ancestor_of_same_name():
+    """A scope's own bare variable fills gaps, it never overrides a name the ancestor already
+    provides bare (regression: tests_ce/functional_tests/test_sqlite's `id + simple_user.id`
+    silently collapsed onto the SAME id for every row once the nested scope's own 'id' started
+    winning bare resolution)."""
+    result = DataMimicTestFactory(_dir / "nested_scope.xml", "self_vs_ancestor").create()
+    child = result["child"][0]
+    assert child["bare_id"] == "outer_id"
+    assert child["qualified_id"] == "child_id"

--- a/tests_ce/integration_tests/test_nested_scope_bare_variable/test_nested_scope_bare_variable.py
+++ b/tests_ce/integration_tests/test_nested_scope_bare_variable/test_nested_scope_bare_variable.py
@@ -1,0 +1,21 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+from pathlib import Path
+
+from datamimic_ce.factory.datamimic_test_factory import DataMimicTestFactory
+
+_dir = Path(__file__).resolve().parent
+
+
+def test_bare_variable_resolves_in_nested_generate():
+    """A sibling <variable> feeds a <key> script by BARE name at any nesting depth (regression:
+    a nested scope's own variable was only reachable as <scope>.<var>, not bare)."""
+    outer = DataMimicTestFactory(_dir / "nested_scope.xml", "outer").create()
+    for row in outer["inner"]:
+        assert row["salutation"], "bare sibling variable did not resolve in nested scope"
+        assert row["outer_tag_family"], "bare ancestor variable did not resolve"
+        assert row["qualified"], "qualified nested path did not resolve"


### PR DESCRIPTION
## Summary
- Reported bug (real): a sibling `<variable>` inside a nested `<generate>`/`<nestedKey>` was only reachable by a sibling `<key>` script as `scope.var`, never bare — while the identical pattern at the top level worked bare directly.
- The original fix (`0aa6155`) resolved this by flattening *every* enclosing scope bare, inner shadowing outer at any depth. That's correct for the reported symptom but bigger than it needs to be, and it silently changes two things `AGENTS.md` rule 1 documents ("bare names resolve only at the top level; use `this.`/`parent.`/`root.`"):
  - a bare name colliding across two ancestor scopes silently resolves to the *nearer* one instead of the outermost one — same script, different output, no exception either way.
  - a typo'd bare name that happens to match an unrelated ancestor 2+ levels up silently resolves instead of raising the existing scope-rule `NameError`.
- `this.person.salutation` already resolves the reported bug today on `development`, no engine change required.
- Narrowed the fix instead of dropping it: only the scope *evaluating the script* gets its own variables/products merged bare (mirroring what `this.` already exposes) — ancestors still require `this.`/`parent.`/`root.`.
- **A follow-up commit fixes a real regression this surfaced on CI**: `tests_ce/functional_tests/test_sqlite::test_more_sqlite` failed with a sqlite `UNIQUE constraint` error — every inserted row got the same `id`. The fixture's `<key name="id" script="id + simple_user.id"/>` deliberately combines an ancestor's bare `id` with its own nested scope's `id` via the qualified path; once the nested scope's own bare `id` started winning, both sides of that formula collapsed onto the same value. Fixed by making self's own bare vars fill gaps only — an ancestor's bare name always wins on a clash. Added a permanent regression test (`self_vs_ancestor` in `nested_scope.xml`) modeled directly on this real fixture.

## Test plan
- [x] Original regression test (`test_bare_variable_resolves_in_nested_generate`) still passes.
- [x] `test_bare_variable_does_not_shadow_ancestor_across_depths`, `test_bare_variable_does_not_reach_up_past_self`, `test_own_bare_variable_does_not_override_ancestor_of_same_name` — each confirmed to fail under the version of the fix it guards against.
- [x] `tests_ce/functional_tests/test_sqlite::test_more_sqlite` (the real regression CI caught) passes again.
- [x] Full local suite (unit + integration + functional + api + factory): 1424 passed, 15 skipped.
- [x] `mypy datamimic_ce` clean, `ruff check` clean.