### PR TITLE
fix(generate): only block genuinely headerless .wgt.csv at generate-level

### DIFF
--- a/datamimic_ce/tasks/task_util.py
+++ b/datamimic_ce/tasks/task_util.py
@@ -93,6 +93,19 @@ from datamimic_ce.utils.object_util import ObjectUtil
 
 class TaskUtil:
     @staticmethod
+    def _wgt_csv_has_header(file_path, separator: str) -> bool:
+        """Whether a '.wgt.csv' file's first row is a header: its weight column isn't numeric
+        (same sniff FileUtil.read_weight_csv itself uses to skip an optional header row)."""
+        raw_data = FileUtil._read_raw_csv(file_path, separator, "utf-8")
+        if not raw_data or len(raw_data[0]) <= 1:
+            return False
+        try:
+            float(raw_data[0][1])
+            return False
+        except (TypeError, ValueError):
+            return True
+
+    @staticmethod
     def get_task_by_statement(
         ctx: SetupContext,
         stmt: Statement,
@@ -344,19 +357,23 @@ class TaskUtil:
             else:
                 # Evaluate script in source
                 source_data = context.evaluate_python_expression(stmt.script)
-        elif source_str.endswith(".wgt.csv"):
-            # A ".wgt.csv" file is headerless (value|weight, no column names) - the plain CSV
-            # reader below would treat its first data row as a header, producing nonsense column
-            # names and one fewer row than the file has. Unlike ".wgt.ent.csv" (a normal headered
-            # CSV that merely has an extra "weight" column - reading it plainly is coherent, just
-            # unweighted), there is no coherent plain-CSV reading of this format at all. <key
-            # source="...wgt.csv"> already applies its weights correctly; <generate>-level
-            # weighted-entity sourcing is real work, not yet done - fail loudly instead of
-            # silently generating garbage.
+        elif source_str.endswith(".wgt.csv") and not TaskUtil._wgt_csv_has_header(
+            root_context.descriptor_dir / source_str, separator
+        ):
+            # A HEADERLESS ".wgt.csv" file (value|weight, no column names) has no coherent plain-CSV
+            # reading at all - the reader below would treat its first data row as a header,
+            # producing nonsense column names and one fewer row than the file has. A HEADERED
+            # ".wgt.csv" falls through to the plain ".csv" branch below instead: like ".wgt.ent.csv"
+            # (a normal headered CSV that merely has an extra "weight" column), reading it plainly is
+            # coherent, just unweighted. <key source="...wgt.csv"> already applies weights correctly
+            # either way (FileUtil.read_weight_csv auto-detects the header); <generate>-level
+            # weighted-entity sourcing is real work, not yet done - fail loudly instead of silently
+            # generating garbage, but only where there IS no coherent fallback.
             raise ValueError(
                 f"<generate> '{stmt.full_name}': source '{source_str}' is a headerless weighted "
                 f"value|weight file - not supported at <generate>-level (only <key source=...> "
-                f"applies '.wgt.csv' weights today)"
+                f"applies '.wgt.csv' weights today; add a header row to read it as a plain, "
+                f"unweighted CSV instead)"
             )
         # Load data from CSV
         elif source_str.endswith(".csv"):

--- a/datamimic_ce/tasks/task_util.py
+++ b/datamimic_ce/tasks/task_util.py
@@ -97,13 +97,7 @@ class TaskUtil:
         """Whether a '.wgt.csv' file's first row is a header: its weight column isn't numeric
         (same sniff FileUtil.read_weight_csv itself uses to skip an optional header row)."""
         raw_data = FileUtil._read_raw_csv(file_path, separator, "utf-8")
-        if not raw_data or len(raw_data[0]) <= 1:
-            return False
-        try:
-            float(raw_data[0][1])
-            return False
-        except (TypeError, ValueError):
-            return True
+        return bool(raw_data) and len(raw_data[0]) > 1 and not FileUtil._parses_as_float(raw_data[0][1])
 
     @staticmethod
     def get_task_by_statement(

--- a/tests_ce/integration_tests/test_generate_wgt_source_guard/data/active_with_header.wgt.csv
+++ b/tests_ce/integration_tests/test_generate_wgt_source_guard/data/active_with_header.wgt.csv
@@ -1,0 +1,3 @@
+value|weight
+true|80
+false|20

--- a/tests_ce/integration_tests/test_generate_wgt_source_guard/generate_wgt_with_header.xml
+++ b/tests_ce/integration_tests/test_generate_wgt_source_guard/generate_wgt_with_header.xml
@@ -1,0 +1,3 @@
+<setup>
+    <generate name="rows" source="data/active_with_header.wgt.csv" count="5" target="JSON"/>
+</setup>

--- a/tests_ce/integration_tests/test_generate_wgt_source_guard/test_generate_wgt_source_guard.py
+++ b/tests_ce/integration_tests/test_generate_wgt_source_guard/test_generate_wgt_source_guard.py
@@ -4,16 +4,21 @@
 # See LICENSE file for the full text of the license.
 # For questions and support, contact: info@rapiddweller.com
 
-"""<generate source="x.wgt.csv"> (the headerless value|weight format) falls through to the plain
-CSV reader, which has no coherent way to read it - it would treat the first data row as a header,
-producing nonsense column names and one fewer row than the file has. Full weighted-entity support
-at <generate>-level needs pagination-core work (see PR #194 discussion); until that lands, fail
-loudly instead of silently producing garbage.
+"""<generate source="x.wgt.csv"> (the value|weight format) only raises when the file is
+HEADERLESS - the plain CSV reader has no coherent way to read that at all, it would treat the
+first data row as a header, producing nonsense column names and one fewer row than the file has.
+A HEADERED ".wgt.csv" (FileUtil.read_weight_csv now accepts either, see feat/wgt-csv-header-
+optional) falls through to the plain CSV reader instead: reading it plainly (ignoring the weight,
+no resampling) is coherent, just unweighted - the same tolerance ".wgt.ent.csv" already gets.
 
-".wgt.ent.csv" is different: it's a normal headered CSV that happens to carry an extra "weight"
-column, so reading it plainly (ignoring the weight, no resampling) is coherent - just unweighted.
-An existing test (test_source_script/test_iterate_source_scripted.xml) already relies on exactly
-that, so this must keep working."""
+Full weighted-entity support at <generate>-level needs pagination-core work (see PR #194
+discussion); until that lands, fail loudly instead of silently producing garbage, but only where
+there is no coherent fallback.
+
+".wgt.ent.csv" is a normal headered CSV that happens to carry an extra "weight" column, so reading
+it plainly (ignoring the weight, no resampling) is coherent - just unweighted. An existing test
+(test_source_script/test_iterate_source_scripted.xml) already relies on exactly that, so this must
+keep working."""
 
 from pathlib import Path
 
@@ -24,10 +29,21 @@ from datamimic_ce.data_mimic_test import DataMimicTest
 _dir = Path(__file__).resolve().parent
 
 
-def test_generate_source_wgt_csv_raises():
+def test_generate_source_wgt_csv_headerless_raises():
     engine = DataMimicTest(_dir, "generate_wgt_plain.xml", capture_test_result=True)
     with pytest.raises(ValueError, match=r"\.wgt\.csv"):
         engine.test_with_timer()
+
+
+def test_generate_source_wgt_csv_with_header_reads_as_plain_csv():
+    """A headered '.wgt.csv' is NOT weighted (no resampling, no bias toward the higher-weight
+    row) - just an ordinary headered CSV read, weight column included as literal data. Must NOT
+    raise, unlike the headerless case."""
+    engine = DataMimicTest(_dir, "generate_wgt_with_header.xml", capture_test_result=True)
+    engine.test_with_timer()
+    rows = engine.capture_result()["rows"]
+    assert {row["value"] for row in rows} <= {"true", "false"}
+    assert all("weight" in row for row in rows)
 
 
 def test_generate_source_wgt_ent_csv_reads_as_plain_csv():


### PR DESCRIPTION
## Summary
- #194 blocked ALL \`.wgt.csv\` at \`<generate>\`-level, merged before #196 (\`.wgt.csv\` accepts an optional header) landed. That makes it too strict now: a HEADERED \`.wgt.csv\` reads coherently through the plain CSV path (proper column names, just unweighted) - the same tolerance \`.wgt.ent.csv\` already gets. Only a genuinely headerless \`.wgt.csv\` has no coherent plain-CSV reading at all (first data row misread as a header, producing nonsense column names).
- Narrowed the guard to sniff the file's own first row (same check \`FileUtil.read_weight_csv\` itself uses to auto-detect a header) and only raise when there is no header to fall back on.

## Test plan
- [x] Headerless \`.wgt.csv\` at \`<generate>\`-level still raises.
- [x] New: headered \`.wgt.csv\` at \`<generate>\`-level now reads through (unweighted, coherent columns) instead of raising.
- [x] \`.wgt.ent.csv\` regression test still passes.
- [x] Full suite: 1442 passed, 15 skipped, mypy/ruff clean.