### PR TITLE
docs(readme): align with 4.0.0 contract, fix broken examples, agent discoverability

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,20 @@ on:
       - development
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+    # Docs-only changes don't need the pipeline. Path filters are NOT evaluated for
+    # tag pushes, so releases always run. cheatsheet.md is re-included: it ships in
+    # the package and is gate-tested (test_reference_and_recipes.py).
+    paths:
+      - '**'
+      - '!**.md'
+      - 'datamimic_ce/**.md'
   pull_request:
     branches:
       - '*'
+    paths:
+      - '**'
+      - '!**.md'
+      - 'datamimic_ce/**.md'
 
 env:
   RUNTIME_ENVIRONMENT: production

--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@
 > CE is fully usable standalone for deterministic synthetic data generation and PII-aware pseudonymization. The Enterprise Platform adds governed workflows, PII scanning, role-based access, audit logging, scheduling, multi-system execution, and the full operational layer that regulated enterprises require.
 >
 > 👉 **Enterprise Platform:** [datamimic.io](https://datamimic.io) &nbsp;|&nbsp; 📘 **Docs:** [docs.datamimic.io](https://docs.datamimic.io) &nbsp;|&nbsp; 📅 **Book a strategy call:** [datamimic.io/contact](https://datamimic.io/contact)
+>
+> 🤖 **AI agent?** Start at [`AGENTS.md`](AGENTS.md): register the MCP server, then author descriptors with the `datamimic_reference` → `datamimic_check` (lint) → `datamimic_run` (dry-run) loop. Verified end-to-end examples live in [`examples/showcase/`](examples/showcase/).
 
 ---
 
 [![CI](https://img.shields.io/badge/CI-passing-brightgreen.svg)](https://github.com/rapiddweller/datamimic/actions)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=rapiddweller_datamimic&metric=coverage)](https://sonarcloud.io/summary/new_code?id=rapiddweller_datamimic)
 [![Maintainability](https://sonarcloud.io/api/project_badges/measure?project=rapiddweller_datamimic&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=rapiddweller_datamimic)
-[![Python](https://img.shields.io/badge/Python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
+[![Python](https://img.shields.io/badge/Python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![MCP Ready](https://img.shields.io/badge/MCP-ready-8A2BE2.svg)](docs/mcp_quickstart.md)
 
@@ -27,7 +29,8 @@ The Enterprise Platform adds the governed workflows, scanners, dashboards, and e
 
 - **Generate** fully synthetic, deterministic datasets — model-driven, no source data required
 - **Pseudonymize** staging/QA exports — deterministic (seeded) or privacy-maximized (non-seeded) field transformation; PII fields identified and modeled manually in the XML pipeline
-- **Execute** single-system pipelines against PostgreSQL · MySQL · Oracle · MS SQL · SQLite · MongoDB · CSV · JSON · XML · XLSX · DbUnit
+- **Execute** single-system pipelines against PostgreSQL · MySQL · Oracle · MS SQL · SQLite · MongoDB · CSV · JSON · XML · XLSX · DbUnit · fixed-width (`.fcw`)
+- **Model behavior** — weighted state machines, composite multi-field references, control flow (`<while>`, `<assert>`), and a scriptable memstore for staged aggregation
 - **Emit provenance** — append-only execution logs and per-output content hash for audit re-execution
 - **Serve agents** — bundled MCP server with the full authoring loop (`datamimic_reference` DSL lookup, `datamimic_check` lint with fix hints, `datamimic_run` safe dry-run) plus the deterministic `generate` tool
 
@@ -204,7 +207,7 @@ CE and EE are **not the same engine with a feature flag**. They share the DSL an
 | Capability | Community Edition (CE) | Enterprise Platform (EE) |
 |---|---|---|
 | Deterministic data generation | ✅ | ✅ |
-| Deterministic seeding in the DSL | ✅ entities (`<setup rngSeed>`, `<variable rngSeed>`) | ✅ entities + standalone literal `<key generator>` |
+| Deterministic seeding in the DSL | ✅ entities + standalone literal `<key generator>` (4.0.0) | ✅ same, plus sandboxed script expressions and stdlib `random` calls |
 | **Pseudonymization — seeded** *(GDPR Art. 4(5); supports Art. 25 / Art. 32)* | ✅ manual model | ✅ automated via DataWorkbench |
 | **Pseudonymization — non-seeded (privacy-maximized)** | ✅ manual model | ✅ automated via DataWorkbench |
 | Python API + XML pipelines | ✅ | ✅ |
@@ -313,14 +316,14 @@ Most test data tools produce random output. That breaks regression tests, audit 
 **DATAMIMIC's determinism contract (CE):**
 
 - **Same engine version + same model + same seed = byte-identical output**, every run, every machine. Holds at three layers: the `generate_domain` facade, every domain service called directly, and every literal generator that accepts an `rng=` argument. Verified per-service on every CI run via [`tests_ce/architecture/test_service_replay_determinism.py`](tests_ce/architecture/test_service_replay_determinism.py).
-- **DSL-level seeding (entities):** `<setup rngSeed="N">` makes the whole model deterministic — every seed-less `<variable entity="…">` derives a reproducible child RNG from it, and `<variable rngSeed="…">` overrides it for that block (no seed anywhere → wall-clock random). Verified by [`tests_ce/integration_tests/test_determinism_seed_scenarios`](tests_ce/integration_tests/test_determinism_seed_scenarios). Deterministic DSL-level seeding of standalone literal generators (`<key generator="…">`) is an **Enterprise (EE) feature**; in CE such generators are seeded only when used directly from Python with `rng=`.
+- **DSL-level seeding:** `<setup rngSeed="N">` makes the whole model deterministic — every seed-less `<variable entity="…">` derives a reproducible child RNG from it, and `<variable rngSeed="…">` overrides it for that block (no seed anywhere → wall-clock random). Verified by [`tests_ce/integration_tests/test_determinism_seed_scenarios`](tests_ce/integration_tests/test_determinism_seed_scenarios). As of 4.0.0 the same seed also reaches standalone literal generators (`<key generator="…">`), typed/pattern keys, `DateTimeGenerator`, and cross-page `unique` picks — machine-independently.
 - **Source reads:** `distribution="ordered"` reads a data source in stable file order; `distribution="random"` shuffles but replays identically when `<setup rngSeed>` is set (without a seed the shuffle is non-deterministic by design, for privacy-maximized one-time deliveries). Deterministic shuffling across distributed / multi-process execution is EE.
 - **Provenance hash on every facade output** = re-executable lineage. Same input → same `determinism_proof.content_hash`, always.
 - **UUIDv5 entity identifiers** = stable across runs and machines.
 - **Single wall-clock SPOT** (`now_utc_naive()`); raw `datetime.now()` is forbidden in production code and the clock-drift architecture gate fails CI on any reintroduction.
 - **RNG/clock runtime SPOTs** in `datamimic_ce/domains/domain_core/runtime/`: `spawn_rng` (reproducible child-RNG derivation), `now_utc_naive`, and `resolve_clock`. The same contract vocabulary the Enterprise Platform enforces end-to-end.
 
-**The Enterprise Platform (EE) goes further:** beyond the CE contract, EE makes the whole execution environment deterministic — a configurable/frozen wall-clock (not just CE's fixed anchor), DSL-level seeding of literal `<key generator>` generators, and deterministic `SAFE_GLOBALS` plus the Python `random` functions, so sandboxed script expressions and any stdlib `random` call replay identically as well.
+**The Enterprise Platform (EE) goes further:** beyond the CE contract, EE makes the whole execution environment deterministic — a configurable/frozen wall-clock (not just CE's fixed anchor), and deterministic `SAFE_GLOBALS` plus the Python `random` functions, so sandboxed script expressions and any stdlib `random` call replay identically as well.
 
 ```python
 from datamimic_ce.domains.facade import generate_domain
@@ -359,12 +362,12 @@ assert card_a.bic == card_b.bic and card_a.card_number == card_b.card_number
 | **Literal generators** (with seeded `rng=...`) | ✅ byte-identical | ✅ byte-identical |
 | **RNG / clock runtime SPOTs** | ✅ `spawn_rng`, `now_utc_naive`, `resolve_clock` | ✅ same contract, enforced end-to-end |
 | **Architecture gates in CI** | ✅ facade replay + service replay (every service) + clock drift | ✅ 5+ gates (RNG ownership, clock drift, DSL eval, seeded-mode propagation, dataset SPOT) |
-| **Custom XML pipelines** | ⚠️ best-effort | ✅ byte-identical |
+| **Custom XML pipelines** (seeded via `<setup rngSeed>`) | ✅ byte-identical, machine-independent (single-process) | ✅ byte-identical, distributed |
 | **Multi-system coordinated execution** (Oracle + MongoDB + Kafka in one run) | — | ✅ byte-identical end-to-end |
 | **Seeded vs unseeded pseudonymization** (deterministic clock anchor vs CSPRNG live-clock) | — | ✅ |
 | **Threat-led / TLPT-grade audit evidence** (full contract enforcement, per-stage execution logging) | — | ✅ |
 
-CE delivers contract-enforced determinism for the synthetic-data generation surface (facade, services, generators). The Enterprise Platform extends the same contract across the full pipeline — custom XML descriptors, multi-system writes with referential integrity, the seeded/unseeded pseudonymization modes — and adds the five drift-gates that lock the contract end-to-end for regulated deployments.
+CE delivers contract-enforced determinism for the synthetic-data generation surface (facade, services, generators) and, as of 4.0.0, for seeded XML descriptors — byte-identical across machines, executed single-process. The Enterprise Platform extends the same contract to distributed and multi-system execution with referential integrity and the seeded/unseeded pseudonymization modes, and adds the five drift-gates that lock the contract end-to-end for regulated deployments.
 
 ---
 
@@ -443,8 +446,8 @@ DATAMIMIC supports two pseudonymization modes with different privacy postures:
 In CE, PII fields are identified and modeled manually in the XML pipeline:
 
 ```xml
-<setup>
-  <generate name="customers" source="customer_export" target="customer_test" distribution="ordered">
+<setup defaultSeparator=",">
+  <generate name="customers" source="customer_export.csv" target="CSV" distribution="ordered">
     <!-- distribution="ordered" reads the source in a stable order — required so the
          Nth source row maps to the same seeded synthetic value on every run. The
          default ("random") shuffles non-deterministically and would break it.
@@ -517,23 +520,23 @@ Output column names — including whether to even emit a timestamp or series-id 
 
 ```xml
 <setup>
-  <!-- Stock ticks: three symbols, 5-min interval, 30-min window -->
+  <!-- Stock ticks: three symbols, 5-min interval, 30-min window (writes ticks.csv) -->
   <generate name="ticks" count="3"
             start="2026-01-01T09:30:00+00:00"
             end="2026-01-01T10:00:00+00:00"
             interval="PT5M"
-            target="ticks.csv">
+            target="CSV">
     <key name="timestamp" script="ts.now.isoformat()"/>
     <key name="symbol"    script="['AAPL','MSFT','GOOG'][ts.series]"/>
     <key name="price"     script="100 + ts.step * 0.25"/>
   </generate>
 
-  <!-- Sensor with diurnal seasonality, single series (count defaults to 1) -->
+  <!-- Sensor with diurnal seasonality, single series (count defaults to 1; writes readings.csv) -->
   <generate name="readings"
             start="2026-01-01T00:00:00+00:00"
             end="2026-01-08T00:00:00+00:00"
             interval="PT1H"
-            target="readings.csv">
+            target="CSV">
     <key name="timestamp" script="ts.now.isoformat()"/>
     <key name="value"     script="20 - 10 * math.cos(ts.now.hour * math.pi / 12)"/>
   </generate>
@@ -566,7 +569,7 @@ response = generate_domain({
     "seed": "ci-pipeline-42", "locale": "en_US",
     "clock": "2026-01-01T00:00:00Z",
 })
-# Same engine version + same model + same seed + same worker count → same output, every machine, every run.
+# Same engine version + same model + same seed → same output, every machine, every run.
 ```
 
 **2. Deterministic data backend for AI agents and LLM tooling.** The bundled MCP server (`pip install datamimic-ce[mcp]`) exposes `generate` as an MCP tool. Agents call it with seed, locale, count; outputs ship with a `determinism_proof.content_hash` so the same call can be re-executed and verified later — useful for agent regression tests and for any workflow where the data the agent saw needs to be reconstructable.
@@ -650,6 +653,7 @@ EE adds Kafka, EDIFACT, SWIFT MT, HL7 v2.x, and HL7 FHIR as additional targets �
 | CSV / JSON / XML | ✅ | ✅ | Flat file pipelines |
 | XLSX | ✅ | ✅ | Spreadsheet read + write (first row = header) |
 | DbUnit XML | ✅ | ✅ | `.dbunit.xml` dataset read + write |
+| Fixed-width (`.fcw`) | ✅ | ✅ | Self-describing column files, read + write |
 | Apache Kafka | — | ✅ | Real-time streaming, payment scenarios |
 | HL7 v2.x | — | ✅ | Test/training output via template engine |
 | HL7 FHIR | — | ✅ | Test/training output via template engine |


### PR DESCRIPTION
## Summary

Pre-release README pass for 4.0.0. Every claim below was verified empirically (snippets executed against the engine, determinism claims tested with repeated seeded runs).

### Broken examples fixed
- **Time-series example failed as published**: `target="ticks.csv"` / `target="readings.csv"` are not valid targets — the run errors and `datamimic lint` flags DM401. Now `target="CSV"` (output file name comes from the generate name).
- **Pseudonymization example failed the linter** (DM401 unknown target, DM402 invalid source): placeholders replaced with a lint-clean, runnable descriptor; `defaultSeparator=","` added since it reads a comma CSV (engine default is `|`).

### Stale determinism claims corrected for 4.0.0
- Removed "+ same worker count" from the contract — seeded generation runs single-process since 4.0.0, so worker count cannot affect output.
- "DSL-level seeding of standalone literal `<key generator>` is an EE feature" is no longer true: verified byte-identical replay of `<key generator="EmailAddressGenerator">` / `IntegerGenerator(...)` under `<setup rngSeed>` in CE. Bullet and both CE/EE tables updated; EE differentiation now points at what is actually EE (sandboxed script expressions, stdlib `random`, frozen clock, distributed execution).
- "Custom XML pipelines: CE ⚠️ best-effort" contradicted the 4.0.0 release notes — seeded descriptors are byte-identical and machine-independent in CE.

### Agent discoverability
- AI-agent callout at the top of the README routing to `AGENTS.md` and the `datamimic_reference` → `datamimic_check` → `datamimic_run` loop. (A `CLAUDE.md` pointer was considered but the repo gitignores it deliberately.)

### Smaller
- Fixed-width (`.fcw`) added to Supported systems and the Execute list.
- New "Model behavior" CE bullet (state machines, composite references, control flow, scriptable memstore).
- Python badge 3.11+ → 3.10+ (matches `requires-python`).

## Validation
- All 4 README XML snippets pass `datamimic lint` (fragments wrapped appropriately).
- The 3 complete descriptors (pseudonymization, patient scenario, time-series) run green.
- Seeded-replay checks: typed/pattern keys and explicit `<key generator>` under `rngSeed` produce identical output across runs.