### PR TITLE
feat(generators): SequenceTableGenerator explicit sequence= name (Benerator parity)

### DIFF
--- a/datamimic_ce/clients/rdbms_client.py
+++ b/datamimic_ce/clients/rdbms_client.py
@@ -518,8 +518,13 @@ class RdbmsClient(DatabaseClient):
         with self._create_engine().connect() as connection:
             transaction = connection.begin()
             try:
-                # Check if sequence exists in the specified schema
+                # Check if sequence exists in the specified schema. A dotted name
+                # ('zsv.t_angebote_id_seq', explicit sequence= from the DSL) carries its own
+                # schema - splitting here keeps every query below two-part; blindly prepending
+                # the credential schema would build malformed public.zsv.t_angebote_id_seq.
                 schema = self._credential.db_schema or "public"
+                if "." in sequence_name:
+                    schema, sequence_name = sequence_name.split(".", 1)
                 check_query = text(
                     "SELECT EXISTS (SELECT 1 FROM pg_sequences WHERE schemaname = :schema AND sequencename = :seq_name)"
                 )
@@ -551,6 +556,8 @@ class RdbmsClient(DatabaseClient):
             transaction = connection.begin()
             try:
                 schema = self._credential.db_schema or "public"
+                if "." in sequence_name:  # dotted name carries its own schema (see get_current_sequence_number)
+                    schema, sequence_name = sequence_name.split(".", 1)
                 # Use a transaction to ensure atomicity
                 query = text(
                     f"SELECT setval('{schema}.{sequence_name}', nextval('{schema}.{sequence_name}') + :increment)"

--- a/datamimic_ce/domains/common/literal_generators/generator_util.py
+++ b/datamimic_ce/domains/common/literal_generators/generator_util.py
@@ -137,11 +137,19 @@ class GeneratorUtil:
                 return result
 
             if class_name == "SequenceTableGenerator":
-                result = cls(context=self._context, stmt=stmt)
+                # Optional explicit sequence name: SequenceTableGenerator(sequence='zsv.t_angebote_id_seq')
+                # (Benerator DBSequenceGenerator parity). ast-parsed like DateTimeGenerator below, but
+                # keyword-only and single-kwarg - anything else raises, args are never silently dropped.
+                parsed_sequence = GeneratorUtil._parse_sequence_kwarg(generator_str)
+                result = cls(context=self._context, stmt=stmt, sequence=parsed_sequence)
                 if pagination:
                     result.add_pagination(pagination=pagination)
-                # Use unified cache key (may differ from generator_str when a key is provided)
-                self._context.root.generators[cache_key] = result
+                    # Cache only generation-ready (paginated) instances. GenerateTask.pre_execute
+                    # builds its sub-tasks with pagination=None; caching that instance under the
+                    # same full_name|generator cache key the paginated page-tasks use later made
+                    # every single-process run hit _current=None -> StopIteration on the first
+                    # record -> 0 rows (only the numProcess=2 path had coverage, masking this).
+                    self._context.root.generators[cache_key] = result
                 return result
 
             # --- DateTimeGenerator special parsing ---
@@ -274,6 +282,47 @@ class GeneratorUtil:
                 raise ValueError(f"Cannot create generator '{current_class_name}'{element_name_str}: {e}") from e
             else:
                 raise
+
+    @staticmethod
+    def _parse_sequence_kwarg(generator_str: str) -> str | None:
+        """Extract the optional sequence='...' kwarg from a SequenceTableGenerator generator
+        string. Bare "SequenceTableGenerator" and empty "SequenceTableGenerator()" return None
+        (convention-derived name). Positional args, unknown kwargs, non-string values, and
+        malformed syntax all raise ValueError - this generator's args used to be silently
+        discarded, which is exactly the failure mode this replaces."""
+        if "(" not in generator_str:
+            return None
+        try:
+            module_node = ast.parse(generator_str)
+        except SyntaxError as e_syn:
+            raise ValueError(
+                f"Error parsing parameters for SequenceTableGenerator from '{generator_str}': {e_syn}"
+            ) from e_syn
+        if not (
+            module_node.body
+            and isinstance(module_node.body[0], ast.Expr)
+            and isinstance(module_node.body[0].value, ast.Call)
+            and isinstance(module_node.body[0].value.func, ast.Name)
+            and module_node.body[0].value.func.id == "SequenceTableGenerator"
+        ):
+            raise ValueError(f"Cannot parse SequenceTableGenerator arguments from '{generator_str}'")
+        call_node = module_node.body[0].value
+        if call_node.args:
+            raise ValueError(
+                f"SequenceTableGenerator does not accept positional arguments; "
+                f"use sequence='...' in '{generator_str}'"
+            )
+        parsed_sequence: str | None = None
+        for kw in call_node.keywords:
+            if kw.arg != "sequence":
+                raise ValueError(
+                    f"Unsupported keyword argument '{kw.arg}' for SequenceTableGenerator in "
+                    f"'{generator_str}'; only 'sequence' is supported"
+                )
+            if not isinstance(kw.value, ast.Constant) or not isinstance(kw.value.value, str):
+                raise ValueError(f"'sequence' must be a string literal in '{generator_str}'")
+            parsed_sequence = kw.value.value
+        return parsed_sequence
 
     @staticmethod
     def is_valid_uuid(input_string: str) -> bool:

--- a/datamimic_ce/domains/common/literal_generators/sequence_table_generator.py
+++ b/datamimic_ce/domains/common/literal_generators/sequence_table_generator.py
@@ -36,6 +36,7 @@ class SequenceTableGenerator(BaseLiteralGenerator):
         self,
         context: Context,
         stmt: KeyStatement | VariableStatement,
+        sequence: str | None = None,
     ):
         """
         Initialize the sequence table generator.
@@ -43,6 +44,12 @@ class SequenceTableGenerator(BaseLiteralGenerator):
         Args:
             context: Context object containing configuration and state
             stmt: Statement object containing sequence configuration
+            sequence: Optional explicit DB sequence name (e.g. 'zsv.t_angebote_id_seq' for a
+                schema-qualified native sequence - Benerator DBSequenceGenerator parity). When
+                None, falls back to the convention-derived f"{type}_{name}_seq". Caution: a
+                sequence that doesn't exist is still auto-created starting at 1, so a typo'd
+                explicit name silently mints a fresh sequence instead of erroring - against a
+                live table with real rows that means duplicate keys.
 
         Raises:
             ValueError: If required attributes are missing or invalid
@@ -53,6 +60,7 @@ class SequenceTableGenerator(BaseLiteralGenerator):
         self._process_id: int | None = None
         self._current: int | None = None
         self._end: int | None = None
+        self._explicit_sequence_name = sequence or None  # "" falls back to convention too
 
         # Handle database attribute access safely
         if not hasattr(stmt, "database"):
@@ -63,10 +71,12 @@ class SequenceTableGenerator(BaseLiteralGenerator):
         if rdbms_client is None:
             raise ValueError(f"No database client found for source: {self._source_name}")
 
-        # Get root generate statement safely
+        # Get root generate statement safely (stashed: the root of a key/variable cannot change
+        # over this instance's lifetime, so pre_execute reuses it instead of re-walking the tree)
         root_gen_stmt = self._stmt.get_root_generate_statement()
         if root_gen_stmt is None:
             raise ValueError("Root generate statement is required")
+        self._root_gen_stmt = root_gen_stmt
 
         # Initialize sequence with process-safe range
         try:
@@ -79,9 +89,7 @@ class SequenceTableGenerator(BaseLiteralGenerator):
             per_process_count = (total_count + total_processes - 1) // total_processes
 
             # Get current sequence and calculate process-specific range
-            current_seq = rdbms_client.get_current_sequence_number(
-                sequence_name=f"{root_gen_stmt.type}_{self._stmt.name}_seq"
-            )
+            current_seq = rdbms_client.get_current_sequence_number(sequence_name=self._resolve_sequence_name())
 
             # Calculate process-specific offset to avoid conflicts
             process_offset = self._process_id * per_process_count
@@ -94,6 +102,13 @@ class SequenceTableGenerator(BaseLiteralGenerator):
         except Exception as e:
             raise ValueError(f"Failed to initialize sequence: {str(e)}") from e
 
+    def _resolve_sequence_name(self) -> str:
+        """Explicit sequence= name if given (e.g. a migrated Benerator DBSequenceGenerator name,
+        schema-qualified or not); otherwise the existing convention f"{type}_{name}_seq"."""
+        if self._explicit_sequence_name:
+            return self._explicit_sequence_name
+        return f"{self._root_gen_stmt.type}_{self._stmt.name}_seq"
+
     def pre_execute(self, context: Context) -> None:
         """
         Increase the sequence number in the database before execution.
@@ -105,16 +120,12 @@ class SequenceTableGenerator(BaseLiteralGenerator):
         Raises:
             ValueError: If required statements or attributes are missing
         """
-        root_gen_stmt = self._stmt.get_root_generate_statement()
-        if root_gen_stmt is None:
-            raise ValueError("Root generate statement is required for pre_execute")
-
         rdbms_client = context.root.clients.get(self._source_name)
         if rdbms_client is None:
             raise ValueError(f"No database client found for source: {self._source_name}")
 
         rdbms_client.increase_sequence_number(
-            sequence_name=f"{root_gen_stmt.type}_{self._stmt.name}_seq", increment=root_gen_stmt.count
+            sequence_name=self._resolve_sequence_name(), increment=self._root_gen_stmt.count
         )
 
     def add_pagination(self, pagination: DataSourcePagination | None = None) -> None:

--- a/tests_ce/external_service_tests/test_sequence_table_generator/postgresql_explicit_sequence_test.xml
+++ b/tests_ce/external_service_tests/test_sequence_table_generator/postgresql_explicit_sequence_test.xml
@@ -1,0 +1,23 @@
+<setup>
+
+    <database id="sourceDB" system="postgresql" />
+
+    <execute uri="script/setup_explicit_sequence.scr.sql" target="sourceDB" />
+
+    <!-- Explicit unqualified name: lands in the credential schema (functional), NOT the
+         convention-derived explicit_plain_id_seq. -->
+    <generate name="plain_rows" type="explicit_plain" count="5" target="ConsoleExporter">
+        <key name="id" database="sourceDB" generator="SequenceTableGenerator(sequence='custom_seq_name')" />
+    </generate>
+
+    <!-- Schema-qualified name of a DBA-pre-created sequence (START 500) - the actual Benerator
+         migration shape (zsv.t_angebote_id_seq). Ids must come from the 500-region. -->
+    <generate name="qualified_rows" type="explicit_qualified" count="5" target="ConsoleExporter">
+        <key name="id" database="sourceDB" generator="SequenceTableGenerator(sequence='migrated_schema.legacy_seq')" />
+    </generate>
+
+    <!-- Catalog check: which of the expected/forbidden sequence names actually exist. -->
+    <generate name="seq_catalog" source="sourceDB"
+        selector="SELECT schemaname || '.' || sequencename AS seq FROM pg_sequences WHERE sequencename IN ('custom_seq_name', 'legacy_seq', 'explicit_plain_id_seq', 'explicit_qualified_id_seq')"
+        target="ConsoleExporter" />
+</setup>

--- a/tests_ce/external_service_tests/test_sequence_table_generator/script/setup_explicit_sequence.scr.sql
+++ b/tests_ce/external_service_tests/test_sequence_table_generator/script/setup_explicit_sequence.scr.sql
@@ -1,0 +1,12 @@
+-- Explicit sequence= test setup: a non-default schema plus a DBA-pre-created sequence,
+-- mirroring the Benerator migration case (zsv.t_angebote_id_seq: existing, arbitrarily named).
+CREATE SCHEMA IF NOT EXISTS migrated_schema;
+
+-- Idempotency across test runs
+DROP SEQUENCE IF EXISTS functional.custom_seq_name;
+DROP SEQUENCE IF EXISTS migrated_schema.legacy_seq;
+
+-- Pre-created at 500: generated ids must come from the 500-region, proving the generator FOUND
+-- this sequence instead of minting a fresh one at 1 (which is what the pre-fix schema handling
+-- would have done, if it didn't fail on the malformed 3-part identifier outright).
+CREATE SEQUENCE migrated_schema.legacy_seq START 500;

--- a/tests_ce/external_service_tests/test_sequence_table_generator/test_sequence_table_generator.py
+++ b/tests_ce/external_service_tests/test_sequence_table_generator/test_sequence_table_generator.py
@@ -20,6 +20,33 @@ class TestSequenceTableGenerator:
         engine.test_with_timer()
         engine.capture_result()
 
+    def test_sequence_table_generator_postgres_explicit_sequence_name(self):
+        """sequence='...' overrides the {type}_{name}_seq convention (Benerator
+        DBSequenceGenerator parity): an unqualified explicit name lands in the credential
+        schema, a schema-qualified one ('migrated_schema.legacy_seq') binds to the DBA
+        pre-created sequence (START 500) instead of failing on a 3-part identifier or
+        minting a fresh sequence at 1."""
+        engine = DataMimicTest(
+            test_dir=self._test_dir, filename="postgresql_explicit_sequence_test.xml", capture_test_result=True
+        )
+        engine.test_with_timer()
+        result = engine.capture_result()
+
+        catalog = {row["seq"] for row in result["seq_catalog"]}
+        assert "functional.custom_seq_name" in catalog
+        assert "migrated_schema.legacy_seq" in catalog
+        # The convention-derived names must NOT have been created for these keys
+        assert not any("explicit_plain_id_seq" in s or "explicit_qualified_id_seq" in s for s in catalog)
+
+        qualified_ids = [row["id"] for row in result["qualified_rows"]]
+        assert len(qualified_ids) == 5
+        # Pre-created at START 500: ids from the 500-region prove the existing sequence was
+        # found and used, not a fresh one starting at 1.
+        assert all(i >= 400 for i in qualified_ids), qualified_ids
+
+        plain_ids = [row["id"] for row in result["plain_rows"]]
+        assert len(plain_ids) == len(set(plain_ids)) == 5
+
     @pytest.mark.skip(reason="MySQL is not supported in this version")
     def test_sequence_table_generator_mysql(self):
         engine = DataMimicTest(test_dir=self._test_dir, filename="mysql_test.xml", capture_test_result=True)

--- a/tests_ce/unit_tests/test_generator/test_generator_cache_behavior.py
+++ b/tests_ce/unit_tests/test_generator/test_generator_cache_behavior.py
@@ -4,10 +4,10 @@ from pathlib import Path
 import pytest
 
 from datamimic_ce.contexts.setup_context import SetupContext
+from datamimic_ce.data_sources.data_source_pagination import DataSourcePagination
 from datamimic_ce.domains.common.literal_generators.generator_util import GeneratorUtil
 from datamimic_ce.exporters.test_result_exporter import TestResultExporter
 from datamimic_ce.product_storage.memstore_manager import MemstoreManager
-from datamimic_ce.data_sources.data_source_pagination import DataSourcePagination
 
 
 class DummyRootGenStmt:
@@ -93,12 +93,37 @@ def test_sequence_table_generator_uses_cache_key(setup_context: SetupContext):
     root_gen = DummyRootGenStmt(type_="gen", count=5)
     stmt = DummyStmt(name="id", parent=None, database="db1", root_gen=root_gen)
 
-    g1 = util.create_generator("SequenceTableGenerator", stmt=stmt, key="seq:orders:id")
-    g2 = util.create_generator("SequenceTableGenerator", stmt=stmt, key="seq:orders:id")
+    # Pagination is what makes the instance generation-ready; only such instances are cached
+    # (an unpaginated one, as built by GenerateTask.pre_execute, must NOT poison the cache).
+    pagination = DataSourcePagination(skip=0, limit=5)
+    g1 = util.create_generator("SequenceTableGenerator", stmt=stmt, key="seq:orders:id", pagination=pagination)
+    g2 = util.create_generator("SequenceTableGenerator", stmt=stmt, key="seq:orders:id", pagination=pagination)
 
     assert g1 is g2
     assert "seq:orders:id" in setup_context.generators
     assert "SequenceTableGenerator" not in setup_context.generators
+
+
+def test_sequence_table_generator_unpaginated_instance_is_not_cached(setup_context: SetupContext):
+    """GenerateTask.pre_execute builds sub-tasks with pagination=None; caching that instance under
+    the generation cache key made every single-process page StopIterate on its first record
+    (0 rows generated). The pre-execute instance must stay out of the cache."""
+    setup_context.clients["db1"] = DummyRdbmsClient()
+    util = GeneratorUtil(context=setup_context)
+
+    root_gen = DummyRootGenStmt(type_="gen", count=5)
+    stmt = DummyStmt(name="id", parent=None, database="db1", root_gen=root_gen)
+
+    unpaginated = util.create_generator("SequenceTableGenerator", stmt=stmt, key="seq:t:id")
+    assert "seq:t:id" not in setup_context.generators
+
+    paginated = util.create_generator(
+        "SequenceTableGenerator", stmt=stmt, key="seq:t:id", pagination=DataSourcePagination(skip=0, limit=5)
+    )
+    assert paginated is not unpaginated
+    assert setup_context.generators["seq:t:id"] is paginated
+    # The generation-path instance actually generates (the poisoned one raised StopIteration)
+    assert isinstance(paginated.generate(), int)
 
 
 def test_datetime_generator_ast_path_uses_cache_key(setup_context: SetupContext):

--- a/tests_ce/unit_tests/test_generator/test_sequence_table_generator_explicit_name.py
+++ b/tests_ce/unit_tests/test_generator/test_sequence_table_generator_explicit_name.py
@@ -1,0 +1,137 @@
+# DATAMIMIC
+# Copyright (c) 2023-2025 Rapiddweller Asia Co., Ltd.
+# This software is licensed under the MIT License.
+# See LICENSE file for the full text of the license.
+# For questions and support, contact: info@rapiddweller.com
+
+"""SequenceTableGenerator explicit sequence= name (Benerator parity: DBSequenceGenerator binds to
+an arbitrarily DBA-named native sequence, e.g. 'zsv.t_angebote_id_seq' - not derivable from the
+{type}_{name}_seq convention). Unit-tested with a recording fake client (same precedent as
+test_generator_cache_behavior.py) because the assertion target is the literal string that reaches
+the client, which a live-DB DSL test can't observe directly."""
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from datamimic_ce.contexts.setup_context import SetupContext
+from datamimic_ce.domains.common.literal_generators.generator_util import GeneratorUtil
+from datamimic_ce.exporters.test_result_exporter import TestResultExporter
+from datamimic_ce.product_storage.memstore_manager import MemstoreManager
+
+
+class DummyRootGenStmt:
+    def __init__(self, type_: str = "orders", count: int = 10):
+        self.type = type_
+        self.count = count
+
+
+class DummyStmt:
+    def __init__(self, name: str, database: str, root_gen):
+        self.name = name
+        self.parent = None
+        self.database = database
+        self._root_gen = root_gen
+
+    def get_root_generate_statement(self):
+        return self._root_gen
+
+
+class RecordingRdbmsClient:
+    """Records every sequence_name it is asked for, so tests can assert the literal string."""
+
+    def __init__(self):
+        self._seq = {}
+        self.requested_names: list[str] = []
+
+    def get_current_sequence_number(self, sequence_name: str) -> int:
+        self.requested_names.append(sequence_name)
+        return self._seq.get(sequence_name, 1000)
+
+    def increase_sequence_number(self, sequence_name: str, increment: int) -> None:
+        self.requested_names.append(sequence_name)
+        self._seq[sequence_name] = self._seq.get(sequence_name, 1000) + increment
+
+
+@pytest.fixture()
+def setup_context() -> SetupContext:
+    return SetupContext(
+        memstore_manager=MemstoreManager(),
+        task_id=str(uuid.uuid4()),
+        test_mode=True,
+        test_result_exporter=TestResultExporter(),
+        default_separator=",",
+        default_locale="en_US",
+        default_dataset="default",
+        use_mp=False,
+        descriptor_dir=Path("."),
+        num_process=1,
+        default_variable_prefix="${",
+        default_variable_suffix="}",
+        default_line_separator="\n",
+        current_seed=123,
+        clients={},
+        data_source_len={},
+        properties={},
+        namespace={},
+        global_variables={},
+        generators={},
+        default_source_scripted=False,
+        report_logging=False,
+    )
+
+
+def _make(setup_context: SetupContext, generator_str: str, key: str):
+    client = RecordingRdbmsClient()
+    setup_context.clients["db1"] = client
+    root_gen = DummyRootGenStmt(type_="orders", count=5)
+    stmt = DummyStmt(name="id", database="db1", root_gen=root_gen)
+    gen = GeneratorUtil(context=setup_context).create_generator(generator_str, stmt=stmt, key=key)
+    return gen, client
+
+
+def test_default_name_is_the_existing_convention(setup_context: SetupContext):
+    _, client = _make(setup_context, "SequenceTableGenerator", key="k1")
+    assert client.requested_names == ["orders_id_seq"]
+
+
+def test_empty_parens_behave_like_no_parens(setup_context: SetupContext):
+    _, client = _make(setup_context, "SequenceTableGenerator()", key="k2")
+    assert client.requested_names == ["orders_id_seq"]
+
+
+def test_explicit_sequence_name_reaches_client_verbatim(setup_context: SetupContext):
+    gen, client = _make(
+        setup_context, "SequenceTableGenerator(sequence='zsv.t_angebote_id_seq')", key="k3"
+    )
+    assert client.requested_names == ["zsv.t_angebote_id_seq"]
+    # pre_execute (the increment side) must resolve to the same explicit name
+    gen.pre_execute(setup_context)
+    assert client.requested_names[-1] == "zsv.t_angebote_id_seq"
+
+
+def test_pre_execute_uses_convention_name_when_no_override(setup_context: SetupContext):
+    gen, client = _make(setup_context, "SequenceTableGenerator", key="k4")
+    gen.pre_execute(setup_context)
+    assert client.requested_names == ["orders_id_seq", "orders_id_seq"]
+
+
+def test_positional_arg_is_rejected(setup_context: SetupContext):
+    with pytest.raises(ValueError, match="positional"):
+        _make(setup_context, "SequenceTableGenerator('positional_value')", key="k5")
+
+
+def test_unsupported_kwarg_is_rejected(setup_context: SetupContext):
+    with pytest.raises(ValueError, match="bogus"):
+        _make(setup_context, "SequenceTableGenerator(bogus='x')", key="k6")
+
+
+def test_malformed_args_are_rejected(setup_context: SetupContext):
+    with pytest.raises(ValueError):
+        _make(setup_context, "SequenceTableGenerator(sequence=)", key="k7")
+
+
+def test_non_string_sequence_is_rejected(setup_context: SetupContext):
+    with pytest.raises(ValueError, match="string"):
+        _make(setup_context, "SequenceTableGenerator(sequence=42)", key="k8")


### PR DESCRIPTION
## Summary
Unblocks the single largest remaining Benerator-migration gap (~330 of 445 items in one real enterprise project): `DBSequenceGenerator('zsv.t_angebote_id_seq')` binds to an **arbitrarily DBA-named** native DB sequence. CE's `SequenceTableGenerator` could only derive `{type}_{name}_seq` by convention, and any args in `generator="SequenceTableGenerator(...)"` were **silently discarded**.

1. **`sequence=` parameter** on `SequenceTableGenerator`; the duplicated convention f-string in `__init__`/`pre_execute` is centralized into `_resolve_sequence_name()`.
2. **Minimal ast kwarg parser** in `GeneratorUtil`'s special-case branch - keyword-only, string-literal-only; positional args, unknown kwargs, and malformed input now raise `ValueError` instead of being silently dropped. Bare `"SequenceTableGenerator"` and empty `"()"` resolve to the convention name exactly as before.
3. **Schema-qualified names fixed in `RdbmsClient`**: `'zsv.t_angebote_id_seq'` used to build the malformed 3-part identifier `public.zsv.t_angebote_id_seq` and an existence check that could never match - a DBA-pre-created sequence was unfindable. A dotted name now carries its own schema; unqualified names take the exact same path as before.

## Pre-existing bug found & fixed en passant
Every **single-process** `<generate>` using `SequenceTableGenerator` produced **0 rows** (verified empirically on unmodified `development`). `GenerateTask.pre_execute` builds its sub-tasks with `pagination=None`; that unpaginated instance (`_current=None`) got cached under the same `full_name|generator` key the paginated page-tasks use → first record raised `StopIteration` → page died empty. Only the `numProcess=2` path had coverage, masking it. Fix: **cache only generation-ready (paginated) instances**. A first attempt (unconditional `add_pagination`) was rejected by the existing MP test - it produced unpartitioned duplicate PKs across workers - the cache guard keeps MP semantics identical.

## Known limitation (flagged, unchanged semantics)
An explicit name that doesn't exist is still auto-created starting at 1 (matches today's convention behavior) - a typo'd migrated name silently mints a fresh sequence instead of erroring. Worth a strict-mode follow-up for the migration use case. Postgres-only, inherited from the `pg_sequences` implementation.

## Test plan
- [x] 8 unit tests with a recording fake client: convention default unchanged, empty-parens compat, verbatim explicit name through both `__init__` and `pre_execute`, and all rejection cases (positional / unknown kwarg / malformed / non-string).
- [x] Cache-guard unit test (unpaginated instance stays out of the cache; paginated instance generates).
- [x] Real Postgres test: unqualified explicit name lands in the credential schema; schema-qualified `migrated_schema.legacy_seq` binds to a DBA-pre-created sequence (`START 500` - generated ids come from the 500-region, proving it was found, not re-minted); convention-derived names asserted absent. Existing `postgresql_test.xml` untouched byte-for-byte.
- [x] Discriminating-test check: client fix reverted locally → qualified test fails; parser/generator proven RED before implementation.
- [x] Full suite 1465 passed / 15 skipped; external service tests green; mypy (424 files) and ruff clean.