### PR TITLE
feat(generators): widen DepartmentNameGenerator data, fix de/en mismatch

### DIFF
--- a/datamimic_ce/domains/common/literal_generators/department_name_generator.py
+++ b/datamimic_ce/domains/common/literal_generators/department_name_generator.py
@@ -22,17 +22,28 @@ class DepartmentNameGenerator(BaseLiteralGenerator):
             "Manufacturing",
             "Logistics",
             "Legal",
+            "Engineering",
+            "Finance",
+            "Customer Support",
+            "Operations",
+            "Research and Development",
         ]
         sp_locale = ("de", "en")
         if locale == "de":
             self._department_data = [
-                "Accounting",
+                "Buchhaltung",
                 "Human Resources",
                 "Vertrieb",
                 "Marketing",
                 "IT",
+                "Fertigung",
                 "Logistik",
                 "Recht",
+                "Entwicklung",
+                "Finanzen",
+                "Kundensupport",
+                "Betrieb",
+                "Forschung und Entwicklung",
             ]
         elif locale not in sp_locale:
             logger.info(f"Department name does not support locale '{locale}'. Change to department_en data")

--- a/tests_ce/unit_tests/test_generator/test_department_name_generator.py
+++ b/tests_ce/unit_tests/test_generator/test_department_name_generator.py
@@ -1,0 +1,20 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+
+from datamimic_ce.domains.common.literal_generators.department_name_generator import DepartmentNameGenerator
+
+
+def test_department_name_generator_support_locale():
+    support_locales = ("en", "de")
+    for support_locale in support_locales:
+        department = DepartmentNameGenerator(locale=support_locale).generate()
+        assert isinstance(department, str)
+
+
+def test_department_name_generator_unsupported_locale_falls_back_to_en():
+    department = DepartmentNameGenerator(locale="fr").generate()
+    assert department in DepartmentNameGenerator(locale="en")._department_data


### PR DESCRIPTION
## Summary
- Reported as a missing generator (`DepartmentNameGenerator`), but it already exists at `datamimic_ce/domains/common/literal_generators/department_name_generator.py` - registered automatically via `auto_register_generators()` (location + naming convention, no manual export needed).
- The actual gap: a thin word list (no Engineering/Finance/Customer Support/Operations/R&D) and a de/en mismatch - the German list carried untranslated English words ("Accounting") and was missing a "Manufacturing" counterpart.
- Widened both locale lists to the same 13 departments, properly translated for de.
- Added the missing unit test (none existed - only incidental DSL coverage in `test_large_count/test_generators.xml` and the demo `organization.xml` that exercises generation without asserting on values).

**Reproducibility note:** `DepartmentNameGenerator.generate()` is `rng.choice(self._department_data)`. Widening/reordering that list changes which department a given seed produces - any existing seeded run using this generator will get different (but still valid) department values after this merges. Unavoidable if the goal is more departments; flagging so it's not a surprise for a seeded-run consumer.

## Test plan
- [x] New unit test (`test_department_name_generator_support_locale`, `test_department_name_generator_unsupported_locale_falls_back_to_en`).
- [x] Existing DSL fixture using the generator still passes.
- [x] mypy/ruff clean.