### PR TITLE
Resolve Sonar quality findings

### DIFF
--- a/datamimic_ce/authoring/acceptance.py
+++ b/datamimic_ce/authoring/acceptance.py
@@ -45,6 +45,7 @@ from datamimic_ce.authoring.contracts import (
     PerParentCountAcceptancePlan,
     PerParentCountAcceptanceResult,
     ProductCaptureCompleteness,
+    ProductCompilePlan,
     RangeAcceptancePlan,
     RangeAcceptanceResult,
     RequiredConsumerForeignKey,
@@ -52,7 +53,7 @@ from datamimic_ce.authoring.contracts import (
     UniqueAcceptancePlan,
     UniqueAcceptanceResult,
 )
-from datamimic_ce.authoring.dryrun import CapturedProducts
+from datamimic_ce.authoring.dryrun import CapturedProduct, CapturedProducts
 from datamimic_ce.authoring.spec import (
     AllowedValuesExpectation,
     AuthoringSpecV1,
@@ -63,6 +64,8 @@ from datamimic_ce.authoring.spec import (
     RowConditionExpectation,
     UniqueExpectation,
 )
+
+_BOOLEAN_OPERANDS_ERROR = "boolean operators require boolean operands"
 
 
 @dataclass(frozen=True)
@@ -541,65 +544,13 @@ def _unique_result(
             distinct_count=None,
         )
     if expectation.scope == "global":
-        duplicates = _duplicates(values)
-        distinct_count = len({_display(value) for value in values})
+        duplicates, distinct_count = _global_unique_evidence(values)
     else:
-        product_plan = next(
-            (item for item in plan.products if item.name == expectation.product),
-            None,
+        duplicates, distinct_count, scope_error = _per_parent_unique_evidence(
+            expectation, plan, captured
         )
-        if not isinstance(product_plan, GeneratedProductCompilePlan) or product_plan.parent is None:
-            return UniqueAcceptanceResult(
-                status=AcceptanceStatus.UNEVALUABLE,
-                source=source,
-                message="per-parent uniqueness requires a nested product in CompilePlan",
-                product=expectation.product,
-                field=expectation.field,
-                scope=expectation.scope,
-                observed_count=len(rows),
-                distinct_count=None,
-            )
-        grouped, error = _group_by_parent(
-            plan,
-            captured,
-            child_product=expectation.product,
-            parent_product=product_plan.parent,
-        )
-        if grouped is None:
-            return UniqueAcceptanceResult(
-                status=AcceptanceStatus.UNEVALUABLE,
-                source=source,
-                message=str(error),
-                product=expectation.product,
-                field=expectation.field,
-                scope=expectation.scope,
-                observed_count=len(rows),
-                distinct_count=None,
-            )
-        groups, _child_field, _parent_field = grouped
-        duplicates = []
-        distinct_count = 0
-        for parent, group_rows in sorted(groups.items()):
-            group_values, error = _values(
-                tuple(group_rows),
-                product=expectation.product,
-                field=expectation.field,
-            )
-            if group_values is None:
-                return UniqueAcceptanceResult(
-                    status=AcceptanceStatus.UNEVALUABLE,
-                    source=source,
-                    message=str(error),
-                    product=expectation.product,
-                    field=expectation.field,
-                    scope=expectation.scope,
-                    observed_count=len(rows),
-                    distinct_count=None,
-                )
-            duplicates.extend(
-                f"parent={parent}:{value}" for value in _duplicates(group_values)
-            )
-            distinct_count += len({_display(value) for value in group_values})
+        if scope_error is not None:
+            return _unevaluable_unique_result(expectation, source, len(rows), scope_error)
     passed = not duplicates
     return UniqueAcceptanceResult(
         status=AcceptanceStatus.PASS if passed else AcceptanceStatus.FAIL,
@@ -611,6 +562,65 @@ def _unique_result(
         observed_count=len(rows),
         distinct_count=distinct_count,
         duplicate_values=duplicates[:20],
+    )
+
+
+def _global_unique_evidence(values: list[object]) -> tuple[list[str], int]:
+    return _duplicates(values), len({_display(value) for value in values})
+
+
+def _per_parent_unique_evidence(
+    expectation: _Unique,
+    plan: CompilePlan,
+    captured: CapturedProducts,
+) -> tuple[list[str], int, str | None]:
+    product_plan = next(
+        (item for item in plan.products if item.name == expectation.product),
+        None,
+    )
+    if not isinstance(product_plan, GeneratedProductCompilePlan) or product_plan.parent is None:
+        return [], 0, "per-parent uniqueness requires a nested product in CompilePlan"
+    grouped, error = _group_by_parent(
+        plan,
+        captured,
+        child_product=expectation.product,
+        parent_product=product_plan.parent,
+    )
+    if grouped is None:
+        return [], 0, str(error)
+    groups, _child_field, _parent_field = grouped
+    duplicates: list[str] = []
+    distinct_count = 0
+    for parent, group_rows in sorted(groups.items()):
+        group_values, error = _values(
+            tuple(group_rows),
+            product=expectation.product,
+            field=expectation.field,
+        )
+        if group_values is None:
+            return [], 0, str(error)
+        duplicates.extend(
+            f"parent={parent}:{value}" for value in _duplicates(group_values)
+        )
+        distinct_count += len({_display(value) for value in group_values})
+    return duplicates, distinct_count, None
+
+
+def _unevaluable_unique_result(
+    expectation: _Unique,
+    source: AcceptanceSource,
+    observed_count: int,
+    message: str,
+) -> UniqueAcceptanceResult:
+    return UniqueAcceptanceResult(
+        status=AcceptanceStatus.UNEVALUABLE,
+        source=source,
+        message=message,
+        product=expectation.product,
+        field=expectation.field,
+        scope=expectation.scope,
+        observed_count=observed_count,
+        distinct_count=None,
     )
 
 
@@ -872,15 +882,30 @@ def _safe_condition_value(value: object) -> object:
 
 
 def _validate_condition_tree(tree: ast.AST) -> None:
-    node_count = 0
+    _ConditionTreeValidator().validate(tree)
 
-    def visit(node: ast.AST, depth: int) -> None:
-        nonlocal node_count
-        node_count += 1
-        if node_count > _MAX_CONDITION_NODES:
+
+class _ConditionTreeValidator:
+    """Validate one typed condition AST against the bounded expression contract."""
+
+    def __init__(self) -> None:
+        self._node_count = 0
+
+    def validate(self, tree: ast.AST) -> None:
+        self._visit(tree, 0)
+
+    def _visit(self, node: ast.AST, depth: int) -> None:
+        self._node_count += 1
+        if self._node_count > _MAX_CONDITION_NODES:
             raise _UnsafeCondition("condition exceeds the AST node budget")
         if depth > _MAX_CONDITION_DEPTH:
             raise _UnsafeCondition("condition exceeds the AST depth budget")
+        self._validate_node(node)
+        for child in ast.iter_child_nodes(node):
+            self._visit(child, depth + 1)
+
+    @staticmethod
+    def _validate_node(node: ast.AST) -> None:
         if isinstance(node, ast.Constant):
             _safe_condition_value(node.value)
         if (
@@ -888,43 +913,68 @@ def _validate_condition_tree(tree: ast.AST) -> None:
             and len(node.elts) > _MAX_CONTAINER_ITEMS
         ):
             raise _UnsafeCondition("condition literal exceeds the container budget")
-        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mult):
-            if isinstance(node.left, ast.List | ast.Tuple | ast.Set) or isinstance(
-                node.right,
-                ast.List | ast.Tuple | ast.Set,
-            ):
-                raise _UnsafeCondition("sequence repetition is forbidden in row conditions")
-            if (
-                isinstance(node.left, ast.Constant)
-                and isinstance(node.left.value, str)
-            ) or (
-                isinstance(node.right, ast.Constant)
-                and isinstance(node.right.value, str)
-            ):
-                raise _UnsafeCondition("string repetition is forbidden in row conditions")
-        for child in ast.iter_child_nodes(node):
-            visit(child, depth + 1)
+        if isinstance(node, ast.BinOp):
+            _ConditionTreeValidator._validate_repetition(node)
 
-    visit(tree, 0)
+    @staticmethod
+    def _validate_repetition(node: ast.BinOp) -> None:
+        if not isinstance(node.op, ast.Mult):
+            return
+        if isinstance(node.left, ast.List | ast.Tuple | ast.Set) or isinstance(
+            node.right,
+            ast.List | ast.Tuple | ast.Set,
+        ):
+            raise _UnsafeCondition("sequence repetition is forbidden in row conditions")
+        if (
+            isinstance(node.left, ast.Constant) and isinstance(node.left.value, str)
+        ) or (
+            isinstance(node.right, ast.Constant) and isinstance(node.right.value, str)
+        ):
+            raise _UnsafeCondition("string repetition is forbidden in row conditions")
 
 
 def _eval_condition_node(node: ast.AST, row: Mapping[str, object]) -> object:
-    if isinstance(node, ast.Expression):
-        return _eval_condition_node(node.body, row)
-    if isinstance(node, ast.Constant):
-        return _safe_condition_value(node.value)
-    if isinstance(node, ast.Name):
-        if node.id not in row:
+    return _ConditionEvaluator(row).evaluate(node)
+
+
+class _ConditionEvaluator:
+    """Evaluate the explicitly supported condition AST without dynamic dispatch."""
+
+    def __init__(self, row: Mapping[str, object]) -> None:
+        self._row = row
+
+    def evaluate(self, node: ast.AST) -> object:
+        if isinstance(node, ast.Expression):
+            return self.evaluate(node.body)
+        if isinstance(node, ast.Constant):
+            return _safe_condition_value(node.value)
+        if isinstance(node, ast.Name):
+            return self._name(node)
+        if isinstance(node, ast.List):
+            return [self.evaluate(item) for item in node.elts]
+        if isinstance(node, ast.Tuple):
+            return tuple(self.evaluate(item) for item in node.elts)
+        if isinstance(node, ast.Set):
+            return {self.evaluate(item) for item in node.elts}
+        if isinstance(node, ast.UnaryOp):
+            return self._unary(node)
+        if isinstance(node, ast.BinOp):
+            return self._binary(node)
+        if isinstance(node, ast.BoolOp):
+            return self._boolean(node)
+        if isinstance(node, ast.Compare):
+            return self._compare(node)
+        raise _UnsafeCondition(
+            f"unsupported condition syntax '{type(node).__name__}'; calls, attributes, and subscripts are forbidden"
+        )
+
+    def _name(self, node: ast.Name) -> object:
+        if node.id not in self._row:
             raise _UnsafeCondition(f"name '{node.id}' is missing from the captured row")
-        return _safe_condition_value(row[node.id])
-    if isinstance(node, ast.List):
-        return [_eval_condition_node(item, row) for item in node.elts]
-    if isinstance(node, ast.Tuple):
-        return tuple(_eval_condition_node(item, row) for item in node.elts)
-    if isinstance(node, ast.Set):
-        return {_eval_condition_node(item, row) for item in node.elts}
-    if isinstance(node, ast.UnaryOp):
-        operand = _eval_condition_node(node.operand, row)
+        return _safe_condition_value(self._row[node.id])
+
+    def _unary(self, node: ast.UnaryOp) -> object:
+        operand = self.evaluate(node.operand)
         if isinstance(node.op, ast.Not):
             if not isinstance(operand, bool):
                 raise _UnsafeCondition("not requires a boolean operand")
@@ -934,43 +984,52 @@ def _eval_condition_node(node: ast.AST, row: Mapping[str, object]) -> object:
         if isinstance(node.op, ast.UAdd):
             return _safe_number(+_safe_number(operand))
         raise _UnsafeCondition("unsupported unary operator")
-    if isinstance(node, ast.BinOp):
+
+    def _binary(self, node: ast.BinOp) -> object:
         operation = _BINARY_OPERATORS.get(type(node.op))
         if operation is None:
             raise _UnsafeCondition("unsupported binary operator")
-        left = _safe_number(_eval_condition_node(node.left, row))
-        right = _safe_number(_eval_condition_node(node.right, row))
-        return _safe_number(
-            operation(left, right),
-        )
-    if isinstance(node, ast.BoolOp):
-        bool_result = _eval_condition_node(node.values[0], row)
+        left = _safe_number(self.evaluate(node.left))
+        right = _safe_number(self.evaluate(node.right))
+        return _safe_number(operation(left, right))
+
+    def _boolean(self, node: ast.BoolOp) -> bool:
+        bool_result = self.evaluate(node.values[0])
         if not isinstance(bool_result, bool):
-            raise _UnsafeCondition("boolean operators require boolean operands")
+            raise _UnsafeCondition(_BOOLEAN_OPERANDS_ERROR)
         if isinstance(node.op, ast.And):
-            for value in node.values[1:]:
-                if not bool_result:
-                    return bool_result
-                bool_result = _eval_condition_node(value, row)
-                if not isinstance(bool_result, bool):
-                    raise _UnsafeCondition("boolean operators require boolean operands")
-            return bool_result
+            return self._and(node.values[1:], bool_result)
         if isinstance(node.op, ast.Or):
-            for value in node.values[1:]:
-                if bool_result:
-                    return bool_result
-                bool_result = _eval_condition_node(value, row)
-                if not isinstance(bool_result, bool):
-                    raise _UnsafeCondition("boolean operators require boolean operands")
-            return bool_result
+            return self._or(node.values[1:], bool_result)
         raise _UnsafeCondition("unsupported boolean operator")
-    if isinstance(node, ast.Compare):
-        compare_left = _eval_condition_node(node.left, row)
+
+    def _and(self, values: list[ast.expr], result: bool) -> bool:
+        for value in values:
+            if not result:
+                return result
+            next_result = self.evaluate(value)
+            if not isinstance(next_result, bool):
+                raise _UnsafeCondition(_BOOLEAN_OPERANDS_ERROR)
+            result = next_result
+        return result
+
+    def _or(self, values: list[ast.expr], result: bool) -> bool:
+        for value in values:
+            if result:
+                return result
+            next_result = self.evaluate(value)
+            if not isinstance(next_result, bool):
+                raise _UnsafeCondition(_BOOLEAN_OPERANDS_ERROR)
+            result = next_result
+        return result
+
+    def _compare(self, node: ast.Compare) -> bool:
+        compare_left = self.evaluate(node.left)
         for operation_node, comparator in zip(node.ops, node.comparators, strict=True):
             operation = _COMPARE_OPERATORS.get(type(operation_node))
             if operation is None:
                 raise _UnsafeCondition("unsupported comparison operator")
-            compare_right = _eval_condition_node(comparator, row)
+            compare_right = self.evaluate(comparator)
             _safe_condition_value(compare_left)
             _safe_condition_value(compare_right)
             if isinstance(operation_node, ast.In | ast.NotIn) and not isinstance(
@@ -982,9 +1041,6 @@ def _eval_condition_node(node: ast.AST, row: Mapping[str, object]) -> object:
                 return False
             compare_left = compare_right
         return True
-    raise _UnsafeCondition(
-        f"unsupported condition syntax '{type(node).__name__}'; calls, attributes, and subscripts are forbidden"
-    )
 
 
 def _row_condition_result(
@@ -1075,6 +1131,50 @@ def _memstore_result(
     plan: CompilePlan,
     captured: CapturedProducts,
 ) -> MemstoreCompletenessAcceptanceResult:
+    resolved_context = _resolve_memstore_context(expectation, source, plan, captured)
+    if isinstance(resolved_context, MemstoreCompletenessAcceptanceResult):
+        return resolved_context
+    count_result = _memstore_count_result(resolved_context)
+    if count_result is not None:
+        return count_result
+    resolved_binding = _resolve_memstore_binding(resolved_context)
+    if isinstance(resolved_binding, MemstoreCompletenessAcceptanceResult):
+        return resolved_binding
+    resolved_values = _resolve_memstore_values(resolved_context, resolved_binding, captured)
+    if isinstance(resolved_values, MemstoreCompletenessAcceptanceResult):
+        return resolved_values
+    return _memstore_identity_result(resolved_context, resolved_binding, resolved_values)
+
+
+@dataclass(frozen=True)
+class _MemstoreContext:
+    expectation: _MemstoreCompleteness
+    source: AcceptanceSource
+    producer: CapturedProduct
+    consumer: CapturedProduct
+    consumer_plan: ProductCompilePlan
+    producer_identifiers: frozenset[str]
+    required_foreign_key: RequiredConsumerForeignKey | None
+
+
+@dataclass(frozen=True)
+class _MemstoreBinding:
+    consumer_key_field: str
+    producer_key_field: str
+
+
+@dataclass(frozen=True)
+class _MemstoreValues:
+    producer: list[object]
+    consumer: list[object]
+
+
+def _resolve_memstore_context(
+    expectation: _MemstoreCompleteness,
+    source: AcceptanceSource,
+    plan: CompilePlan,
+    captured: CapturedProducts,
+) -> _MemstoreContext | MemstoreCompletenessAcceptanceResult:
     producer = captured.get(expectation.producer_product)
     consumer = captured.get(expectation.consumer_product)
     if producer is None or consumer is None:
@@ -1113,129 +1213,190 @@ def _memstore_result(
             producer_count=len(producer.rows),
             consumer_count=len(consumer.rows),
         )
-    producer_identifiers = {
+    producer_identifiers = frozenset(
         field.name
         for field in producer_plan.fields
         if any(isinstance(role, IdentifierRolePlan) for role in field.roles)
-    }
-    required_foreign_key: RequiredConsumerForeignKey | None = None
-    if len(producer_identifiers) == 1:
-        producer_identifier = next(iter(producer_identifiers))
-        observed_roles = sum(
-            1
-            for field in consumer_plan.fields
-            for role in field.roles
-            if isinstance(role, ForeignKeyRolePlan)
-            and role.parent_product == expectation.producer_product
-            and role.parent_field == producer_identifier
-        )
-        required_foreign_key = RequiredConsumerForeignKey(
-            parent_product=expectation.producer_product,
-            parent_field=producer_identifier,
-            observed_count=observed_roles,
-        )
-    if len(producer.rows) != len(consumer.rows):
-        return MemstoreCompletenessAcceptanceResult(
-            status=AcceptanceStatus.FAIL,
-            source=source,
-            message="producer and memstore consumer bounded row counts differ",
-            producer_product=expectation.producer_product,
-            consumer_product=expectation.consumer_product,
-            source_id=expectation.source_id,
-            producer_count=len(producer.rows),
-            consumer_count=len(consumer.rows),
-            required_consumer_foreign_key=required_foreign_key,
-        )
-    candidates = [
-        (field.name, role.parent_field)
+    )
+    required_foreign_key = _required_memstore_foreign_key(
+        expectation,
+        consumer_plan,
+        producer_identifiers,
+    )
+    return _MemstoreContext(
+        expectation=expectation,
+        source=source,
+        producer=producer,
+        consumer=consumer,
+        consumer_plan=consumer_plan,
+        producer_identifiers=producer_identifiers,
+        required_foreign_key=required_foreign_key,
+    )
+
+
+def _required_memstore_foreign_key(
+    expectation: _MemstoreCompleteness,
+    consumer_plan: ProductCompilePlan,
+    producer_identifiers: frozenset[str],
+) -> RequiredConsumerForeignKey | None:
+    if len(producer_identifiers) != 1:
+        return None
+    producer_identifier = next(iter(producer_identifiers))
+    observed_roles = sum(
+        1
         for field in consumer_plan.fields
         for role in field.roles
         if isinstance(role, ForeignKeyRolePlan)
         and role.parent_product == expectation.producer_product
-        and role.parent_field in producer_identifiers
+        and role.parent_field == producer_identifier
+    )
+    return RequiredConsumerForeignKey(
+        parent_product=expectation.producer_product,
+        parent_field=producer_identifier,
+        observed_count=observed_roles,
+    )
+
+
+def _memstore_count_result(
+    context: _MemstoreContext,
+) -> MemstoreCompletenessAcceptanceResult | None:
+    if len(context.producer.rows) != len(context.consumer.rows):
+        return MemstoreCompletenessAcceptanceResult(
+            status=AcceptanceStatus.FAIL,
+            source=context.source,
+            message="producer and memstore consumer bounded row counts differ",
+            producer_product=context.expectation.producer_product,
+            consumer_product=context.expectation.consumer_product,
+            source_id=context.expectation.source_id,
+            producer_count=len(context.producer.rows),
+            consumer_count=len(context.consumer.rows),
+            required_consumer_foreign_key=context.required_foreign_key,
+        )
+    return None
+
+
+def _resolve_memstore_binding(
+    context: _MemstoreContext,
+) -> _MemstoreBinding | MemstoreCompletenessAcceptanceResult:
+    candidates = [
+        (field.name, role.parent_field)
+        for field in context.consumer_plan.fields
+        for role in field.roles
+        if isinstance(role, ForeignKeyRolePlan)
+        and role.parent_product == context.expectation.producer_product
+        and role.parent_field in context.producer_identifiers
     ]
     if len(candidates) != 1:
         return MemstoreCompletenessAcceptanceResult(
             status=AcceptanceStatus.UNEVALUABLE,
-            source=source,
+            source=context.source,
             message=(
                 "memstore completeness requires exactly one explicit consumer FK role "
                 "targeting a typed producer identifier; "
                 f"found {len(candidates)}"
             ),
-            producer_product=expectation.producer_product,
-            consumer_product=expectation.consumer_product,
-            source_id=expectation.source_id,
-            producer_count=len(producer.rows),
-            consumer_count=len(consumer.rows),
-            required_consumer_foreign_key=required_foreign_key,
+            producer_product=context.expectation.producer_product,
+            consumer_product=context.expectation.consumer_product,
+            source_id=context.expectation.source_id,
+            producer_count=len(context.producer.rows),
+            consumer_count=len(context.consumer.rows),
+            required_consumer_foreign_key=context.required_foreign_key,
         )
     consumer_key_field, producer_key_field = candidates[0]
-    producer_rows, producer_error = _rows(captured, expectation.producer_product)
-    consumer_rows, consumer_error = _rows(captured, expectation.consumer_product)
+    return _MemstoreBinding(
+        consumer_key_field=consumer_key_field,
+        producer_key_field=producer_key_field,
+    )
+
+
+def _resolve_memstore_values(
+    context: _MemstoreContext,
+    binding: _MemstoreBinding,
+    captured: CapturedProducts,
+) -> _MemstoreValues | MemstoreCompletenessAcceptanceResult:
+    producer_rows, producer_error = _rows(
+        captured,
+        context.expectation.producer_product,
+    )
+    consumer_rows, consumer_error = _rows(
+        captured,
+        context.expectation.consumer_product,
+    )
     if producer_rows is None or consumer_rows is None:
-        return MemstoreCompletenessAcceptanceResult(
-            status=AcceptanceStatus.UNEVALUABLE,
-            source=source,
-            message=str(producer_error or consumer_error),
-            producer_product=expectation.producer_product,
-            consumer_product=expectation.consumer_product,
-            source_id=expectation.source_id,
-            producer_count=len(producer.rows),
-            consumer_count=len(consumer.rows),
-            producer_key_field=producer_key_field,
-            consumer_key_field=consumer_key_field,
-            required_consumer_foreign_key=required_foreign_key,
+        return _unevaluable_memstore_values(
+            context,
+            binding,
+            str(producer_error or consumer_error),
         )
     producer_values, producer_error = _values(
         producer_rows,
-        product=expectation.producer_product,
-        field=producer_key_field,
+        product=context.expectation.producer_product,
+        field=binding.producer_key_field,
     )
     consumer_values, consumer_error = _values(
         consumer_rows,
-        product=expectation.consumer_product,
-        field=consumer_key_field,
+        product=context.expectation.consumer_product,
+        field=binding.consumer_key_field,
     )
     if producer_values is None or consumer_values is None:
-        return MemstoreCompletenessAcceptanceResult(
-            status=AcceptanceStatus.UNEVALUABLE,
-            source=source,
-            message=str(producer_error or consumer_error),
-            producer_product=expectation.producer_product,
-            consumer_product=expectation.consumer_product,
-            source_id=expectation.source_id,
-            producer_count=len(producer.rows),
-            consumer_count=len(consumer.rows),
-            producer_key_field=producer_key_field,
-            consumer_key_field=consumer_key_field,
-            required_consumer_foreign_key=required_foreign_key,
+        return _unevaluable_memstore_values(
+            context,
+            binding,
+            str(producer_error or consumer_error),
         )
-    producer_keys = {_display(value) for value in producer_values}
-    consumer_keys = {_display(value) for value in consumer_values}
-    producer_labels = {_display(value): repr(value) for value in producer_values}
-    consumer_labels = {_display(value): repr(value) for value in consumer_values}
+    return _MemstoreValues(producer=producer_values, consumer=consumer_values)
+
+
+def _unevaluable_memstore_values(
+    context: _MemstoreContext,
+    binding: _MemstoreBinding,
+    message: str,
+) -> MemstoreCompletenessAcceptanceResult:
+    return MemstoreCompletenessAcceptanceResult(
+        status=AcceptanceStatus.UNEVALUABLE,
+        source=context.source,
+        message=message,
+        producer_product=context.expectation.producer_product,
+        consumer_product=context.expectation.consumer_product,
+        source_id=context.expectation.source_id,
+        producer_count=len(context.producer.rows),
+        consumer_count=len(context.consumer.rows),
+        producer_key_field=binding.producer_key_field,
+        consumer_key_field=binding.consumer_key_field,
+        required_consumer_foreign_key=context.required_foreign_key,
+    )
+
+
+def _memstore_identity_result(
+    context: _MemstoreContext,
+    binding: _MemstoreBinding,
+    values: _MemstoreValues,
+) -> MemstoreCompletenessAcceptanceResult:
+    producer_keys = {_display(value) for value in values.producer}
+    consumer_keys = {_display(value) for value in values.consumer}
+    producer_labels = {_display(value): repr(value) for value in values.producer}
+    consumer_labels = {_display(value): repr(value) for value in values.consumer}
     missing = sorted(producer_labels[key] for key in producer_keys - consumer_keys)
     unexpected = sorted(consumer_labels[key] for key in consumer_keys - producer_keys)
-    duplicate_producer = _duplicates(producer_values)
-    duplicate_consumer = _duplicates(consumer_values)
+    duplicate_producer = _duplicates(values.producer)
+    duplicate_consumer = _duplicates(values.consumer)
     passed = not (missing or unexpected or duplicate_producer or duplicate_consumer)
     return MemstoreCompletenessAcceptanceResult(
         status=AcceptanceStatus.PASS if passed else AcceptanceStatus.FAIL,
-        source=source,
+        source=context.source,
         message=(
             "every bounded producer identity was read back exactly once"
             if passed
             else "memstore consumer identities do not exactly match producer identities"
         ),
-        producer_product=expectation.producer_product,
-        consumer_product=expectation.consumer_product,
-        source_id=expectation.source_id,
-        producer_count=len(producer.rows),
-        consumer_count=len(consumer.rows),
-        producer_key_field=producer_key_field,
-        consumer_key_field=consumer_key_field,
-        required_consumer_foreign_key=required_foreign_key,
+        producer_product=context.expectation.producer_product,
+        consumer_product=context.expectation.consumer_product,
+        source_id=context.expectation.source_id,
+        producer_count=len(context.producer.rows),
+        consumer_count=len(context.consumer.rows),
+        producer_key_field=binding.producer_key_field,
+        consumer_key_field=binding.consumer_key_field,
+        required_consumer_foreign_key=context.required_foreign_key,
         missing_keys=missing[:20],
         unexpected_keys=unexpected[:20],
         duplicate_producer_keys=duplicate_producer[:20],
@@ -1265,20 +1426,38 @@ def _incomplete_result(
     captured: CapturedProducts,
     evidence: CaptureCompletenessEvidence,
 ) -> AcceptanceResult:
+    result = _incomplete_result_without_evidence(
+        entry,
+        captured,
+        _incomplete_message(evidence),
+    )
+    return result.with_capture_completeness(evidence)
+
+
+def _captured_count(captured: CapturedProducts, product: str) -> int | None:
+    capture = captured.get(product)
+    if capture is None:
+        return None
+    return len(capture.rows)
+
+
+def _incomplete_result_without_evidence(
+    entry: _ExpectationEntry,
+    captured: CapturedProducts,
+    message: str,
+) -> AcceptanceResult:
     expectation = entry.expectation
-    message = _incomplete_message(evidence)
     if isinstance(expectation, _Exact):
-        product = captured.get(expectation.product)
-        result: AcceptanceResult = ExactCountAcceptanceResult(
+        return ExactCountAcceptanceResult(
             status=AcceptanceStatus.UNEVALUABLE,
             source=entry.source,
             message=message,
             product=expectation.product,
             expected_count=expectation.count,
-            observed_count=None if product is None else len(product.rows),
+            observed_count=_captured_count(captured, expectation.product),
         )
-    elif isinstance(expectation, _PerParent):
-        result = PerParentCountAcceptanceResult(
+    if isinstance(expectation, _PerParent):
+        return PerParentCountAcceptanceResult(
             status=AcceptanceStatus.UNEVALUABLE,
             source=entry.source,
             message=message,
@@ -1286,21 +1465,19 @@ def _incomplete_result(
             parent_product=expectation.parent_product,
             expected_count_per_parent=expectation.count,
         )
-    elif isinstance(expectation, _Unique):
-        product = captured.get(expectation.product)
-        result = UniqueAcceptanceResult(
+    if isinstance(expectation, _Unique):
+        return UniqueAcceptanceResult(
             status=AcceptanceStatus.UNEVALUABLE,
             source=entry.source,
             message=message,
             product=expectation.product,
             field=expectation.field,
             scope=expectation.scope,
-            observed_count=None if product is None else len(product.rows),
+            observed_count=_captured_count(captured, expectation.product),
             distinct_count=None,
         )
-    elif isinstance(expectation, _ForeignKey):
-        product = captured.get(expectation.product)
-        result = ForeignKeyAcceptanceResult(
+    if isinstance(expectation, _ForeignKey):
+        return ForeignKeyAcceptanceResult(
             status=AcceptanceStatus.UNEVALUABLE,
             source=entry.source,
             message=message,
@@ -1308,21 +1485,20 @@ def _incomplete_result(
             child_field=expectation.child_field,
             parent_product=expectation.parent_product,
             parent_field=expectation.parent_field,
-            observed_count=None if product is None else len(product.rows),
+            observed_count=_captured_count(captured, expectation.product),
         )
-    elif isinstance(expectation, _AllowedValues):
-        product = captured.get(expectation.product)
-        result = AllowedValuesAcceptanceResult(
+    if isinstance(expectation, _AllowedValues):
+        return AllowedValuesAcceptanceResult(
             status=AcceptanceStatus.UNEVALUABLE,
             source=entry.source,
             message=message,
             product=expectation.product,
             field=expectation.field,
             allowed_values=list(expectation.values),
-            observed_count=None if product is None else len(product.rows),
+            observed_count=_captured_count(captured, expectation.product),
         )
-    elif isinstance(expectation, _Range):
-        result = RangeAcceptanceResult(
+    if isinstance(expectation, _Range):
+        return RangeAcceptanceResult(
             status=AcceptanceStatus.UNEVALUABLE,
             source=entry.source,
             message=message,
@@ -1331,30 +1507,25 @@ def _incomplete_result(
             expected_minimum=str(expectation.minimum),
             expected_maximum=str(expectation.maximum),
         )
-    elif isinstance(expectation, _RowCondition):
-        product = captured.get(expectation.product)
-        result = RowConditionAcceptanceResult(
+    if isinstance(expectation, _RowCondition):
+        return RowConditionAcceptanceResult(
             status=AcceptanceStatus.UNEVALUABLE,
             source=entry.source,
             message=message,
             product=expectation.product,
             condition=expectation.condition,
-            observed_count=None if product is None else len(product.rows),
+            observed_count=_captured_count(captured, expectation.product),
         )
-    else:
-        producer = captured.get(expectation.producer_product)
-        consumer = captured.get(expectation.consumer_product)
-        result = MemstoreCompletenessAcceptanceResult(
-            status=AcceptanceStatus.UNEVALUABLE,
-            source=entry.source,
-            message=message,
-            producer_product=expectation.producer_product,
-            consumer_product=expectation.consumer_product,
-            source_id=expectation.source_id,
-            producer_count=None if producer is None else len(producer.rows),
-            consumer_count=None if consumer is None else len(consumer.rows),
-        )
-    return result.with_capture_completeness(evidence)
+    return MemstoreCompletenessAcceptanceResult(
+        status=AcceptanceStatus.UNEVALUABLE,
+        source=entry.source,
+        message=message,
+        producer_product=expectation.producer_product,
+        consumer_product=expectation.consumer_product,
+        source_id=expectation.source_id,
+        producer_count=_captured_count(captured, expectation.producer_product),
+        consumer_count=_captured_count(captured, expectation.consumer_product),
+    )
 
 
 def _evaluate_entry(

--- a/datamimic_ce/authoring/compiler.py
+++ b/datamimic_ce/authoring/compiler.py
@@ -132,18 +132,26 @@ def _field_element(field: FieldIntentUnion, *, depth: int) -> Element:
     if isinstance(field, PersonEmailField):
         attributes["script"] = f"{_entity_variable(depth)}.email"
         return Element("key", attributes)
+    if isinstance(field, IntegerRangeField | DecimalRangeField | StringLengthField):
+        return _range_field_element(field, attributes)
+    if isinstance(field, ValuesField | WeightedField | PatternField | ConstantField | ScriptField):
+        return _literal_field_element(field, attributes)
+    if isinstance(field, NestedListField):
+        return _nested_list_element(field, attributes, depth)
+    raise CompileError(f"unsupported field intent kind {field.kind!r}")
+
+
+def _range_field_element(
+    field: IntegerRangeField | DecimalRangeField | StringLengthField,
+    attributes: dict[str, str],
+) -> Element:
     if isinstance(field, IntegerRangeField):
         attributes.update(
-            {
-                "type": "int",
-                "min": str(field.minimum),
-                "max": str(field.maximum),
-            }
+            {"type": "int", "min": str(field.minimum), "max": str(field.maximum)}
         )
         if field.unique:
             attributes["distribution"] = "shuffle"
-        return Element("key", attributes)
-    if isinstance(field, DecimalRangeField):
+    elif isinstance(field, DecimalRangeField):
         attributes.update(
             {
                 "type": "decimal",
@@ -151,8 +159,7 @@ def _field_element(field: FieldIntentUnion, *, depth: int) -> Element:
                 "max": _stringify_number(field.maximum),
             }
         )
-        return Element("key", attributes)
-    if isinstance(field, StringLengthField):
+    else:
         attributes.update(
             {
                 "type": "string",
@@ -160,44 +167,51 @@ def _field_element(field: FieldIntentUnion, *, depth: int) -> Element:
                 "maxLength": str(field.maximum),
             }
         )
-        return Element("key", attributes)
+    return Element("key", attributes)
+
+
+def _literal_field_element(
+    field: ValuesField | WeightedField | PatternField | ConstantField | ScriptField,
+    attributes: dict[str, str],
+) -> Element:
     if isinstance(field, ValuesField):
         attributes["values"] = _literal_collection(field.values)
-        return Element("key", attributes)
-    if isinstance(field, WeightedField):
+    elif isinstance(field, WeightedField):
         attributes["values"] = _literal_collection(field.values)
         attributes["weights"] = _literal_collection(field.weights)
-        return Element("key", attributes)
-    if isinstance(field, PatternField):
+    elif isinstance(field, PatternField):
         attributes["pattern"] = field.pattern
-        return Element("key", attributes)
-    if isinstance(field, ConstantField):
+    elif isinstance(field, ConstantField):
         attributes["constant"] = field.value
-        return Element("key", attributes)
-    if isinstance(field, ScriptField):
+    else:
         attributes["script"] = field.script
-        return Element("key", attributes)
-    if isinstance(field, NestedListField):
-        attributes.update(
-            {
-                "type": "list",
-                "minCount": str(field.minimum_count),
-                "maxCount": str(field.maximum_count),
-            }
-        )
-        nested = Element("nestedKey", attributes)
-        nested_depth = depth + 1
-        if _uses_person(field.fields):
-            nested.append(
-                Element(
-                    "variable",
-                    {"name": _entity_variable(nested_depth), "entity": "Person"},
-                )
+    return Element("key", attributes)
+
+
+def _nested_list_element(
+    field: NestedListField,
+    attributes: dict[str, str],
+    depth: int,
+) -> Element:
+    attributes.update(
+        {
+            "type": "list",
+            "minCount": str(field.minimum_count),
+            "maxCount": str(field.maximum_count),
+        }
+    )
+    nested = Element("nestedKey", attributes)
+    nested_depth = depth + 1
+    if _uses_person(field.fields):
+        nested.append(
+            Element(
+                "variable",
+                {"name": _entity_variable(nested_depth), "entity": "Person"},
             )
-        for child in field.fields:
-            nested.append(_field_element(child, depth=nested_depth))
-        return nested
-    raise CompileError(f"unsupported field intent kind {field.kind!r}")
+        )
+    for child in field.fields:
+        nested.append(_field_element(child, depth=nested_depth))
+    return nested
 
 
 def _target_attributes(product: ProductIntentUnion | NestedGeneratedProduct) -> dict[str, str]:
@@ -222,20 +236,23 @@ def _generate_element(
     *,
     depth: int,
 ) -> Element:
+    attributes = _product_attributes(product)
+    attributes.update(_target_attributes(product))
+    element = Element("generate", attributes)
+    _append_product_fields(element, product, depth)
+    _append_generated_children(element, product, depth)
+    return element
+
+
+def _product_attributes(
+    product: ProductIntentUnion | NestedGeneratedProduct,
+) -> dict[str, str]:
     attributes = {"name": product.name}
     if isinstance(product, GeneratedProduct | NestedGeneratedProduct):
         attributes["count"] = str(product.count)
     elif isinstance(product, SourceProduct):
-        if isinstance(product.source, FileSource):
-            attributes["source"] = product.source.path
-            if product.source.separator is not None:
-                attributes["separator"] = product.source.separator
-        elif isinstance(product.source, MemstoreSource):
-            attributes["source"] = product.source.id
-            if product.source.product is not None:
-                attributes["type"] = product.source.product
-        attributes["distribution"] = product.source.distribution
-    elif isinstance(product, TimeSeriesProduct):
+        attributes.update(_source_product_attributes(product))
+    else:
         attributes.update(
             {
                 "count": str(product.series_count),
@@ -244,18 +261,45 @@ def _generate_element(
                 "interval": product.window.interval,
             }
         )
-    attributes.update(_target_attributes(product))
-    element = Element("generate", attributes)
+    return attributes
+
+
+def _source_product_attributes(product: SourceProduct) -> dict[str, str]:
+    source = product.source
+    attributes: dict[str, str] = {}
+    if isinstance(source, FileSource):
+        attributes["source"] = source.path
+        if source.separator is not None:
+            attributes["separator"] = source.separator
+    else:
+        attributes["source"] = source.id
+        if source.product is not None:
+            attributes["type"] = source.product
+    attributes["distribution"] = source.distribution
+    return attributes
+
+
+def _append_product_fields(
+    element: Element,
+    product: ProductIntentUnion | NestedGeneratedProduct,
+    depth: int,
+) -> None:
     if _uses_person(product.fields):
         element.append(
             Element("variable", {"name": _entity_variable(depth), "entity": "Person"})
         )
     for field in product.fields:
         element.append(_field_element(field, depth=depth))
+
+
+def _append_generated_children(
+    element: Element,
+    product: ProductIntentUnion | NestedGeneratedProduct,
+    depth: int,
+) -> None:
     if isinstance(product, GeneratedProduct):
         for child in product.children:
             element.append(_generate_element(child, depth=depth + 1))
-    return element
 
 
 def _all_products(spec: AuthoringSpecV1) -> list[tuple[ProductIntentUnion | NestedGeneratedProduct, str | None]]:
@@ -356,75 +400,125 @@ def _static_cardinalities(
     list[UnresolvedCompileFact],
 ]:
     products = _all_products(spec)
+    counts, relationships, unresolved = _direct_cardinalities(products)
+    _resolve_memstore_cardinalities(products, counts, relationships, unresolved)
+    return counts, relationships, unresolved
+
+
+def _direct_cardinalities(
+    products: list[tuple[ProductIntentUnion | NestedGeneratedProduct, str | None]],
+) -> tuple[
+    dict[str, int | None],
+    list[RelationshipPlan],
+    list[UnresolvedCompileFact],
+]:
     counts: dict[str, int | None] = {}
     relationships: list[RelationshipPlan] = []
     unresolved: list[UnresolvedCompileFact] = []
-
     for product, parent in products:
-        if isinstance(product, GeneratedProduct | NestedGeneratedProduct):
-            count: int | None = int(product.count)
-            if parent is not None:
-                parent_count = counts.get(parent)
-                count = parent_count * int(product.count) if parent_count is not None else None
-                relationships.append(
-                    NestedRelationshipPlan(parent=parent, child=product.name)
-                )
-            counts[product.name] = count
-        elif isinstance(product, TimeSeriesProduct):
-            try:
-                window = TimeSeriesConfig.parse(
-                    product.window.start,
-                    product.window.end,
-                    product.window.interval,
-                )
-            except ValueError as error:
-                raise CompileError(str(error)) from error
-            counts[product.name] = int(product.series_count) * window.ticks_per_series
-        elif isinstance(product.source, FileSource):
-            counts[product.name] = None
-            unresolved.append(
-                UnresolvedCompileFact(
-                    product=product.name,
-                    aspect="cardinality",
-                    reason="file source length requires I/O and is intentionally unknown at compile time",
-                )
-            )
+        _register_direct_cardinality(product, parent, counts, relationships, unresolved)
+    return counts, relationships, unresolved
 
-    pending: list[SourceProduct] = []
-    for product, _parent in products:
-        if isinstance(product, SourceProduct) and isinstance(product.source, MemstoreSource):
-            pending.append(product)
+
+def _register_direct_cardinality(
+    product: ProductIntentUnion | NestedGeneratedProduct,
+    parent: str | None,
+    counts: dict[str, int | None],
+    relationships: list[RelationshipPlan],
+    unresolved: list[UnresolvedCompileFact],
+) -> None:
+    if isinstance(product, GeneratedProduct | NestedGeneratedProduct):
+        count: int | None = int(product.count)
+        if parent is not None:
+            parent_count = counts.get(parent)
+            count = parent_count * int(product.count) if parent_count is not None else None
+            relationships.append(NestedRelationshipPlan(parent=parent, child=product.name))
+        counts[product.name] = count
+    elif isinstance(product, TimeSeriesProduct):
+        counts[product.name] = _time_series_cardinality(product)
+    elif isinstance(product.source, FileSource):
+        counts[product.name] = None
+        unresolved.append(
+            UnresolvedCompileFact(
+                product=product.name,
+                aspect="cardinality",
+                reason="file source length requires I/O and is intentionally unknown at compile time",
+            )
+        )
+
+
+def _time_series_cardinality(product: TimeSeriesProduct) -> int:
+    try:
+        window = TimeSeriesConfig.parse(
+            product.window.start,
+            product.window.end,
+            product.window.interval,
+        )
+    except ValueError as error:
+        raise CompileError(str(error)) from error
+    return int(product.series_count) * window.ticks_per_series
+
+
+def _memstore_source_products(
+    products: list[tuple[ProductIntentUnion | NestedGeneratedProduct, str | None]],
+) -> list[SourceProduct]:
+    return [
+        product
+        for product, _parent in products
+        if isinstance(product, SourceProduct) and isinstance(product.source, MemstoreSource)
+    ]
+
+
+def _resolve_memstore_cardinalities(
+    products: list[tuple[ProductIntentUnion | NestedGeneratedProduct, str | None]],
+    counts: dict[str, int | None],
+    relationships: list[RelationshipPlan],
+    unresolved: list[UnresolvedCompileFact],
+) -> None:
+    pending = _memstore_source_products(products)
     while pending:
         progressed = False
         for product in list(pending):
-            source = product.source
-            if not isinstance(source, MemstoreSource):
-                raise CompileError(f"internal source classification failed for '{product.name}'")
-            producer = _producer_for_source(source, products)
-            if producer.name not in counts:
-                continue
-            counts[product.name] = counts[producer.name]
-            relationships.append(
-                MemstoreRelationshipPlan(
-                    parent=producer.name,
-                    child=product.name,
-                    source_id=source.id,
-                )
-            )
-            if counts[product.name] is None:
-                unresolved.append(
-                    UnresolvedCompileFact(
-                        product=product.name,
-                        aspect="cardinality",
-                        reason=f"producer '{producer.name}' has unknown cardinality",
-                    )
-                )
-            pending.remove(product)
-            progressed = True
+            if _resolve_memstore_cardinality(
+                product, products, counts, relationships, unresolved
+            ):
+                pending.remove(product)
+                progressed = True
         if not progressed:
             cycle = ", ".join(product.name for product in pending)
             raise CompileError(f"cyclic or unresolved memstore source chain: {cycle}")
-    return counts, relationships, unresolved
+
+
+def _resolve_memstore_cardinality(
+    product: SourceProduct,
+    products: list[tuple[ProductIntentUnion | NestedGeneratedProduct, str | None]],
+    counts: dict[str, int | None],
+    relationships: list[RelationshipPlan],
+    unresolved: list[UnresolvedCompileFact],
+) -> bool:
+    source = product.source
+    if not isinstance(source, MemstoreSource):
+        raise CompileError(f"internal source classification failed for '{product.name}'")
+    producer = _producer_for_source(source, products)
+    if producer.name not in counts:
+        return False
+    counts[product.name] = counts[producer.name]
+    relationships.append(
+        MemstoreRelationshipPlan(
+            parent=producer.name,
+            child=product.name,
+            source_id=source.id,
+        )
+    )
+    if counts[product.name] is None:
+        unresolved.append(
+            UnresolvedCompileFact(
+                product=product.name,
+                aspect="cardinality",
+                reason=f"producer '{producer.name}' has unknown cardinality",
+            )
+        )
+    return True
 
 
 def _field_plan(field: FieldIntentUnion) -> FieldPlan:
@@ -492,55 +586,69 @@ def _derived_field_acceptance(
     result: list[DerivedAcceptancePlan] = []
     unique_fields: set[str] = set()
     for field in product.fields:
-        if isinstance(field, IntegerRangeField):
+        field_acceptance, field_is_unique = _derived_value_acceptance(product.name, field)
+        result.extend(field_acceptance)
+        if field_is_unique:
+            unique_fields.add(field.name)
+        result.extend(_derived_role_acceptance(product.name, field, unique_fields))
+    return result
+
+
+def _derived_value_acceptance(
+    product_name: str,
+    field: FieldIntentUnion,
+) -> tuple[list[DerivedAcceptancePlan], bool]:
+    if isinstance(field, IntegerRangeField):
+        result: list[DerivedAcceptancePlan] = [
+            RangeAcceptancePlan(
+                product=product_name,
+                field=field.name,
+                minimum=str(field.minimum),
+                maximum=str(field.maximum),
+            )
+        ]
+        if field.unique:
+            result.append(UniqueAcceptancePlan(product=product_name, field=field.name))
+        return result, field.unique
+    if isinstance(field, DecimalRangeField):
+        return [
+            RangeAcceptancePlan(
+                product=product_name,
+                field=field.name,
+                minimum=str(field.minimum),
+                maximum=str(field.maximum),
+            )
+        ], False
+    if isinstance(field, ValuesField | WeightedField):
+        return [
+            AllowedValuesAcceptancePlan(
+                product=product_name,
+                field=field.name,
+                allowed_values=list(field.values),
+            )
+        ], False
+    return [], False
+
+
+def _derived_role_acceptance(
+    product_name: str,
+    field: FieldIntentUnion,
+    unique_fields: set[str],
+) -> list[DerivedAcceptancePlan]:
+    result: list[DerivedAcceptancePlan] = []
+    for role in field.roles:
+        if isinstance(role, IdentifierRole) and field.name not in unique_fields:
+            unique_fields.add(field.name)
+            result.append(UniqueAcceptancePlan(product=product_name, field=field.name))
+        if isinstance(role, ForeignKeyRole):
             result.append(
-                RangeAcceptancePlan(
-                    product=product.name,
-                    field=field.name,
-                    minimum=str(field.minimum),
-                    maximum=str(field.maximum),
+                ForeignKeyAcceptancePlan(
+                    product=product_name,
+                    parent_product=role.parent_product,
+                    parent_field=role.parent_field,
+                    child_field=field.name,
                 )
             )
-            if field.unique:
-                unique_fields.add(field.name)
-                result.append(
-                    UniqueAcceptancePlan(
-                        product=product.name,
-                        field=field.name,
-                    )
-                )
-        elif isinstance(field, DecimalRangeField):
-            result.append(
-                RangeAcceptancePlan(
-                    product=product.name,
-                    field=field.name,
-                    minimum=str(field.minimum),
-                    maximum=str(field.maximum),
-                )
-            )
-        elif isinstance(field, ValuesField | WeightedField):
-            result.append(
-                AllowedValuesAcceptancePlan(
-                    product=product.name,
-                    field=field.name,
-                    allowed_values=list(field.values),
-                )
-            )
-        for role in field.roles:
-            if isinstance(role, IdentifierRole) and field.name not in unique_fields:
-                unique_fields.add(field.name)
-                result.append(
-                    UniqueAcceptancePlan(product=product.name, field=field.name)
-                )
-            if isinstance(role, ForeignKeyRole):
-                result.append(
-                    ForeignKeyAcceptancePlan(
-                        product=product.name,
-                        parent_product=role.parent_product,
-                        parent_field=role.parent_field,
-                        child_field=field.name,
-                    )
-                )
     return result
 
 
@@ -551,88 +659,125 @@ def _compile_plan(spec: AuthoringSpecV1) -> CompilePlan:
     acceptance: list[DerivedAcceptancePlan] = []
     for product, parent in all_products:
         per_parent = int(product.count) if isinstance(product, NestedGeneratedProduct) else None
-        children = (
-            [child.name for child in product.children]
-            if isinstance(product, GeneratedProduct)
-            else []
-        )
         fields = [_field_plan(field) for field in product.fields]
         targets = _target_plans(product)
-        if isinstance(product, GeneratedProduct | NestedGeneratedProduct):
-            static_count = counts[product.name]
-            if static_count is None:
-                raise CompileError(f"generated product '{product.name}' has unknown cardinality")
-            product_plan: ProductCompilePlan = GeneratedProductCompilePlan(
-                name=product.name,
-                fields=fields,
-                targets=targets,
+        product_plans.append(
+            _product_compile_plan(
+                product,
                 parent=parent,
-                children=children,
-                static_count=static_count,
-                count_per_parent=per_parent,
-            )
-        elif isinstance(product, SourceProduct):
-            source = _source_plan(product)
-            if source is None:
-                raise CompileError(f"source plan missing for '{product.name}'")
-            product_plan = SourceProductCompilePlan(
-                name=product.name,
-                fields=fields,
-                targets=targets,
+                per_parent=per_parent,
                 static_count=counts[product.name],
-                source=source,
-            )
-        else:
-            static_count = counts[product.name]
-            if static_count is None:
-                raise CompileError(f"time-series product '{product.name}' has unknown cardinality")
-            product_plan = TimeSeriesProductCompilePlan(
-                name=product.name,
                 fields=fields,
                 targets=targets,
-                static_count=static_count,
-                series_count=product.series_count,
             )
-        product_plans.append(product_plan)
-        exact_count = counts[product.name]
-        if exact_count is not None:
-            acceptance.append(
-                ExactCountAcceptancePlan(
-                    product=product.name,
-                    exact_count=exact_count,
-                )
+        )
+        acceptance.extend(
+            _derived_count_acceptance(
+                product.name,
+                parent=parent,
+                per_parent=per_parent,
+                static_count=counts[product.name],
             )
-        if parent is not None and per_parent is not None:
-            acceptance.append(
-                PerParentCountAcceptancePlan(
-                    product=product.name,
-                    parent_product=parent,
-                    count_per_parent=per_parent,
-                )
-            )
+        )
         acceptance.extend(_derived_field_acceptance(product))
-
-        required_unique_count = counts[product.name]
-        for field in product.fields:
-            if not isinstance(field, IntegerRangeField) or not field.unique:
-                continue
-            if required_unique_count is None:
-                raise CompileError(
-                    f"field '{field.name}' in product '{product.name}' uses unique=true but "
-                    "cardinality is not statically known"
-                )
-            capacity = field.maximum - field.minimum + 1
-            if capacity < required_unique_count:
-                raise CompileError(
-                    f"field '{field.name}' in product '{product.name}' has only {capacity} "
-                    f"possible values under unique=true but requires {required_unique_count}"
-                )
+        _validate_unique_capacities(product, counts[product.name])
     return CompilePlan(
         products=product_plans,
         relationships=relationships,
         unresolved=unresolved,
         derived_acceptance=acceptance,
     )
+
+
+def _product_compile_plan(
+    product: ProductIntentUnion | NestedGeneratedProduct,
+    *,
+    parent: str | None,
+    per_parent: int | None,
+    static_count: int | None,
+    fields: list[FieldPlan],
+    targets: list[TargetBindingPlan],
+) -> ProductCompilePlan:
+    if isinstance(product, GeneratedProduct | NestedGeneratedProduct):
+        if static_count is None:
+            raise CompileError(f"generated product '{product.name}' has unknown cardinality")
+        children = (
+            [child.name for child in product.children]
+            if isinstance(product, GeneratedProduct)
+            else []
+        )
+        return GeneratedProductCompilePlan(
+            name=product.name,
+            fields=fields,
+            targets=targets,
+            parent=parent,
+            children=children,
+            static_count=static_count,
+            count_per_parent=per_parent,
+        )
+    if isinstance(product, SourceProduct):
+        source = _source_plan(product)
+        if source is None:
+            raise CompileError(f"source plan missing for '{product.name}'")
+        return SourceProductCompilePlan(
+            name=product.name,
+            fields=fields,
+            targets=targets,
+            static_count=static_count,
+            source=source,
+        )
+    if static_count is None:
+        raise CompileError(f"time-series product '{product.name}' has unknown cardinality")
+    return TimeSeriesProductCompilePlan(
+        name=product.name,
+        fields=fields,
+        targets=targets,
+        static_count=static_count,
+        series_count=product.series_count,
+    )
+
+
+def _derived_count_acceptance(
+    product_name: str,
+    *,
+    parent: str | None,
+    per_parent: int | None,
+    static_count: int | None,
+) -> list[DerivedAcceptancePlan]:
+    result: list[DerivedAcceptancePlan] = []
+    if static_count is not None:
+        result.append(
+            ExactCountAcceptancePlan(product=product_name, exact_count=static_count)
+        )
+    if parent is not None and per_parent is not None:
+        result.append(
+            PerParentCountAcceptancePlan(
+                product=product_name,
+                parent_product=parent,
+                count_per_parent=per_parent,
+            )
+        )
+    return result
+
+
+def _validate_unique_capacities(
+    product: ProductIntentUnion | NestedGeneratedProduct,
+    required_count: int | None,
+) -> None:
+    for field in product.fields:
+        if not isinstance(field, IntegerRangeField) or not field.unique:
+            continue
+        if required_count is None:
+            raise CompileError(
+                f"field '{field.name}' in product '{product.name}' uses unique=true but "
+                "cardinality is not statically known"
+            )
+        capacity = field.maximum - field.minimum + 1
+        if capacity < required_count:
+            raise CompileError(
+                f"field '{field.name}' in product '{product.name}' has only {capacity} "
+                f"possible values under unique=true but requires {required_count}"
+            )
 
 
 def compile_authoring_spec(spec: AuthoringSpecV1) -> CompileResult:

--- a/datamimic_ce/authoring/compiler.py
+++ b/datamimic_ce/authoring/compiler.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from decimal import Decimal
+from typing import assert_never
 from xml.etree.ElementTree import Element
 from xml.sax.saxutils import quoteattr
 
@@ -547,20 +548,20 @@ def _field_plan(field: FieldIntentUnion) -> FieldPlan:
     return LeafFieldPlan(name=field.name, kind=field.kind, roles=roles)
 
 
-def _source_plan(product: ProductIntentUnion | NestedGeneratedProduct) -> SourceBindingPlan | None:
-    if not isinstance(product, SourceProduct):
-        return None
+def _source_plan(product: SourceProduct) -> SourceBindingPlan:
     if isinstance(product.source, FileSource):
         return FileSourceBindingPlan(
             path=product.source.path,
             separator=product.source.separator,
             distribution=product.source.distribution,
         )
-    return MemstoreSourceBindingPlan(
-        id=product.source.id,
-        product=product.source.product,
-        distribution=product.source.distribution,
-    )
+    if isinstance(product.source, MemstoreSource):
+        return MemstoreSourceBindingPlan(
+            id=product.source.id,
+            product=product.source.product,
+            distribution=product.source.distribution,
+        )
+    assert_never(product.source)
 
 
 def _target_plans(
@@ -717,8 +718,6 @@ def _product_compile_plan(
         )
     if isinstance(product, SourceProduct):
         source = _source_plan(product)
-        if source is None:
-            raise CompileError(f"source plan missing for '{product.name}'")
         return SourceProductCompilePlan(
             name=product.name,
             fields=fields,

--- a/datamimic_ce/authoring/contracts.py
+++ b/datamimic_ce/authoring/contracts.py
@@ -11,6 +11,8 @@ the shared numeric limits here prevents one transport from accepting requests
 that another transport rejects.
 """
 
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from decimal import Decimal, InvalidOperation
 from enum import StrEnum
 from typing import Annotated, Any, Literal, Self
@@ -640,6 +642,429 @@ DerivedAcceptancePlan = Annotated[
 ]
 
 
+@dataclass(frozen=True)
+class _CompilePlanIndex:
+    products: dict[str, ProductCompilePlan]
+    fields: dict[str, dict[str, FieldPlan]]
+    nested_edges: set[tuple[str, str]]
+
+    def require_product(self, name: str, context: str) -> ProductCompilePlan:
+        product = self.products.get(name)
+        if product is None:
+            raise ValueError(f"{context} references unknown product '{name}'")
+        return product
+
+    def require_field(self, product_name: str, field_name: str, context: str) -> FieldPlan:
+        self.require_product(product_name, context)
+        field = self.fields[product_name].get(field_name)
+        if field is None:
+            raise ValueError(
+                f"{context} references unknown field '{field_name}' "
+                f"on product '{product_name}'"
+            )
+        return field
+
+
+@dataclass
+class _AcceptanceFacts:
+    exact: set[str] = dataclass_field(default_factory=set)
+    per_parent: set[tuple[str, str]] = dataclass_field(default_factory=set)
+    unique: set[tuple[str, str]] = dataclass_field(default_factory=set)
+    foreign_key: set[tuple[str, str, str, str]] = dataclass_field(default_factory=set)
+    allowed_values: set[tuple[str, str]] = dataclass_field(default_factory=set)
+    ranges: set[tuple[str, str]] = dataclass_field(default_factory=set)
+
+
+def _unique_products(products: list[ProductCompilePlan]) -> dict[str, ProductCompilePlan]:
+    products_by_name: dict[str, ProductCompilePlan] = {}
+    for product in products:
+        if product.name in products_by_name:
+            raise ValueError(f"duplicate product name '{product.name}'")
+        products_by_name[product.name] = product
+    return products_by_name
+
+
+def _unique_fields(products: list[ProductCompilePlan]) -> dict[str, dict[str, FieldPlan]]:
+    fields_by_product: dict[str, dict[str, FieldPlan]] = {}
+    for product in products:
+        fields: dict[str, FieldPlan] = {}
+        for field in product.fields:
+            if field.name in fields:
+                raise ValueError(
+                    f"duplicate field name '{field.name}' in product '{product.name}'"
+                )
+            fields[field.name] = field
+        fields_by_product[product.name] = fields
+    return fields_by_product
+
+
+def _generated_graph(
+    products: list[ProductCompilePlan],
+    products_by_name: dict[str, ProductCompilePlan],
+) -> tuple[set[tuple[str, str]], dict[str, GeneratedProductCompilePlan]]:
+    nested_edges: set[tuple[str, str]] = set()
+    generated_products: dict[str, GeneratedProductCompilePlan] = {}
+    for product in products:
+        if not isinstance(product, GeneratedProductCompilePlan):
+            continue
+        generated_products[product.name] = product
+        _validate_generated_parent(product, products_by_name)
+        for child_name in product.children:
+            _validate_generated_child(product, child_name, products_by_name)
+            nested_edges.add((product.name, child_name))
+    return nested_edges, generated_products
+
+
+def _known_product(
+    products_by_name: dict[str, ProductCompilePlan],
+    name: str,
+    context: str,
+) -> ProductCompilePlan:
+    product = products_by_name.get(name)
+    if product is None:
+        raise ValueError(f"{context} references unknown product '{name}'")
+    return product
+
+
+def _validate_generated_parent(
+    product: GeneratedProductCompilePlan,
+    products_by_name: dict[str, ProductCompilePlan],
+) -> None:
+    if product.parent is None:
+        return
+    parent = _known_product(
+        products_by_name,
+        product.parent,
+        f"generated product '{product.name}'",
+    )
+    if not isinstance(parent, GeneratedProductCompilePlan):
+        raise ValueError(f"generated parent '{product.parent}' must be a generated product")
+    if product.name not in parent.children:
+        raise ValueError(
+            f"generated child '{product.name}' is not declared by parent '{parent.name}'"
+        )
+
+
+def _validate_generated_child(
+    product: GeneratedProductCompilePlan,
+    child_name: str,
+    products_by_name: dict[str, ProductCompilePlan],
+) -> None:
+    child = _known_product(
+        products_by_name,
+        child_name,
+        f"generated product '{product.name}'",
+    )
+    if not isinstance(child, GeneratedProductCompilePlan):
+        raise ValueError(f"generated child '{child_name}' must be a generated product")
+    if child.parent != product.name:
+        raise ValueError(
+            f"generated child '{child_name}' does not reference parent '{product.name}'"
+        )
+
+
+def _validate_generated_cycles(
+    generated_products: dict[str, GeneratedProductCompilePlan],
+) -> None:
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(product_name: str) -> None:
+        if product_name in visiting:
+            raise ValueError(f"generated product graph contains a cycle at '{product_name}'")
+        if product_name in visited:
+            return
+        visiting.add(product_name)
+        for child_name in generated_products[product_name].children:
+            visit(child_name)
+        visiting.remove(product_name)
+        visited.add(product_name)
+
+    for product_name in generated_products:
+        visit(product_name)
+
+
+def _compile_plan_index(products: list[ProductCompilePlan]) -> _CompilePlanIndex:
+    products_by_name = _unique_products(products)
+    fields_by_product = _unique_fields(products)
+    nested_edges, generated_products = _generated_graph(products, products_by_name)
+    _validate_generated_cycles(generated_products)
+    return _CompilePlanIndex(
+        products=products_by_name,
+        fields=fields_by_product,
+        nested_edges=nested_edges,
+    )
+
+
+def _validate_memstore_source_products(
+    products: list[ProductCompilePlan],
+    index: _CompilePlanIndex,
+) -> None:
+    for product in products:
+        if not isinstance(product, SourceProductCompilePlan):
+            continue
+        if not isinstance(product.source, MemstoreSourceBindingPlan):
+            continue
+        if product.source.product is not None:
+            index.require_product(
+                product.source.product,
+                f"memstore source product '{product.name}'",
+            )
+
+
+def _validate_nested_relationship(
+    relationship: NestedRelationshipPlan,
+    parent: ProductCompilePlan,
+    child: ProductCompilePlan,
+    nested_relationships: set[tuple[str, str]],
+    index: _CompilePlanIndex,
+) -> None:
+    endpoints = (relationship.parent, relationship.child)
+    if endpoints in nested_relationships:
+        raise ValueError(
+            f"duplicate nested relationship '{relationship.parent}' -> "
+            f"'{relationship.child}'"
+        )
+    nested_relationships.add(endpoints)
+    if endpoints not in index.nested_edges:
+        raise ValueError(
+            f"nested relationship '{relationship.parent}' -> "
+            f"'{relationship.child}' is inconsistent with product graph"
+        )
+    if not isinstance(parent, GeneratedProductCompilePlan) or not isinstance(
+        child, GeneratedProductCompilePlan
+    ):
+        raise ValueError("nested relationship endpoints must be generated products")
+
+
+def _validate_memstore_relationship_child(
+    relationship: MemstoreRelationshipPlan,
+    child: ProductCompilePlan,
+) -> SourceProductCompilePlan:
+    if not isinstance(child, SourceProductCompilePlan) or not isinstance(
+        child.source, MemstoreSourceBindingPlan
+    ):
+        raise ValueError("memstore relationship child must use a memstore source")
+    if child.source.id != relationship.source_id:
+        raise ValueError("memstore relationship source_id does not match child source")
+    if child.source.product is not None and child.source.product != relationship.parent:
+        raise ValueError("memstore relationship parent does not match child source product")
+    return child
+
+
+def _validate_memstore_relationship(
+    relationship: MemstoreRelationshipPlan,
+    parent: ProductCompilePlan,
+    child: ProductCompilePlan,
+    memstore_relationships: set[tuple[str, str]],
+    memstore_children: set[str],
+) -> None:
+    endpoints = (relationship.parent, relationship.child)
+    if endpoints in memstore_relationships:
+        raise ValueError(
+            f"duplicate memstore relationship '{relationship.parent}' -> "
+            f"'{relationship.child}'"
+        )
+    memstore_relationships.add(endpoints)
+    if relationship.child in memstore_children:
+        raise ValueError(
+            f"source product '{relationship.child}' has multiple memstore relationships"
+        )
+    memstore_children.add(relationship.child)
+    _validate_memstore_relationship_child(relationship, child)
+    if not any(
+        isinstance(target, MemstoreTargetBindingPlan) and target.id == relationship.source_id
+        for target in parent.targets
+    ):
+        raise ValueError("memstore relationship source_id does not match parent target")
+
+
+def _validate_relationships(
+    relationships: list[RelationshipPlan],
+    products: list[ProductCompilePlan],
+    index: _CompilePlanIndex,
+) -> None:
+    nested_relationships: set[tuple[str, str]] = set()
+    memstore_relationships: set[tuple[str, str]] = set()
+    memstore_children: set[str] = set()
+    for relationship in relationships:
+        parent = index.require_product(relationship.parent, "relationship")
+        child = index.require_product(relationship.child, "relationship")
+        if isinstance(relationship, NestedRelationshipPlan):
+            _validate_nested_relationship(
+                relationship, parent, child, nested_relationships, index
+            )
+        else:
+            _validate_memstore_relationship(
+                relationship,
+                parent,
+                child,
+                memstore_relationships,
+                memstore_children,
+            )
+    if nested_relationships != index.nested_edges:
+        raise ValueError("nested product graph and relationship declarations differ")
+    _require_memstore_relationships(products, memstore_children)
+
+
+def _require_memstore_relationships(
+    products: list[ProductCompilePlan],
+    memstore_children: set[str],
+) -> None:
+    for product in products:
+        if not isinstance(product, SourceProductCompilePlan):
+            continue
+        if not isinstance(product.source, MemstoreSourceBindingPlan):
+            continue
+        if product.name not in memstore_children:
+            raise ValueError(
+                f"memstore source product '{product.name}' has no relationship declaration"
+            )
+
+
+def _validate_exact_acceptance(
+    acceptance: ExactCountAcceptancePlan,
+    product: ProductCompilePlan,
+    facts: _AcceptanceFacts,
+) -> None:
+    if acceptance.product in facts.exact:
+        raise ValueError(f"duplicate exact-count acceptance for '{acceptance.product}'")
+    facts.exact.add(acceptance.product)
+    if acceptance.exact_count != product.static_count:
+        raise ValueError("exact-count acceptance does not match product static_count")
+
+
+def _validate_per_parent_acceptance(
+    acceptance: PerParentCountAcceptancePlan,
+    product: ProductCompilePlan,
+    facts: _AcceptanceFacts,
+    index: _CompilePlanIndex,
+) -> None:
+    fact = (acceptance.parent_product, acceptance.product)
+    if fact in facts.per_parent:
+        raise ValueError("duplicate per-parent acceptance")
+    facts.per_parent.add(fact)
+    parent = index.require_product(acceptance.parent_product, "per-parent acceptance")
+    if not isinstance(parent, GeneratedProductCompilePlan) or not isinstance(
+        product, GeneratedProductCompilePlan
+    ):
+        raise ValueError("per-parent acceptance requires generated products")
+    if fact not in index.nested_edges or product.parent != parent.name:
+        raise ValueError("per-parent acceptance does not match nested relationship")
+    if acceptance.count_per_parent != product.count_per_parent:
+        raise ValueError("per-parent acceptance does not match child count_per_parent")
+
+
+def _validate_unique_acceptance(
+    acceptance: UniqueAcceptancePlan,
+    facts: _AcceptanceFacts,
+    index: _CompilePlanIndex,
+) -> None:
+    fact = (acceptance.product, acceptance.field)
+    if fact in facts.unique:
+        raise ValueError("duplicate unique acceptance")
+    facts.unique.add(fact)
+    field = index.require_field(acceptance.product, acceptance.field, "unique acceptance")
+    has_identifier_role = any(isinstance(role, IdentifierRolePlan) for role in field.roles)
+    if field.kind is not FieldIntentKind.INTEGER_RANGE and not has_identifier_role:
+        raise ValueError("unique acceptance requires an integer range or identifier role")
+
+
+def _validate_foreign_key_acceptance(
+    acceptance: ForeignKeyAcceptancePlan,
+    facts: _AcceptanceFacts,
+    index: _CompilePlanIndex,
+) -> None:
+    fact = (
+        acceptance.product,
+        acceptance.child_field,
+        acceptance.parent_product,
+        acceptance.parent_field,
+    )
+    if fact in facts.foreign_key:
+        raise ValueError("duplicate foreign-key acceptance")
+    facts.foreign_key.add(fact)
+    child_field = index.require_field(
+        acceptance.product, acceptance.child_field, "foreign-key acceptance"
+    )
+    index.require_field(
+        acceptance.parent_product, acceptance.parent_field, "foreign-key acceptance"
+    )
+    if not any(
+        isinstance(role, ForeignKeyRolePlan)
+        and role.parent_product == acceptance.parent_product
+        and role.parent_field == acceptance.parent_field
+        for role in child_field.roles
+    ):
+        raise ValueError("foreign-key acceptance does not match child field role")
+
+
+def _validate_allowed_values_acceptance(
+    acceptance: AllowedValuesAcceptancePlan,
+    facts: _AcceptanceFacts,
+    index: _CompilePlanIndex,
+) -> None:
+    fact = (acceptance.product, acceptance.field)
+    if fact in facts.allowed_values:
+        raise ValueError("duplicate allowed-values acceptance")
+    facts.allowed_values.add(fact)
+    field = index.require_field(
+        acceptance.product, acceptance.field, "allowed-values acceptance"
+    )
+    if field.kind not in (FieldIntentKind.VALUES, FieldIntentKind.WEIGHTED):
+        raise ValueError("allowed-values acceptance requires values or weighted field intent")
+
+
+def _validate_range_acceptance(
+    acceptance: RangeAcceptancePlan,
+    facts: _AcceptanceFacts,
+    index: _CompilePlanIndex,
+) -> None:
+    fact = (acceptance.product, acceptance.field)
+    if fact in facts.ranges:
+        raise ValueError("duplicate range acceptance")
+    facts.ranges.add(fact)
+    field = index.require_field(acceptance.product, acceptance.field, "range acceptance")
+    if field.kind not in (FieldIntentKind.INTEGER_RANGE, FieldIntentKind.DECIMAL_RANGE):
+        raise ValueError("range acceptance requires a numeric range field intent")
+
+
+def _validate_acceptance(
+    acceptances: list[DerivedAcceptancePlan],
+    index: _CompilePlanIndex,
+) -> None:
+    facts = _AcceptanceFacts()
+    for acceptance in acceptances:
+        product = index.require_product(acceptance.product, "derived acceptance")
+        if isinstance(acceptance, ExactCountAcceptancePlan):
+            _validate_exact_acceptance(acceptance, product, facts)
+        elif isinstance(acceptance, PerParentCountAcceptancePlan):
+            _validate_per_parent_acceptance(acceptance, product, facts, index)
+        elif isinstance(acceptance, UniqueAcceptancePlan):
+            _validate_unique_acceptance(acceptance, facts, index)
+        elif isinstance(acceptance, ForeignKeyAcceptancePlan):
+            _validate_foreign_key_acceptance(acceptance, facts, index)
+        elif isinstance(acceptance, AllowedValuesAcceptancePlan):
+            _validate_allowed_values_acceptance(acceptance, facts, index)
+        else:
+            _validate_range_acceptance(acceptance, facts, index)
+
+
+def _validate_unresolved_facts(
+    unresolved_facts: list[UnresolvedCompileFact],
+    index: _CompilePlanIndex,
+) -> None:
+    seen: set[tuple[str, str]] = set()
+    for unresolved in unresolved_facts:
+        index.require_product(unresolved.product, "unresolved fact")
+        fact = (unresolved.product, unresolved.aspect)
+        if fact in seen:
+            raise ValueError(
+                f"duplicate unresolved fact '{unresolved.aspect}' for '{unresolved.product}'"
+            )
+        seen.add(fact)
+
+
 class CompilePlan(CompilePlanModel):
     """Complete compiler-owned handoff for execution and acceptance stages."""
 
@@ -650,277 +1075,11 @@ class CompilePlan(CompilePlanModel):
 
     @model_validator(mode="after")
     def _validate_graph_integrity(self) -> "CompilePlan":
-        products_by_name: dict[str, ProductCompilePlan] = {}
-        fields_by_product: dict[str, dict[str, FieldPlan]] = {}
-        for product in self.products:
-            if product.name in products_by_name:
-                raise ValueError(f"duplicate product name '{product.name}'")
-            products_by_name[product.name] = product
-            fields: dict[str, FieldPlan] = {}
-            for field in product.fields:
-                if field.name in fields:
-                    raise ValueError(
-                        f"duplicate field name '{field.name}' in product '{product.name}'"
-                    )
-                fields[field.name] = field
-            fields_by_product[product.name] = fields
-
-        def require_product(name: str, context: str) -> ProductCompilePlan:
-            product = products_by_name.get(name)
-            if product is None:
-                raise ValueError(f"{context} references unknown product '{name}'")
-            return product
-
-        def require_field(product_name: str, field_name: str, context: str) -> FieldPlan:
-            require_product(product_name, context)
-            field = fields_by_product[product_name].get(field_name)
-            if field is None:
-                raise ValueError(
-                    f"{context} references unknown field '{field_name}' "
-                    f"on product '{product_name}'"
-                )
-            return field
-
-        product_nested_edges: set[tuple[str, str]] = set()
-        generated_products: dict[str, GeneratedProductCompilePlan] = {}
-        for product in self.products:
-            if not isinstance(product, GeneratedProductCompilePlan):
-                continue
-            generated_products[product.name] = product
-            if product.parent is not None:
-                parent = require_product(product.parent, f"generated product '{product.name}'")
-                if not isinstance(parent, GeneratedProductCompilePlan):
-                    raise ValueError(
-                        f"generated parent '{product.parent}' must be a generated product"
-                    )
-                if product.name not in parent.children:
-                    raise ValueError(
-                        f"generated child '{product.name}' is not declared by parent "
-                        f"'{parent.name}'"
-                    )
-            for child_name in product.children:
-                child = require_product(child_name, f"generated product '{product.name}'")
-                if not isinstance(child, GeneratedProductCompilePlan):
-                    raise ValueError(f"generated child '{child_name}' must be a generated product")
-                if child.parent != product.name:
-                    raise ValueError(
-                        f"generated child '{child_name}' does not reference parent "
-                        f"'{product.name}'"
-                    )
-                product_nested_edges.add((product.name, child_name))
-
-        visiting: set[str] = set()
-        visited: set[str] = set()
-
-        def visit_generated(product_name: str) -> None:
-            if product_name in visiting:
-                raise ValueError(f"generated product graph contains a cycle at '{product_name}'")
-            if product_name in visited:
-                return
-            visiting.add(product_name)
-            product = generated_products[product_name]
-            for child_name in product.children:
-                visit_generated(child_name)
-            visiting.remove(product_name)
-            visited.add(product_name)
-
-        for product_name in generated_products:
-            visit_generated(product_name)
-
-        for product in self.products:
-            if (
-                isinstance(product, SourceProductCompilePlan)
-                and isinstance(product.source, MemstoreSourceBindingPlan)
-                and product.source.product is not None
-            ):
-                require_product(
-                    product.source.product,
-                    f"memstore source product '{product.name}'",
-                )
-
-        nested_relationships: set[tuple[str, str]] = set()
-        memstore_relationships: set[tuple[str, str]] = set()
-        memstore_children: set[str] = set()
-        for relationship in self.relationships:
-            parent = require_product(relationship.parent, "relationship")
-            child = require_product(relationship.child, "relationship")
-            endpoints = (relationship.parent, relationship.child)
-            if isinstance(relationship, NestedRelationshipPlan):
-                if endpoints in nested_relationships:
-                    raise ValueError(
-                        f"duplicate nested relationship '{relationship.parent}' -> "
-                        f"'{relationship.child}'"
-                    )
-                nested_relationships.add(endpoints)
-                if endpoints not in product_nested_edges:
-                    raise ValueError(
-                        f"nested relationship '{relationship.parent}' -> "
-                        f"'{relationship.child}' is inconsistent with product graph"
-                    )
-                if not isinstance(parent, GeneratedProductCompilePlan) or not isinstance(
-                    child, GeneratedProductCompilePlan
-                ):
-                    raise ValueError("nested relationship endpoints must be generated products")
-                continue
-
-            if endpoints in memstore_relationships:
-                raise ValueError(
-                    f"duplicate memstore relationship '{relationship.parent}' -> "
-                    f"'{relationship.child}'"
-                )
-            memstore_relationships.add(endpoints)
-            if relationship.child in memstore_children:
-                raise ValueError(
-                    f"source product '{relationship.child}' has multiple memstore relationships"
-                )
-            memstore_children.add(relationship.child)
-            if not isinstance(child, SourceProductCompilePlan) or not isinstance(
-                child.source, MemstoreSourceBindingPlan
-            ):
-                raise ValueError("memstore relationship child must use a memstore source")
-            if child.source.id != relationship.source_id:
-                raise ValueError("memstore relationship source_id does not match child source")
-            if child.source.product is not None and child.source.product != relationship.parent:
-                raise ValueError("memstore relationship parent does not match child source product")
-            if not any(
-                isinstance(target, MemstoreTargetBindingPlan)
-                and target.id == relationship.source_id
-                for target in parent.targets
-            ):
-                raise ValueError("memstore relationship source_id does not match parent target")
-
-        if nested_relationships != product_nested_edges:
-            raise ValueError("nested product graph and relationship declarations differ")
-        for product in self.products:
-            if (
-                isinstance(product, SourceProductCompilePlan)
-                and isinstance(product.source, MemstoreSourceBindingPlan)
-                and product.name not in memstore_children
-            ):
-                raise ValueError(
-                    f"memstore source product '{product.name}' has no relationship declaration"
-                )
-
-        exact_facts: set[str] = set()
-        per_parent_facts: set[tuple[str, str]] = set()
-        unique_facts: set[tuple[str, str]] = set()
-        foreign_key_facts: set[tuple[str, str, str, str]] = set()
-        allowed_values_facts: set[tuple[str, str]] = set()
-        range_facts: set[tuple[str, str]] = set()
-        for acceptance in self.derived_acceptance:
-            product = require_product(acceptance.product, "derived acceptance")
-            if isinstance(acceptance, ExactCountAcceptancePlan):
-                if acceptance.product in exact_facts:
-                    raise ValueError(
-                        f"duplicate exact-count acceptance for '{acceptance.product}'"
-                    )
-                exact_facts.add(acceptance.product)
-                if acceptance.exact_count != product.static_count:
-                    raise ValueError("exact-count acceptance does not match product static_count")
-            elif isinstance(acceptance, PerParentCountAcceptancePlan):
-                per_parent_fact = (acceptance.parent_product, acceptance.product)
-                if per_parent_fact in per_parent_facts:
-                    raise ValueError("duplicate per-parent acceptance")
-                per_parent_facts.add(per_parent_fact)
-                parent = require_product(
-                    acceptance.parent_product,
-                    "per-parent acceptance",
-                )
-                if not isinstance(parent, GeneratedProductCompilePlan) or not isinstance(
-                    product, GeneratedProductCompilePlan
-                ):
-                    raise ValueError("per-parent acceptance requires generated products")
-                if (
-                    per_parent_fact not in product_nested_edges
-                    or product.parent != parent.name
-                ):
-                    raise ValueError("per-parent acceptance does not match nested relationship")
-                if acceptance.count_per_parent != product.count_per_parent:
-                    raise ValueError("per-parent acceptance does not match child count_per_parent")
-            elif isinstance(acceptance, UniqueAcceptancePlan):
-                unique_fact = (acceptance.product, acceptance.field)
-                if unique_fact in unique_facts:
-                    raise ValueError("duplicate unique acceptance")
-                unique_facts.add(unique_fact)
-                field = require_field(
-                    acceptance.product,
-                    acceptance.field,
-                    "unique acceptance",
-                )
-                has_identifier_role = any(
-                    isinstance(role, IdentifierRolePlan) for role in field.roles
-                )
-                if field.kind is not FieldIntentKind.INTEGER_RANGE and not has_identifier_role:
-                    raise ValueError(
-                        "unique acceptance requires an integer range or identifier role"
-                    )
-            elif isinstance(acceptance, ForeignKeyAcceptancePlan):
-                foreign_key_fact = (
-                    acceptance.product,
-                    acceptance.child_field,
-                    acceptance.parent_product,
-                    acceptance.parent_field,
-                )
-                if foreign_key_fact in foreign_key_facts:
-                    raise ValueError("duplicate foreign-key acceptance")
-                foreign_key_facts.add(foreign_key_fact)
-                child_field = require_field(
-                    acceptance.product,
-                    acceptance.child_field,
-                    "foreign-key acceptance",
-                )
-                require_field(
-                    acceptance.parent_product,
-                    acceptance.parent_field,
-                    "foreign-key acceptance",
-                )
-                if not any(
-                    isinstance(role, ForeignKeyRolePlan)
-                    and role.parent_product == acceptance.parent_product
-                    and role.parent_field == acceptance.parent_field
-                    for role in child_field.roles
-                ):
-                    raise ValueError("foreign-key acceptance does not match child field role")
-            elif isinstance(acceptance, AllowedValuesAcceptancePlan):
-                allowed_values_fact = (acceptance.product, acceptance.field)
-                if allowed_values_fact in allowed_values_facts:
-                    raise ValueError("duplicate allowed-values acceptance")
-                allowed_values_facts.add(allowed_values_fact)
-                field = require_field(
-                    acceptance.product,
-                    acceptance.field,
-                    "allowed-values acceptance",
-                )
-                if field.kind not in (FieldIntentKind.VALUES, FieldIntentKind.WEIGHTED):
-                    raise ValueError(
-                        "allowed-values acceptance requires values or weighted field intent"
-                    )
-            elif isinstance(acceptance, RangeAcceptancePlan):
-                range_fact = (acceptance.product, acceptance.field)
-                if range_fact in range_facts:
-                    raise ValueError("duplicate range acceptance")
-                range_facts.add(range_fact)
-                field = require_field(
-                    acceptance.product,
-                    acceptance.field,
-                    "range acceptance",
-                )
-                if field.kind not in (
-                    FieldIntentKind.INTEGER_RANGE,
-                    FieldIntentKind.DECIMAL_RANGE,
-                ):
-                    raise ValueError("range acceptance requires a numeric range field intent")
-
-        unresolved_facts: set[tuple[str, str]] = set()
-        for unresolved in self.unresolved:
-            require_product(unresolved.product, "unresolved fact")
-            unresolved_fact = (unresolved.product, unresolved.aspect)
-            if unresolved_fact in unresolved_facts:
-                raise ValueError(
-                    f"duplicate unresolved fact '{unresolved.aspect}' for "
-                    f"'{unresolved.product}'"
-                )
-            unresolved_facts.add(unresolved_fact)
+        index = _compile_plan_index(self.products)
+        _validate_memstore_source_products(self.products, index)
+        _validate_relationships(self.relationships, self.products, index)
+        _validate_acceptance(self.derived_acceptance, index)
+        _validate_unresolved_facts(self.unresolved, index)
         return self
 
 

--- a/datamimic_ce/authoring/dryrun.py
+++ b/datamimic_ce/authoring/dryrun.py
@@ -569,14 +569,13 @@ def neutralize_for_dry_run(
 
             if product_budgets is not None:
                 name = _capture_name(stmt.full_name)
+                requested_per_parent: int | None = requested
+                if requested_per_parent is None and range_bound is None:
+                    requested_per_parent = source_rows
                 product_budgets[name] = _ProductBudget(
                     name=name,
                     parent_name=_parent_capture_name(stmt),
-                    requested_per_parent=(
-                        requested
-                        if requested is not None
-                        else source_rows if range_bound is None else None
-                    ),
+                    requested_per_parent=requested_per_parent,
                     explicit_count=requested is not None,
                     count_kind=count_kind,
                     source_rows_per_parent=source_rows,
@@ -1098,53 +1097,68 @@ def _memstore_capture_evidence(
             "cyclic memstore reads do not provide finite exhaustion evidence",
         )
     if budget.count_kind is _CountBoundaryKind.SOURCE:
-        if available > base.limit:
-            if base.observed == base.limit:
-                return ProductCaptureEvidence(
-                    status=CaptureStatus.CAPPED,
-                    requested=available,
-                    observed=base.observed,
-                    limit=base.limit,
-                    reason=(
-                        f"finite memstore source has {available} available rows, "
-                        f"above capture limit {base.limit}"
-                    ),
-                )
-            return _unknown_from(base, "memstore source did not reach its proven finite window")
-        if base.observed == available:
+        return _source_memstore_capture_evidence(base, available)
+    if budget.count_kind is _CountBoundaryKind.STATIC and base.requested is not None:
+        return _static_memstore_capture_evidence(base, available)
+    return base
+
+
+def _source_memstore_capture_evidence(
+    base: ProductCaptureEvidence,
+    available: int,
+) -> ProductCaptureEvidence:
+    if available > base.limit:
+        if base.observed == base.limit:
             return ProductCaptureEvidence(
-                status=CaptureStatus.EXHAUSTED,
+                status=CaptureStatus.CAPPED,
                 requested=available,
                 observed=base.observed,
                 limit=base.limit,
                 reason=(
-                    f"uniquely resolved memstore producer was fully read: "
-                    f"{available} finite rows"
+                    f"finite memstore source has {available} available rows, "
+                    f"above capture limit {base.limit}"
                 ),
             )
-        return _unknown_from(base, "memstore source did not exhaust its proven finite window")
-    if budget.count_kind is _CountBoundaryKind.STATIC and base.requested is not None:
-        effective_requested = min(base.requested, available)
-        if base.observed == effective_requested:
-            if base.requested >= available:
-                return ProductCaptureEvidence(
-                    status=CaptureStatus.EXHAUSTED,
-                    requested=base.requested,
-                    observed=base.observed,
-                    limit=base.limit,
-                    reason=(
-                        f"static request reached all {available} rows of the uniquely "
-                        "resolved memstore producer"
-                    ),
-                )
-            if base.requested <= base.limit:
-                return ProductCaptureEvidence(
-                    status=CaptureStatus.COMPLETE,
-                    requested=base.requested,
-                    observed=base.observed,
-                    limit=base.limit,
-                    reason="static memstore read completed within the finite source window",
-                )
+        return _unknown_from(base, "memstore source did not reach its proven finite window")
+    if base.observed == available:
+        return ProductCaptureEvidence(
+            status=CaptureStatus.EXHAUSTED,
+            requested=available,
+            observed=base.observed,
+            limit=base.limit,
+            reason=(
+                f"uniquely resolved memstore producer was fully read: "
+                f"{available} finite rows"
+            ),
+        )
+    return _unknown_from(base, "memstore source did not exhaust its proven finite window")
+
+
+def _static_memstore_capture_evidence(
+    base: ProductCaptureEvidence,
+    available: int,
+) -> ProductCaptureEvidence:
+    if base.requested is None or base.observed != min(base.requested, available):
+        return base
+    if base.requested >= available:
+        return ProductCaptureEvidence(
+            status=CaptureStatus.EXHAUSTED,
+            requested=base.requested,
+            observed=base.observed,
+            limit=base.limit,
+            reason=(
+                f"static request reached all {available} rows of the uniquely "
+                "resolved memstore producer"
+            ),
+        )
+    if base.requested <= base.limit:
+        return ProductCaptureEvidence(
+            status=CaptureStatus.COMPLETE,
+            requested=base.requested,
+            observed=base.observed,
+            limit=base.limit,
+            reason="static memstore read completed within the finite source window",
+        )
     return base
 
 
@@ -1156,83 +1170,118 @@ def _capture_evidence_by_product(
 ) -> dict[str, ProductCaptureEvidence]:
     """Resolve ancestry and memstore provenance recursively, independent of name order."""
 
-    observed_by_name = {name: len(rows) for name, rows in captured.items()}
-    resolved: dict[str, ProductCaptureEvidence] = {}
-    visiting: set[str] = set()
+    return _CaptureEvidenceResolver(budgets, captured, max_count).resolve_all()
 
-    def _resolve(name: str) -> ProductCaptureEvidence:
-        existing = resolved.get(name)
+
+class _CaptureEvidenceResolver:
+    """Resolve capture completeness from typed ancestry and memstore facts."""
+
+    def __init__(
+        self,
+        budgets: _ProductBudgets,
+        captured: dict[str, tuple[object, ...]],
+        max_count: int,
+    ) -> None:
+        self._budgets = budgets
+        self._observed = {name: len(rows) for name, rows in captured.items()}
+        self._product_names = tuple(captured)
+        self._max_count = max_count
+        self._resolved: dict[str, ProductCaptureEvidence] = {}
+        self._visiting: set[str] = set()
+
+    def resolve_all(self) -> dict[str, ProductCaptureEvidence]:
+        for product_name in self._product_names:
+            self._resolve(product_name)
+        return self._resolved
+
+    def _resolve(self, name: str) -> ProductCaptureEvidence:
+        existing = self._resolved.get(name)
         if existing is not None:
             return existing
-        budget = budgets.get(name)
-        observed = observed_by_name.get(name, 0)
+        budget = self._budgets.get(name)
         base = _capture_evidence(
             budget,
-            observed=observed,
-            max_count=max_count,
-            observed_by_name=observed_by_name,
+            observed=self._observed.get(name, 0),
+            max_count=self._max_count,
+            observed_by_name=self._observed,
         )
-        if name in visiting:
-            return _unknown_from(base, "capture dependency cycle prevents a completeness proof")
-        visiting.add(name)
-        evidence = base
-        dependency_blocked = False
-        if budget is not None and budget.parent_name is not None:
-            if budget.parent_name not in observed_by_name:
-                evidence = _unknown_from(base, "parent product is missing from runtime capture")
-                dependency_blocked = True
-            else:
-                parent_evidence = _resolve(budget.parent_name)
-                if not parent_evidence.complete:
-                    evidence = _unknown_from(
-                        base,
-                        "parent product capture is not proven complete",
-                    )
-                    dependency_blocked = True
-        binding = budget.memstore_source if budget is not None else None
-        if budget is not None and binding is not None and not dependency_blocked:
-            if binding.status is _MemstoreBindingStatus.MISSING:
-                evidence = _unknown_from(
-                    base,
-                    (
-                        f"memstore '{binding.source_id}' entity '{binding.entity}' "
-                        "has no captured producer"
-                    ),
-                )
-            elif binding.status is _MemstoreBindingStatus.AMBIGUOUS:
-                evidence = _unknown_from(
-                    base,
-                    (
-                        f"memstore '{binding.source_id}' entity '{binding.entity}' "
-                        "has multiple possible producers"
-                    ),
-                )
-            else:
-                producer = next(iter(binding.producers), None)
-                if producer is None or producer.product not in observed_by_name:
-                    evidence = _unknown_from(
-                        base,
-                        "resolved memstore producer is missing from runtime capture",
-                    )
-                else:
-                    evidence = _memstore_capture_evidence(
-                        budget,
-                        base,
-                        producer_evidence=_resolve(producer.product),
-                        producer_observed=observed_by_name[producer.product],
-                        parent_observed=(
-                            observed_by_name.get(budget.parent_name, 0)
-                            if budget.parent_name is not None
-                            else 1
-                        ),
-                    )
-        visiting.remove(name)
-        resolved[name] = evidence
+        if name in self._visiting:
+            return _unknown_from(
+                base,
+                "capture dependency cycle prevents a completeness proof",
+            )
+        self._visiting.add(name)
+        evidence, dependency_blocked = self._parent_evidence(budget, base)
+        if budget is not None and budget.memstore_source is not None and not dependency_blocked:
+            evidence = self._memstore_evidence(budget, base)
+        self._visiting.remove(name)
+        self._resolved[name] = evidence
         return evidence
 
-    for product_name in captured:
-        _resolve(product_name)
-    return resolved
+    def _parent_evidence(
+        self,
+        budget: _ProductBudget | None,
+        base: ProductCaptureEvidence,
+    ) -> tuple[ProductCaptureEvidence, bool]:
+        if budget is None or budget.parent_name is None:
+            return base, False
+        if budget.parent_name not in self._observed:
+            return _unknown_from(base, "parent product is missing from runtime capture"), True
+        parent_evidence = self._resolve(budget.parent_name)
+        if not parent_evidence.complete:
+            return _unknown_from(base, "parent product capture is not proven complete"), True
+        return base, False
+
+    def _memstore_evidence(
+        self,
+        budget: _ProductBudget,
+        base: ProductCaptureEvidence,
+    ) -> ProductCaptureEvidence:
+        binding = budget.memstore_source
+        if binding is None:
+            return base
+        if binding.status is _MemstoreBindingStatus.MISSING:
+            return _unknown_from(
+                base,
+                (
+                    f"memstore '{binding.source_id}' entity '{binding.entity}' "
+                    "has no captured producer"
+                ),
+            )
+        if binding.status is _MemstoreBindingStatus.AMBIGUOUS:
+            return _unknown_from(
+                base,
+                (
+                    f"memstore '{binding.source_id}' entity '{binding.entity}' "
+                    "has multiple possible producers"
+                ),
+            )
+        return self._resolved_memstore_evidence(budget, binding, base)
+
+    def _resolved_memstore_evidence(
+        self,
+        budget: _ProductBudget,
+        binding: _MemstoreSourceBinding,
+        base: ProductCaptureEvidence,
+    ) -> ProductCaptureEvidence:
+        producer = next(iter(binding.producers), None)
+        if producer is None or producer.product not in self._observed:
+            return _unknown_from(
+                base,
+                "resolved memstore producer is missing from runtime capture",
+            )
+        return _memstore_capture_evidence(
+            budget,
+            base,
+            producer_evidence=self._resolve(producer.product),
+            producer_observed=self._observed[producer.product],
+            parent_observed=self._parent_observed(budget),
+        )
+
+    def _parent_observed(self, budget: _ProductBudget) -> int:
+        if budget.parent_name is None:
+            return 1
+        return self._observed.get(budget.parent_name, 0)
 
 
 def _execute_captured(

--- a/datamimic_ce/authoring/intent_validation.py
+++ b/datamimic_ce/authoring/intent_validation.py
@@ -12,6 +12,7 @@ from enum import StrEnum
 from typing import Any
 
 from pydantic import JsonValue, TypeAdapter, ValidationError
+from pydantic_core import ErrorDetails
 
 from datamimic_ce.authoring.contracts import (
     IntentValidationIssue,
@@ -113,29 +114,31 @@ def _validation_location(
             owner_schema = resolved
             raw_owner = current if isinstance(current, Mapping) else None
             break
-        if isinstance(part, int):
-            items = resolved.get("items")
-            schema = items if isinstance(items, Mapping) else {}
-            if (
-                isinstance(current, Sequence)
-                and not isinstance(current, str)
-                and 0 <= part < len(current)
-            ):
-                current = current[part]
-            continue
-        properties = resolved.get("properties")
-        if isinstance(properties, Mapping):
-            property_schema = properties.get(part)
-            schema = property_schema if isinstance(property_schema, Mapping) else {}
-        else:
-            schema = {}
-        if isinstance(current, Mapping) and part in current:
-            current = current[part]
+        schema, current = _descend_location(resolved, current, part)
     return _ValidationLocation(
         path=tuple(public),
         owner_schema=owner_schema,
         raw_owner=raw_owner,
     )
+
+
+def _descend_location(
+    schema: Mapping[str, Any],
+    raw: object,
+    part: str | int,
+) -> tuple[Mapping[str, Any], object]:
+    if isinstance(part, int):
+        items = schema.get("items")
+        next_schema = items if isinstance(items, Mapping) else {}
+        if isinstance(raw, Sequence) and not isinstance(raw, str) and 0 <= part < len(raw):
+            return next_schema, raw[part]
+        return next_schema, raw
+    properties = schema.get("properties")
+    property_schema = properties.get(part) if isinstance(properties, Mapping) else None
+    next_schema = property_schema if isinstance(property_schema, Mapping) else {}
+    if isinstance(raw, Mapping) and part in raw:
+        return next_schema, raw[part]
+    return next_schema, raw
 
 
 def normalize_validation_path(
@@ -174,48 +177,67 @@ def _replace_field(
         return None
     rejected = path[-1]
     document = deepcopy(dict(raw))
-    current: object = document
-    for part in path[:-1]:
-        if isinstance(part, str):
-            if not isinstance(current, dict) or part not in current:
-                return None
-            current = current[part]
-            continue
-        if not isinstance(current, list) or not 0 <= part < len(current):
-            return None
-        current = current[part]
+    current = _replacement_owner(document, path[:-1])
     if (
-        not isinstance(current, dict)
+        current is None
         or rejected not in current
         or replacement in current
     ):
         return None
     raw_rejected_value = current.pop(rejected)
-    try:
-        rejected_value = _JSON_OBJECT_ADAPTER.validate_python(
-            {"value": raw_rejected_value}
-        )["value"]
-    except ValidationError:
+    valid_json, rejected_value = _validated_json_value(raw_rejected_value)
+    if not valid_json:
         return None
     current[replacement] = rejected_value
-    try:
-        AuthoringSpecV1.model_validate(document)
-    except ValidationError as error:
-        owner_prefix = path[:-1]
-        corrected_locations = (
-            _validation_location(tuple(issue["loc"]), document).path
-            for issue in error.errors()
-        )
-        if any(
-            location[: len(owner_prefix)] == owner_prefix
-            for location in corrected_locations
-        ):
-            return None
+    if _owner_has_validation_errors(document, path[:-1]):
+        return None
     try:
         corrected_fragment = _JSON_OBJECT_ADAPTER.validate_python(current)
     except ValidationError:
         return None
     return corrected_fragment, rejected_value
+
+
+def _replacement_owner(
+    document: dict[str, Any],
+    owner_path: tuple[str | int, ...],
+) -> dict[str, Any] | None:
+    current: object = document
+    for part in owner_path:
+        if isinstance(part, str):
+            if not isinstance(current, dict) or part not in current:
+                return None
+            current = current[part]
+        else:
+            if not isinstance(current, list) or not 0 <= part < len(current):
+                return None
+            current = current[part]
+    return current if isinstance(current, dict) else None
+
+
+def _validated_json_value(raw: object) -> tuple[bool, JsonValue]:
+    try:
+        return True, _JSON_OBJECT_ADAPTER.validate_python({"value": raw})["value"]
+    except ValidationError:
+        return False, None
+
+
+def _owner_has_validation_errors(
+    document: dict[str, Any],
+    owner_prefix: tuple[str | int, ...],
+) -> bool:
+    try:
+        AuthoringSpecV1.model_validate(document)
+    except ValidationError as error:
+        corrected_locations = (
+            _validation_location(tuple(issue["loc"]), document).path
+            for issue in error.errors()
+        )
+        return any(
+            location[: len(owner_prefix)] == owner_prefix
+            for location in corrected_locations
+        )
+    return False
 
 
 def _replacement_repair(
@@ -244,56 +266,11 @@ def _replacement_repair(
     properties = location.owner_schema.get("properties")
     if not isinstance(properties, Mapping):
         return None
-    candidates = [
-        field
-        for field in allowed_fields
-        if field != rejected and field not in location.raw_owner
-    ]
-    ranked = sorted(
-        (
-            (
-                SequenceMatcher(
-                    None,
-                    rejected,
-                    candidate,
-                    autojunk=False,
-                ).ratio(),
-                candidate,
-            )
-            for candidate in candidates
-        ),
-        key=lambda item: (-item[0], item[1]),
-    )
-    alias_candidates: list[str] = []
-    for candidate in candidates:
-        property_schema = properties.get(candidate)
-        if not isinstance(property_schema, Mapping):
-            continue
-        aliases = property_schema.get(INTENT_REPAIR_ALIASES_SCHEMA_KEY)
-        if (
-            isinstance(aliases, Sequence)
-            and not isinstance(aliases, str)
-            and rejected in aliases
-        ):
-            alias_candidates.append(candidate)
-
-    selected: list[str]
-    if alias_candidates:
-        selected = sorted(alias_candidates)
-    elif not ranked or ranked[0][0] < _MIN_REPLACEMENT_SIMILARITY or (
-        len(ranked) > 1
-        and ranked[1][0] >= _MIN_REPLACEMENT_SIMILARITY
-        and ranked[0][0] - ranked[1][0] < _MIN_REPLACEMENT_MARGIN
-    ):
+    candidates = _replacement_candidates(rejected, allowed_fields, location.raw_owner)
+    selected = _selected_replacements(rejected, candidates, properties)
+    if not selected:
         return None
-    else:
-        selected = [ranked[0][1]]
-
-    validated = [
-        (replacement, corrected)
-        for replacement in selected
-        if (corrected := _replace_field(raw, location.path, replacement)) is not None
-    ]
+    validated = _validated_replacements(raw, location.path, selected)
     if len(validated) != 1:
         return None
     replacement, (corrected_fragment, rejected_value) = validated[0]
@@ -305,6 +282,88 @@ def _replacement_repair(
         )
     except ValidationError:
         return None
+
+
+def _replacement_candidates(
+    rejected: str,
+    allowed_fields: tuple[str, ...],
+    raw_owner: Mapping[str, Any],
+) -> list[str]:
+    return [
+        field
+        for field in allowed_fields
+        if field != rejected and field not in raw_owner
+    ]
+
+
+def _alias_replacements(
+    rejected: str,
+    candidates: list[str],
+    properties: Mapping[str, Any],
+) -> list[str]:
+    aliases: list[str] = []
+    for candidate in candidates:
+        property_schema = properties.get(candidate)
+        if not isinstance(property_schema, Mapping):
+            continue
+        declared_aliases = property_schema.get(INTENT_REPAIR_ALIASES_SCHEMA_KEY)
+        if (
+            isinstance(declared_aliases, Sequence)
+            and not isinstance(declared_aliases, str)
+            and rejected in declared_aliases
+        ):
+            aliases.append(candidate)
+    return sorted(aliases)
+
+
+def _ranked_replacements(rejected: str, candidates: list[str]) -> list[tuple[float, str]]:
+    return sorted(
+        (
+            (
+                SequenceMatcher(None, rejected, candidate, autojunk=False).ratio(),
+                candidate,
+            )
+            for candidate in candidates
+        ),
+        key=lambda item: (-item[0], item[1]),
+    )
+
+
+def _unambiguous_similar_replacement(ranked: list[tuple[float, str]]) -> str | None:
+    if not ranked or ranked[0][0] < _MIN_REPLACEMENT_SIMILARITY:
+        return None
+    if (
+        len(ranked) > 1
+        and ranked[1][0] >= _MIN_REPLACEMENT_SIMILARITY
+        and ranked[0][0] - ranked[1][0] < _MIN_REPLACEMENT_MARGIN
+    ):
+        return None
+    return ranked[0][1]
+
+
+def _selected_replacements(
+    rejected: str,
+    candidates: list[str],
+    properties: Mapping[str, Any],
+) -> list[str]:
+    aliases = _alias_replacements(rejected, candidates, properties)
+    if aliases:
+        return aliases
+    similar = _unambiguous_similar_replacement(_ranked_replacements(rejected, candidates))
+    return [] if similar is None else [similar]
+
+
+def _validated_replacements(
+    raw: Mapping[str, Any],
+    path: tuple[str | int, ...],
+    replacements: list[str],
+) -> list[tuple[str, tuple[dict[str, JsonValue], JsonValue]]]:
+    validated: list[tuple[str, tuple[dict[str, JsonValue], JsonValue]]] = []
+    for replacement in replacements:
+        corrected = _replace_field(raw, path, replacement)
+        if corrected is not None:
+            validated.append((replacement, corrected))
+    return validated
 
 
 def _repair_context(
@@ -347,12 +406,28 @@ def project_validation_issues(
     error: ValidationError,
     raw: Mapping[str, Any],
 ) -> tuple[IntentValidationIssue, ...]:
-    source = error.errors()
-    public = [
+    public = _public_validation_issues(error.errors(), raw)
+    filtered = _leaf_validation_issues(public)
+    return tuple(
+        _project_validation_issue(location, issue, raw)
+        for location, issue in filtered
+    )
+
+
+def _public_validation_issues(
+    source: list[ErrorDetails],
+    raw: Mapping[str, Any],
+) -> list[tuple[_ValidationLocation, ErrorDetails]]:
+    return [
         (_validation_location(tuple(issue["loc"]), raw), issue)
         for issue in source
     ]
-    filtered = [
+
+
+def _leaf_validation_issues(
+    public: list[tuple[_ValidationLocation, ErrorDetails]],
+) -> list[tuple[_ValidationLocation, ErrorDetails]]:
+    return [
         (location, issue)
         for location, issue in public
         if not any(
@@ -361,47 +436,52 @@ def project_validation_issues(
             for other_location, _ in public
         )
     ]
-    result: list[IntentValidationIssue] = []
-    for location, issue in filtered:
-        path = location.path
-        raw_issue_type = issue["type"]
-        if not isinstance(raw_issue_type, str):
-            issue_type = None
-            intent_issue_type = None
-        else:
-            try:
-                intent_issue_type = IntentModelValidationIssueType(raw_issue_type)
-            except ValueError:
-                intent_issue_type = None
-            try:
-                issue_type = _PydanticIssueType(raw_issue_type)
-            except ValueError:
-                issue_type = None
-        code = _issue_code(issue_type, intent_issue_type)
-        allowed_fields: tuple[str, ...] = ()
-        expected_fragment: dict[str, Any] | None = None
-        model_name: str | None = None
-        repair: ReplaceFieldRepair | None = None
-        if code is IntentValidationIssueCode.UNKNOWN_FIELD:
-            allowed_fields, expected_fragment, model_name, repair = _repair_context(
-                raw,
-                location,
-            )
-        message = str(issue["msg"])
-        if code is IntentValidationIssueCode.UNKNOWN_FIELD and path:
-            owner = f" for {model_name}" if model_name is not None else ""
-            message = f"Unknown field '{path[-1]}'{owner}"
-        result.append(
-            IntentValidationIssue(
-                path=path,
-                code=code,
-                message=message,
-                allowed_fields=allowed_fields,
-                expected_fragment=expected_fragment,
-                repair=repair,
-            )
-        )
-    return tuple(result)
+
+
+def _parsed_issue_types(
+    raw_issue_type: str,
+) -> tuple[_PydanticIssueType | None, IntentModelValidationIssueType | None]:
+    try:
+        intent_issue_type = IntentModelValidationIssueType(raw_issue_type)
+    except ValueError:
+        intent_issue_type = None
+    try:
+        issue_type = _PydanticIssueType(raw_issue_type)
+    except ValueError:
+        issue_type = None
+    return issue_type, intent_issue_type
+
+
+def _unknown_field_message(path: tuple[str | int, ...], model_name: str | None) -> str:
+    owner = f" for {model_name}" if model_name is not None else ""
+    return f"Unknown field '{path[-1]}'{owner}"
+
+
+def _project_validation_issue(
+    location: _ValidationLocation,
+    issue: ErrorDetails,
+    raw: Mapping[str, Any],
+) -> IntentValidationIssue:
+    raw_issue_type = issue["type"]
+    issue_type, intent_issue_type = _parsed_issue_types(raw_issue_type)
+    code = _issue_code(issue_type, intent_issue_type)
+    allowed_fields: tuple[str, ...] = ()
+    expected_fragment: dict[str, JsonValue] | None = None
+    model_name: str | None = None
+    repair: ReplaceFieldRepair | None = None
+    if code is IntentValidationIssueCode.UNKNOWN_FIELD:
+        allowed_fields, expected_fragment, model_name, repair = _repair_context(raw, location)
+    message = str(issue["msg"])
+    if code is IntentValidationIssueCode.UNKNOWN_FIELD and location.path:
+        message = _unknown_field_message(location.path, model_name)
+    return IntentValidationIssue(
+        path=location.path,
+        code=code,
+        message=message,
+        allowed_fields=allowed_fields,
+        expected_fragment=expected_fragment,
+        repair=repair,
+    )
 
 
 def unsupported_intent_issues(errors: list[str]) -> tuple[IntentValidationIssue, ...]:

--- a/datamimic_ce/authoring/normalization.py
+++ b/datamimic_ce/authoring/normalization.py
@@ -188,20 +188,59 @@ def _normalize_field(
     notes: list[str],
     errors: list[str],
 ) -> dict[str, Any] | None:
+    name = _legacy_field_name(field, product_name, notes, errors)
+    kind = _legacy_field_kind(field, name, notes, errors)
+    if kind is None:
+        return None
+    _validate_legacy_field_shape(field, name, kind, errors)
+    result: dict[str, Any] = {"kind": kind, "name": name}
+    _normalize_field_payload(
+        result,
+        field,
+        name=name,
+        kind=kind,
+        product_name=product_name,
+        nested=nested,
+        notes=notes,
+        errors=errors,
+    )
+    return result
+
+
+def _legacy_field_name(
+    field: dict[str, Any],
+    product_name: str,
+    notes: list[str],
+    errors: list[str],
+) -> str:
     name = _one_alias(field, ("name", "field", "column"), "field name", errors)
     if not isinstance(name, str) or not name.strip():
         errors.append(f"field in product '{product_name}' requires a non-empty name")
-        name = "<invalid>"
-    elif "name" not in field:
+        return "<invalid>"
+    if "name" not in field:
         used = "field" if "field" in field else "column"
         notes.append(f"field '{name}': key '{used}' normalized to 'name'")
+    return name
 
+
+def _legacy_field_kind(
+    field: dict[str, Any],
+    name: str,
+    notes: list[str],
+    errors: list[str],
+) -> FieldIntentKind | None:
     raw_kind = _one_alias(field, ("kind", "type"), f"kind of field '{name}'", errors)
     if "kind" not in field and "type" in field:
         notes.append(f"field '{name}': key 'type' normalized to 'kind'")
-    kind = _normalize_kind(raw_kind, str(name), notes, errors)
-    if kind is None:
-        return None
+    return _normalize_kind(raw_kind, name, notes, errors)
+
+
+def _validate_legacy_field_shape(
+    field: dict[str, Any],
+    name: str,
+    kind: FieldIntentKind,
+    errors: list[str],
+) -> None:
 
     if "script" in field and _calls_unsupported_unique_helper(field["script"]):
         errors.append(
@@ -219,7 +258,18 @@ def _normalize_field(
     if kind in (FieldIntentKind.VALUES, FieldIntentKind.WEIGHTED) and "values" not in field:
         errors.append(f"field '{name}' of kind '{kind}' requires an explicit values array")
 
-    result: dict[str, Any] = {"kind": kind, "name": name}
+
+def _normalize_field_payload(
+    result: dict[str, Any],
+    field: dict[str, Any],
+    *,
+    name: str,
+    kind: FieldIntentKind,
+    product_name: str,
+    nested: bool,
+    notes: list[str],
+    errors: list[str],
+) -> None:
     if kind in (
         FieldIntentKind.INTEGER_RANGE,
         FieldIntentKind.DECIMAL_RANGE,
@@ -245,41 +295,61 @@ def _normalize_field(
     elif kind is FieldIntentKind.SCRIPT:
         result["script"] = field.get("script")
     elif kind is FieldIntentKind.NESTED_LIST:
-        if nested:
-            errors.append(
-                f"unsupported feature: nested field '{name}' more than one level deep in product '{product_name}'"
-            )
-        children_raw = _one_alias(
+        _normalize_nested_field(
+            result,
             field,
-            ("fields", "children"),
-            f"nested fields of '{name}'",
-            errors,
-        )
-        if "fields" not in field and "children" in field:
-            notes.append(f"nested field '{name}': key 'children' normalized to 'fields'")
-        children = _objects(
-            children_raw,
-            label=f"nested fields of field '{name}'",
+            name=name,
+            product_name=product_name,
+            nested=nested,
             notes=notes,
             errors=errors,
         )
-        result["minimum_count"] = field.get("min")
-        result["maximum_count"] = field.get("max")
-        result["fields"] = [
-            normalized
-            for child in children
-            if (
-                normalized := _normalize_field(
-                    child,
-                    product_name=product_name,
-                    nested=True,
-                    notes=notes,
-                    errors=errors,
-                )
+
+
+def _normalize_nested_field(
+    result: dict[str, Any],
+    field: dict[str, Any],
+    *,
+    name: str,
+    product_name: str,
+    nested: bool,
+    notes: list[str],
+    errors: list[str],
+) -> None:
+    if nested:
+        errors.append(
+            f"unsupported feature: nested field '{name}' more than one level deep in product '{product_name}'"
+        )
+    children_raw = _one_alias(
+        field,
+        ("fields", "children"),
+        f"nested fields of '{name}'",
+        errors,
+    )
+    if "fields" not in field and "children" in field:
+        notes.append(f"nested field '{name}': key 'children' normalized to 'fields'")
+    children = _objects(
+        children_raw,
+        label=f"nested fields of field '{name}'",
+        notes=notes,
+        errors=errors,
+    )
+    result["minimum_count"] = field.get("min")
+    result["maximum_count"] = field.get("max")
+    result["fields"] = [
+        normalized
+        for child in children
+        if (
+            normalized := _normalize_field(
+                child,
+                product_name=product_name,
+                nested=True,
+                notes=notes,
+                errors=errors,
             )
-            is not None
-        ]
-    return result
+        )
+        is not None
+    ]
 
 
 def _normalize_targets(raw: Any, product_name: str, errors: list[str]) -> list[dict[str, Any]]:
@@ -344,11 +414,43 @@ def _normalize_product(
     notes: list[str],
     errors: list[str],
 ) -> dict[str, Any] | None:
+    name = _legacy_product_name(product, errors)
+    _validate_legacy_product_keys(product, name, errors)
+    normalized_fields = _normalize_product_fields(product, name, notes, errors)
+    targets = _normalize_targets(product.get("target"), name, errors)
+    children = _normalize_product_children(product, name, depth, notes, errors)
+    has_source, timeseries_attrs = _validate_product_mode(product, name, children, errors)
+    common: dict[str, Any] = {
+        "name": name,
+        "fields": normalized_fields,
+        "targets": targets,
+    }
+    if has_source:
+        return _normalized_source_product(product, name, common, errors)
+    if timeseries_attrs:
+        return _normalized_time_series_product(product, common)
+    normalized_children = _normalize_generated_children(children, depth, notes, errors)
+    return {
+        "kind": "generated",
+        **common,
+        "count": product.get("count"),
+        "children": normalized_children,
+    }
+
+
+def _legacy_product_name(product: dict[str, Any], errors: list[str]) -> str:
     name = product.get("name")
     if not isinstance(name, str) or not name.strip():
         errors.append("every legacy generate requires a non-empty name")
-        name = "<invalid>"
+        return "<invalid>"
+    return name
 
+
+def _validate_legacy_product_keys(
+    product: dict[str, Any],
+    name: str,
+    errors: list[str],
+) -> None:
     allowed = {
         "name",
         "count",
@@ -369,12 +471,19 @@ def _normalize_product(
     if unknown:
         errors.append(f"unknown key(s) on generate '{name}': {', '.join(unknown)}")
 
+
+def _normalize_product_fields(
+    product: dict[str, Any],
+    name: str,
+    notes: list[str],
+    errors: list[str],
+) -> list[dict[str, Any]]:
     fields_raw = _one_alias(product, ("fields", "keys", "columns"), f"fields of '{name}'", errors)
     used_field_alias = next((key for key in ("keys", "columns") if key in product), None)
     if "fields" not in product and used_field_alias:
         notes.append(f"generate '{name}': key '{used_field_alias}' normalized to 'fields'")
     fields = _objects(fields_raw, label=f"fields of generate '{name}'", notes=notes, errors=errors)
-    normalized_fields = [
+    return [
         normalized
         for field in fields
         if (
@@ -389,7 +498,14 @@ def _normalize_product(
         is not None
     ]
 
-    targets = _normalize_targets(product.get("target"), str(name), errors)
+
+def _normalize_product_children(
+    product: dict[str, Any],
+    name: str,
+    depth: int,
+    notes: list[str],
+    errors: list[str],
+) -> list[dict[str, Any]]:
     children_raw = _one_alias(product, ("children", "nested"), f"children of '{name}'", errors)
     if "children" not in product and "nested" in product:
         notes.append(f"generate '{name}': key 'nested' normalized to 'children'")
@@ -405,7 +521,15 @@ def _normalize_product(
                 f"unsupported feature: generate '{child.get('name', '<unnamed>')}' nested more "
                 f"than one level deep inside '{name}'"
             )
+    return children
 
+
+def _validate_product_mode(
+    product: dict[str, Any],
+    name: str,
+    children: list[dict[str, Any]],
+    errors: list[str],
+) -> tuple[bool, list[str]]:
     has_source = product.get("source") is not None
     timeseries_attrs = [attr for attr in ("start", "end", "interval") if product.get(attr) is not None]
     if timeseries_attrs and len(timeseries_attrs) != 3:
@@ -418,33 +542,47 @@ def _normalize_product(
         errors.append(f"product '{name}' defines source_type/type without a source")
     if (has_source or timeseries_attrs) and children:
         errors.append(f"source/time-series product '{name}' cannot contain nested child products in V1")
+    return has_source, timeseries_attrs
 
-    common: dict[str, Any] = {
-        "name": name,
-        "fields": normalized_fields,
-        "targets": targets,
+
+def _normalized_source_product(
+    product: dict[str, Any],
+    name: str,
+    common: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any]:
+    source_type = _one_alias(
+        product,
+        ("source_type", "type"),
+        f"source type of '{name}'",
+        errors,
+    )
+    source = _normalize_source(product.get("source"), source_type, name, errors)
+    return {"kind": "source", **common, "source": source}
+
+
+def _normalized_time_series_product(
+    product: dict[str, Any],
+    common: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "kind": "time_series",
+        **common,
+        "series_count": product.get("count", 1),
+        "window": {
+            "start": product.get("start"),
+            "end": product.get("end"),
+            "interval": product.get("interval"),
+        },
     }
-    if has_source:
-        source_type = _one_alias(
-            product,
-            ("source_type", "type"),
-            f"source type of '{name}'",
-            errors,
-        )
-        source = _normalize_source(product.get("source"), source_type, str(name), errors)
-        return {"kind": "source", **common, "source": source}
-    if timeseries_attrs:
-        return {
-            "kind": "time_series",
-            **common,
-            "series_count": product.get("count", 1),
-            "window": {
-                "start": product.get("start"),
-                "end": product.get("end"),
-                "interval": product.get("interval"),
-            },
-        }
 
+
+def _normalize_generated_children(
+    children: list[dict[str, Any]],
+    depth: int,
+    notes: list[str],
+    errors: list[str],
+) -> list[dict[str, Any]]:
     normalized_children = [
         normalized
         for child in children
@@ -466,12 +604,7 @@ def _normalize_product(
     for child in normalized_children:
         child["relationship"] = {"kind": "nested"}
         child.pop("children", None)
-    return {
-        "kind": "generated",
-        **common,
-        "count": product.get("count"),
-        "children": normalized_children,
-    }
+    return normalized_children
 
 
 def _normalize_legacy(raw: dict[str, Any]) -> NormalizationResult:

--- a/datamimic_ce/authoring/reference.py
+++ b/datamimic_ce/authoring/reference.py
@@ -48,6 +48,7 @@ from datamimic_ce.model.constraints import (
     ValidValues,
     authoring_rule_definition,
     authoring_rule_definitions,
+    resolved_allowed,
     resolved_values,
     serialize_constraints,
     serialize_rule_definition,
@@ -113,14 +114,7 @@ def _render_forbids_constraint(fact: Forbids, advisory: str) -> str:
     return f"{fact.attr} cannot combine with: {excludes}{suffix}{advisory}"
 
 
-def _render_constraint_terse(fact: Constraint) -> str:
-    """Render a single constraint object as a terse one-liner for element_reference().
-
-    Renders structural facts only (attr/attrs/needs/excludes/when_true); message is omitted.
-    Attributes are sorted for stable output. lint_only facts are marked with [advisory].
-    """
-    advisory = " [advisory]" if fact.lint_only else ""
-
+def _render_structural_constraint(fact: Constraint, advisory: str) -> str | None:
     if isinstance(fact, RequiredOneOf):
         attrs_str = ", ".join(sorted(fact.attrs))
         return f"at least one of: {attrs_str}{advisory}"
@@ -131,30 +125,57 @@ def _render_constraint_terse(fact: Constraint) -> str:
         attrs_str = ", ".join(sorted(fact.attrs))
         gate = "is true" if fact.when_true else "is set"
         return f"at most one of: {attrs_str} (when {fact.when_attr} {gate}){advisory}"
+    if isinstance(fact, AllOrNone):
+        attrs_str = ", ".join(sorted(fact.attrs))
+        return f"{attrs_str}: all together or none{advisory}"
+    return None
+
+
+def _render_dependency_constraint(fact: Constraint, advisory: str) -> str | None:
     if isinstance(fact, Requires):
         return _render_requires_constraint(fact, advisory)
     if isinstance(fact, RequiresWhenValue):
         return _render_conditional_requires_constraint(fact, advisory)
-    if isinstance(fact, AllOrNone):
-        attrs_str = ", ".join(sorted(fact.attrs))
-        return f"{attrs_str}: all together or none{advisory}"
     if isinstance(fact, Forbids):
         return _render_forbids_constraint(fact, advisory)
     if isinstance(fact, ForbidsWhenValue):
         values_str = ", ".join(sorted(fact.when_values))
         excludes_str = ", ".join(sorted(fact.excludes))
         return f"{fact.when_attr} in [{values_str}] cannot combine with: {excludes_str}{advisory}"
+    return None
+
+
+def _render_value_constraint(fact: Constraint, advisory: str) -> str | None:
     if isinstance(fact, ValidValues):
-        # Evaluate callable values; static sets/tuples are already iterable
-        values = sorted(fact.values()) if callable(fact.values) else sorted(fact.values)
-        values_str = ", ".join(values)
+        values_str = ", ".join(sorted(resolved_values(fact)))
         return f"{fact.attr} must be one of: {values_str}{advisory}"
     if isinstance(fact, AllowedValuesWhen):
-        # Evaluate callable allowed; static sets/tuples are already iterable
-        allowed = sorted(fact.allowed()) if callable(fact.allowed) else sorted(fact.allowed)
-        allowed_str = ", ".join(allowed)
-        suffix = f" (when {fact.when_attr} is true)" if fact.when_true else f" (when {fact.when_attr} is set)"
+        allowed_str = ", ".join(sorted(resolved_allowed(fact)))
+        suffix = (
+            f" (when {fact.when_attr} is true)"
+            if fact.when_true
+            else f" (when {fact.when_attr} is set)"
+        )
         return f"{fact.attr} must be one of: {allowed_str}{suffix}{advisory}"
+    return None
+
+
+def _render_constraint_terse(fact: Constraint) -> str:
+    """Render a single constraint object as a terse one-liner for element_reference().
+
+    Renders structural facts only (attr/attrs/needs/excludes/when_true); message is omitted.
+    Attributes are sorted for stable output. lint_only facts are marked with [advisory].
+    """
+    advisory = " [advisory]" if fact.lint_only else ""
+    structural = _render_structural_constraint(fact, advisory)
+    if structural is not None:
+        return structural
+    dependency = _render_dependency_constraint(fact, advisory)
+    if dependency is not None:
+        return dependency
+    value = _render_value_constraint(fact, advisory)
+    if value is not None:
+        return value
     return f"<unknown constraint type: {type(fact).__name__}>{advisory}"
 
 

--- a/datamimic_ce/authoring/reference.py
+++ b/datamimic_ce/authoring/reference.py
@@ -37,6 +37,7 @@ from datamimic_ce.model.constraints import (
     SOURCE_DISTRIBUTION_VALUES,
     AllOrNone,
     AllowedValuesWhen,
+    Constraint,
     Forbids,
     ForbidsWhenValue,
     MutuallyExclusive,
@@ -55,6 +56,7 @@ from datamimic_ce.model.constraints import (
 )
 
 _GENERATOR_PACKAGE = "datamimic_ce.domains.common.literal_generators"
+_AUTHORING_PACKAGE = "datamimic_ce.authoring"
 
 
 class ReferenceTopic(StrEnum):
@@ -80,7 +82,38 @@ def clip(text: str, max_chars: int, hint: str) -> str:
     return text[: max_chars - len(hint) - 2].rstrip() + "\n…" + hint
 
 
-def _render_constraint_terse(fact) -> str:
+def _render_requires_constraint(fact: Requires, advisory: str) -> str:
+    needs = ", ".join(sorted(fact.needs))
+    if len(fact.needs) == 1:
+        needs = list(fact.needs)[0]
+    suffix = f" (when {fact.attr} is true)" if fact.when_true else ""
+    return f"{fact.attr} requires {needs}{suffix}{advisory}"
+
+
+def _render_conditional_requires_constraint(
+    fact: RequiresWhenValue,
+    advisory: str,
+) -> str:
+    values = ", ".join(sorted(fact.when_values))
+    needs = ", ".join(sorted(fact.needs))
+    unless = f" unless {', '.join(sorted(fact.unless))} is set" if fact.unless else ""
+    return f"{fact.when_attr} in [{values}] requires {needs}{unless}{advisory}"
+
+
+def _render_forbids_constraint(fact: Forbids, advisory: str) -> str:
+    excludes = ", ".join(sorted(fact.excludes))
+    if fact.excludes_when_true:
+        suffix = (
+            f" (when {fact.attr} is true, both true)"
+            if fact.when_true
+            else " (both true)"
+        )
+    else:
+        suffix = f" (when {fact.attr} is true)" if fact.when_true else ""
+    return f"{fact.attr} cannot combine with: {excludes}{suffix}{advisory}"
+
+
+def _render_constraint_terse(fact: Constraint) -> str:
     """Render a single constraint object as a terse one-liner for element_reference().
 
     Renders structural facts only (attr/attrs/needs/excludes/when_true); message is omitted.
@@ -91,56 +124,43 @@ def _render_constraint_terse(fact) -> str:
     if isinstance(fact, RequiredOneOf):
         attrs_str = ", ".join(sorted(fact.attrs))
         return f"at least one of: {attrs_str}{advisory}"
-    elif isinstance(fact, MutuallyExclusive):
+    if isinstance(fact, MutuallyExclusive):
         attrs_str = ", ".join(sorted(fact.attrs))
         return f"at most one of: {attrs_str}{advisory}"
-    elif isinstance(fact, MutuallyExclusiveWhen):
+    if isinstance(fact, MutuallyExclusiveWhen):
         attrs_str = ", ".join(sorted(fact.attrs))
         gate = "is true" if fact.when_true else "is set"
         return f"at most one of: {attrs_str} (when {fact.when_attr} {gate}){advisory}"
-    elif isinstance(fact, Requires):
-        needs_str = ", ".join(sorted(fact.needs))
-        if len(fact.needs) == 1:
-            needs_str = list(fact.needs)[0]
-        suffix = f" (when {fact.attr} is true)" if fact.when_true else ""
-        return f"{fact.attr} requires {needs_str}{suffix}{advisory}"
-    elif isinstance(fact, RequiresWhenValue):
-        values_str = ", ".join(sorted(fact.when_values))
-        needs_str = ", ".join(sorted(fact.needs))
-        unless = f" unless {', '.join(sorted(fact.unless))} is set" if fact.unless else ""
-        return f"{fact.when_attr} in [{values_str}] requires {needs_str}{unless}{advisory}"
-    elif isinstance(fact, AllOrNone):
+    if isinstance(fact, Requires):
+        return _render_requires_constraint(fact, advisory)
+    if isinstance(fact, RequiresWhenValue):
+        return _render_conditional_requires_constraint(fact, advisory)
+    if isinstance(fact, AllOrNone):
         attrs_str = ", ".join(sorted(fact.attrs))
         return f"{attrs_str}: all together or none{advisory}"
-    elif isinstance(fact, Forbids):
-        excludes_str = ", ".join(sorted(fact.excludes))
-        if fact.excludes_when_true:
-            suffix = f" (when {fact.attr} is true, both true)" if fact.when_true else " (both true)"
-        else:
-            suffix = f" (when {fact.attr} is true)" if fact.when_true else ""
-        return f"{fact.attr} cannot combine with: {excludes_str}{suffix}{advisory}"
-    elif isinstance(fact, ForbidsWhenValue):
+    if isinstance(fact, Forbids):
+        return _render_forbids_constraint(fact, advisory)
+    if isinstance(fact, ForbidsWhenValue):
         values_str = ", ".join(sorted(fact.when_values))
         excludes_str = ", ".join(sorted(fact.excludes))
         return f"{fact.when_attr} in [{values_str}] cannot combine with: {excludes_str}{advisory}"
-    elif isinstance(fact, ValidValues):
+    if isinstance(fact, ValidValues):
         # Evaluate callable values; static sets/tuples are already iterable
         values = sorted(fact.values()) if callable(fact.values) else sorted(fact.values)
         values_str = ", ".join(values)
         return f"{fact.attr} must be one of: {values_str}{advisory}"
-    elif isinstance(fact, AllowedValuesWhen):
+    if isinstance(fact, AllowedValuesWhen):
         # Evaluate callable allowed; static sets/tuples are already iterable
         allowed = sorted(fact.allowed()) if callable(fact.allowed) else sorted(fact.allowed)
         allowed_str = ", ".join(allowed)
         suffix = f" (when {fact.when_attr} is true)" if fact.when_true else f" (when {fact.when_attr} is set)"
         return f"{fact.attr} must be one of: {allowed_str}{suffix}{advisory}"
-    else:
-        return f"<unknown constraint type: {type(fact).__name__}>{advisory}"
+    return f"<unknown constraint type: {type(fact).__name__}>{advisory}"
 
 
 @lru_cache(maxsize=1)
 def cheatsheet() -> str:
-    return (resources.files("datamimic_ce.authoring") / "reference_data" / "cheatsheet.md").read_text(encoding="utf-8")
+    return (resources.files(_AUTHORING_PACKAGE) / "reference_data" / "cheatsheet.md").read_text(encoding="utf-8")
 
 
 def element_reference(tag: str) -> str:
@@ -480,7 +500,7 @@ def capabilities_manifest() -> dict[str, Any]:
 
 @lru_cache(maxsize=1)
 def _recipes_index() -> dict[str, list[dict[str, Any]]]:
-    raw = (resources.files("datamimic_ce.authoring") / "recipes" / "recipes.toml").read_text(encoding="utf-8")
+    raw = (resources.files(_AUTHORING_PACKAGE) / "recipes" / "recipes.toml").read_text(encoding="utf-8")
     return tomllib.loads(raw)
 
 
@@ -495,19 +515,15 @@ def load_recipe(recipe_id: str) -> str:
     entries = {recipe["id"]: recipe for recipe in _recipes_index()["recipe"]}
     if recipe_id not in entries:
         raise ValueError(f"Unknown recipe '{recipe_id}'. Known: {', '.join(sorted(entries))}")
-    xml = (resources.files("datamimic_ce.authoring") / "recipes" / f"{recipe_id}.xml").read_text(encoding="utf-8")
+    xml = (resources.files(_AUTHORING_PACKAGE) / "recipes" / f"{recipe_id}.xml").read_text(encoding="utf-8")
     entry = entries[recipe_id]
     return f"# {entry['title']}\n{entry['summary']}\n\n```xml\n{xml}```"
 
 
-def reference(
+def _named_reference(
     topic: ReferenceTopic,
     name: str | None = None,
-    *,
-    query: AuthoringReferenceQuery | None = None,
-) -> str:
-    if topic is ReferenceTopic.OVERVIEW:
-        return clip(cheatsheet(), 16000, " [truncated — ask a specific topic]")
+) -> str | None:
     if topic is ReferenceTopic.ELEMENT:
         if not name:
             raise ValueError("topic=element needs name=<tag>")
@@ -520,6 +536,21 @@ def reference(
         return text
     if topic is ReferenceTopic.ENTITIES:
         return entities_reference(name)
+    if topic is ReferenceTopic.RULES:
+        return rules_reference(name)
+    if topic is ReferenceTopic.RECIPE:
+        if not name:
+            raise ValueError("topic=recipe needs name=<recipe id>. " + list_recipes())
+        return load_recipe(name)
+    return None
+
+
+def _projected_reference(
+    topic: ReferenceTopic,
+    query: AuthoringReferenceQuery | None,
+) -> str:
+    if topic is ReferenceTopic.OVERVIEW:
+        return clip(cheatsheet(), 16000, " [truncated — ask a specific topic]")
     if topic is ReferenceTopic.CONTEXT:
         return context_reference()
     if topic is ReferenceTopic.TIMESERIES:
@@ -530,16 +561,22 @@ def reference(
         return distributions_reference()
     if topic is ReferenceTopic.CONVERTERS:
         return converters_reference()
-    if topic is ReferenceTopic.RULES:
-        return rules_reference(name)
     if topic is ReferenceTopic.SCAFFOLD:
         return scaffold_reference()
     if topic is ReferenceTopic.AUTHORING:
         return compact_authoring_reference(query)
     if topic is ReferenceTopic.RECIPES:
         return list_recipes()
-    if topic is ReferenceTopic.RECIPE:
-        if not name:
-            raise ValueError("topic=recipe needs name=<recipe id>. " + list_recipes())
-        return load_recipe(name)
     raise ValueError(f"Unknown topic '{topic}'. Topics: {', '.join(ReferenceTopic)}")
+
+
+def reference(
+    topic: ReferenceTopic,
+    name: str | None = None,
+    *,
+    query: AuthoringReferenceQuery | None = None,
+) -> str:
+    named = _named_reference(topic, name)
+    if named is not None:
+        return named
+    return _projected_reference(topic, query)

--- a/datamimic_ce/authoring/rules/best_practice.py
+++ b/datamimic_ce/authoring/rules/best_practice.py
@@ -108,28 +108,46 @@ def _literal_nested_demand(
     cardinality_scopes: list[etree._Element],
 ) -> tuple[int | None, str | None]:
     """Prove total uses of one root-cached sequence, or explain why it is dynamic."""
-    if element.get("condition") is not None or any(
-        isinstance(ancestor.tag, str) and ancestor.tag in _CONDITIONAL_TAGS for ancestor in element.iterancestors()
-    ):
-        return None, "a condition can change how many rows evaluate the field"
+    conditional_reason = _conditional_demand_reason(element)
+    if conditional_reason is not None:
+        return None, conditional_reason
 
     demand = 1
     for scope in cardinality_scopes:
-        scope_tag = scope.tag.decode() if isinstance(scope.tag, bytes) else str(scope.tag)
-        scope_name = scope.get("name") or ""
-        if scope.get("condition") is not None:
-            return None, f"<{scope_tag}> '{scope_name}' has condition= and may be skipped"
-        if scope.get("source") is not None or scope.get("script") is not None:
-            return None, f"<{scope_tag}> '{scope_name}' derives cardinality from source/script"
-        if any(scope.get(attr) is not None for attr in ("start", "end", "interval", "minCount", "maxCount")):
-            return None, f"<{scope_tag}> '{scope_name}' has non-literal cardinality semantics"
-        count = scope.get("count")
-        if scope_tag == EL_NESTED_KEY and count is None and scope.get("type") == "dict":
-            continue  # one nested object per enclosing row
-        if count is None or not count.isdigit():
-            return None, f"<{scope_tag}> '{scope_name}' does not have a literal count"
-        demand *= int(count)
+        factor, unknown_reason = _literal_scope_factor(scope)
+        if unknown_reason is not None:
+            return None, unknown_reason
+        demand *= factor
     return demand, None
+
+
+def _conditional_demand_reason(element: etree._Element) -> str | None:
+    if element.get("condition") is not None:
+        return "a condition can change how many rows evaluate the field"
+    if any(
+        isinstance(ancestor.tag, str) and ancestor.tag in _CONDITIONAL_TAGS
+        for ancestor in element.iterancestors()
+    ):
+        return "a condition can change how many rows evaluate the field"
+    return None
+
+
+def _literal_scope_factor(scope: etree._Element) -> tuple[int, str | None]:
+    scope_tag = scope.tag.decode() if isinstance(scope.tag, bytes) else str(scope.tag)
+    scope_name = scope.get("name") or ""
+    if scope.get("condition") is not None:
+        return 1, f"<{scope_tag}> '{scope_name}' has condition= and may be skipped"
+    if scope.get("source") is not None or scope.get("script") is not None:
+        return 1, f"<{scope_tag}> '{scope_name}' derives cardinality from source/script"
+    dynamic_attrs = ("start", "end", "interval", "minCount", "maxCount")
+    if any(scope.get(attr) is not None for attr in dynamic_attrs):
+        return 1, f"<{scope_tag}> '{scope_name}' has non-literal cardinality semantics"
+    count = scope.get("count")
+    if scope_tag == EL_NESTED_KEY and count is None and scope.get("type") == "dict":
+        return 1, None
+    if count is None or not count.isdigit():
+        return 1, f"<{scope_tag}> '{scope_name}' does not have a literal count"
+    return int(count), None
 
 
 def _nested_sequence_analyses(ctx: LintContext) -> Iterable[_NestedSequenceAnalysis]:

--- a/datamimic_ce/authoring/rules/cross_statement.py
+++ b/datamimic_ce/authoring/rules/cross_statement.py
@@ -9,6 +9,7 @@ checks at runtime (unknown targets) or not at all (duplicate names)."""
 
 import ast
 from collections.abc import Iterable
+from dataclasses import dataclass
 
 from lxml import etree
 
@@ -37,6 +38,7 @@ from datamimic_ce.enums.operation_enums import ExportOperation
 from datamimic_ce.exporters.exporter_util import ExporterUtil, buffered_exporter_names
 from datamimic_ce.model.constraints import (
     DynamicSourceKind,
+    SourceFileFormat,
     authoring_rule_definition,
     source_allows_client,
     source_allows_memstore,
@@ -73,6 +75,86 @@ def _is_python_source_expression(source: str) -> bool:
     except SyntaxError:
         return False
     return True
+
+
+@dataclass(frozen=True)
+class _SourceDiagnostic:
+    evidence: str
+    fix_context: str
+
+
+def _source_is_declared(
+    source: str,
+    element_tag: str,
+    source_type: str | None,
+    clients: set[str],
+    memstores: set[str],
+) -> bool:
+    return (
+        source_file_format_for(element_tag, source, source_type) is not None
+        or (source in clients and source_allows_client(element_tag, source_type))
+        or (source in memstores and source_allows_memstore(element_tag, source_type))
+    )
+
+
+def _dynamic_source_is_valid(
+    source: str,
+    element_tag: str,
+    source_type: str | None,
+) -> bool:
+    dynamic_kind = source_dynamic_kind(element_tag, source_type)
+    if dynamic_kind is DynamicSourceKind.BRACED_EXPRESSION:
+        return source.startswith("{") and source.endswith("}")
+    if dynamic_kind is DynamicSourceKind.PYTHON_EXPRESSION:
+        return _is_python_source_expression(source)
+    return False
+
+
+def _unsupported_file_source_diagnostic(
+    element_tag: str,
+    source_type: str | None,
+    known_format: SourceFileFormat,
+) -> _SourceDiagnostic:
+    supported = supported_source_file_formats(element_tag, source_type)
+    allowed = (
+        ", ".join(file_format.value for file_format in supported)
+        if supported
+        else "no file formats"
+    )
+    return _SourceDiagnostic(
+        evidence=(
+            f'<{element_tag}> type="{source_type}" does not support source suffix '
+            f"'{known_format.value}' (allowed: {allowed})"
+        ),
+        fix_context=f"Use a source format supported by <{element_tag}> or another source element.",
+    )
+
+
+def _unknown_source_diagnostic(
+    source: str,
+    element_tag: str,
+    source_type: str | None,
+    clients: set[str],
+    memstores: set[str],
+) -> _SourceDiagnostic | None:
+    known_format = source_file_format(source)
+    if known_format is not None:
+        return _unsupported_file_source_diagnostic(element_tag, source_type, known_format)
+    if _dynamic_source_is_valid(source, element_tag, source_type):
+        return None
+    valid_ids: set[str] = set()
+    if source_allows_client(element_tag, source_type):
+        valid_ids.update(clients)
+    if source_allows_memstore(element_tag, source_type):
+        valid_ids.update(memstores)
+    declared = f" Valid ids: {', '.join(sorted(valid_ids))}." if valid_ids else ""
+    fix_context = f"Declare an allowed source id or select a supported file format.{declared}"
+    if source_allows_memstore(element_tag, source_type):
+        fix_context += f' For memory input add <memstore id="{source}"/> above its users.'
+    return _SourceDiagnostic(
+        evidence=f'<{element_tag}> source="{source}" is not a supported file or source id',
+        fix_context=fix_context,
+    )
 
 
 class UnknownTarget(Rule):
@@ -154,47 +236,18 @@ class UnknownSource(Rule):
                 continue
             element_tag = str(element.tag)
             source_type = element.get("type")
-            if source_file_format_for(element_tag, source, source_type) is not None:
-                continue  # supported file; existence is a separate concern
-            if source in clients and source_allows_client(element_tag, source_type):
+            if _source_is_declared(source, element_tag, source_type, clients, memstores):
                 continue
-            if source in memstores and source_allows_memstore(element_tag, source_type):
+            diagnostic = _unknown_source_diagnostic(
+                source, element_tag, source_type, clients, memstores
+            )
+            if diagnostic is None:
                 continue
-
-            known_format = source_file_format(source)
-            supported = supported_source_file_formats(element_tag, source_type)
-            if known_format is not None:
-                allowed = ", ".join(file_format.value for file_format in supported) if supported else "no file formats"
-                evidence = (
-                    f'<{element_tag}> type="{source_type}" does not support source suffix '
-                    f"'{known_format.value}' (allowed: {allowed})"
-                )
-                fix_context = f"Use a source format supported by <{element_tag}> or another source element."
-            else:
-                dynamic_kind = source_dynamic_kind(element_tag, source_type)
-                if (
-                    dynamic_kind is DynamicSourceKind.BRACED_EXPRESSION
-                    and source.startswith("{")
-                    and source.endswith("}")
-                ):
-                    continue
-                if dynamic_kind is DynamicSourceKind.PYTHON_EXPRESSION and _is_python_source_expression(source):
-                    continue
-                valid_ids = set()
-                if source_allows_client(element_tag, source_type):
-                    valid_ids.update(clients)
-                if source_allows_memstore(element_tag, source_type):
-                    valid_ids.update(memstores)
-                declared = f" Valid ids: {', '.join(sorted(valid_ids))}." if valid_ids else ""
-                evidence = f'<{element_tag}> source="{source}" is not a supported file or source id'
-                fix_context = f"Declare an allowed source id or select a supported file format.{declared}"
-                if source_allows_memstore(element_tag, source_type):
-                    fix_context += f' For memory input add <memstore id="{source}"/> above its users.'
             yield ctx.diag(
                 UnknownSource,
                 element,
-                evidence=evidence,
-                fix_context=fix_context,
+                evidence=diagnostic.evidence,
+                fix_context=diagnostic.fix_context,
             )
 
 

--- a/datamimic_ce/authoring/rules/semantic_rules.py
+++ b/datamimic_ce/authoring/rules/semantic_rules.py
@@ -152,6 +152,182 @@ def _constraint_check(constraints: tuple[Constraint, ...]) -> Callable[[dict[str
 # changes here, because the owning rules derive their applicable elements from the index too.
 _COUNT_RANGE_FACTS = (COUNT_XOR_MIN, COUNT_XOR_MAX)
 _REQUIRES_OWNED_ELSEWHERE = (WEIGHTS_REQUIRE_VALUES,)
+_RequiresGroupKey = tuple[frozenset[str], bool, str | None]
+
+
+def _generation_mode_diag(
+    rule: type[Rule],
+    ctx: LintContext,
+    element: etree._Element,
+    fact: Constraint,
+) -> Diagnostic | None:
+    tag = str(element.tag)
+    if isinstance(fact, MutuallyExclusive):
+        if fact in _COUNT_RANGE_FACTS:
+            return None
+        modes = sorted(attr for attr in fact.attrs if element.get(attr) is not None)
+        if len(modes) > 1:
+            return ctx.diag(
+                rule,
+                element,
+                evidence=f"<{tag}> sets modes {', '.join(modes)}",
+                severity=rule.definition.severity_for(advisory=fact.lint_only),
+            )
+    if (
+        isinstance(fact, RequiredOneOf)
+        and fact != EXIST_COUNT
+        and all(element.get(attr) is None for attr in fact.attrs)
+    ):
+        options = ", ".join(f"{attr}=" for attr in sorted(fact.attrs))
+        return ctx.diag(
+            rule,
+            element,
+            evidence=f"<{tag}> has no value source",
+            fix_context=f"Available modes: {options}.",
+            severity=rule.definition.severity_for(advisory=fact.lint_only),
+        )
+    return None
+
+
+def _weights_require_values_diag(
+    rule: type[Rule],
+    ctx: LintContext,
+    element: etree._Element,
+    constraints: tuple[Constraint, ...],
+) -> Diagnostic | None:
+    if WEIGHTS_REQUIRE_VALUES not in constraints:
+        return None
+    return _model_util_diag(
+        rule,
+        ctx,
+        element,
+        ModelUtil.check_weights_require_values,
+        fix_context="For weighted literals, add values=.",
+    )
+
+
+def _requires_violation(element: etree._Element, fact: Constraint) -> Requires | None:
+    if not isinstance(fact, Requires):
+        return None
+    if fact in _REQUIRES_OWNED_ELSEWHERE or _is_unique_constraint(fact):
+        return None
+    if not _gate_open(element, fact):
+        return None
+    if any(element.get(need) is not None for need in fact.needs):
+        return None
+    return fact
+
+
+def _requires_violations(
+    element: etree._Element,
+    constraints: tuple[Constraint, ...],
+) -> dict[_RequiresGroupKey, list[str]]:
+    violated: dict[_RequiresGroupKey, list[str]] = {}
+    for candidate in constraints:
+        fact = _requires_violation(element, candidate)
+        if fact is not None:
+            violated.setdefault((fact.needs, fact.lint_only, fact.message), []).append(
+                fact.attr
+            )
+    return violated
+
+
+def _source_companion_diag(
+    rule: type[Rule],
+    ctx: LintContext,
+    element: etree._Element,
+    key: _RequiresGroupKey,
+    attrs: list[str],
+) -> Diagnostic:
+    needs, lint_only, declared_message = key
+    present = ", ".join(sorted(attrs))
+    severity = rule.definition.severity_for(advisory=lint_only)
+    if declared_message is not None:
+        return ctx.diag(
+            rule,
+            element,
+            evidence=f"{declared_message}; present: {present}",
+            fix_context=f"Required: {' or '.join(f'{need}=' for need in sorted(needs))}.",
+            severity=severity,
+        )
+    if needs == frozenset((ATTR_SOURCE,)):
+        return ctx.diag(
+            rule,
+            element,
+            evidence=f"{present} is present without source=",
+            severity=severity,
+        )
+    needed = " or ".join(f"{need}=" for need in sorted(needs))
+    return ctx.diag(
+        rule,
+        element,
+        evidence=f"{present} is present without {needed}",
+        fix_context=f"Required: {needed}.",
+        severity=severity,
+    )
+
+
+def _forbidden_companion_diag(
+    rule: type[Rule],
+    ctx: LintContext,
+    element: etree._Element,
+    fact: Constraint,
+) -> Diagnostic | None:
+    if not isinstance(fact, Forbids) or _is_unique_constraint(fact):
+        return None
+    if not _gate_open(element, fact):
+        return None
+    if fact.excludes_when_true:
+        present = sorted(attr for attr in fact.excludes if _attr_true(element.get(attr)))
+    else:
+        present = sorted(attr for attr in fact.excludes if element.get(attr) is not None)
+    if not present:
+        return None
+    tag = str(element.tag)
+    message = fact.message or (
+        f"<{tag}> {fact.attr}= cannot be combined with: {', '.join(present)}."
+    )
+    return ctx.diag(
+        rule,
+        element,
+        evidence=f"{message} Present forbidden attributes: {', '.join(present)}",
+        fix_context=f"Remove {', '.join(f'{attr}=' for attr in present)} or {fact.attr}=.",
+        severity=rule.definition.severity_for(advisory=fact.lint_only),
+    )
+
+
+def _allowed_values_diag(
+    rule: type[Rule],
+    ctx: LintContext,
+    element: etree._Element,
+    fact: Constraint,
+) -> Diagnostic | None:
+    if not isinstance(fact, AllowedValuesWhen) or _is_unique_constraint(fact):
+        return None
+    gate_value = element.get(fact.when_attr)
+    should_check = (not fact.when_true and fact.when_attr in element.attrib) or (
+        fact.when_true and _attr_true(gate_value)
+    )
+    value = element.get(fact.attr)
+    if not should_check or value is None:
+        return None
+    allowed = resolved_allowed(fact)
+    if value in allowed:
+        return None
+    options = ", ".join(sorted(allowed))
+    message = (
+        fact.message.replace("{actual_value}", value)
+        if fact.message is not None
+        else f"when '{fact.when_attr}' is set, '{fact.attr}' value must be one of "
+        f"[{options}], but got: '{value}'"
+    )
+    return ctx.diag(
+        rule,
+        element,
+        evidence=f"{message} Actual {fact.attr}='{value}'",
+        fix_context=f"Allowed values: {options}.",
+        severity=rule.definition.severity_for(advisory=fact.lint_only),
+    )
 
 
 class CountBoundsConflict(Rule):
@@ -211,41 +387,13 @@ class GenerationModeConflict(Rule):
 
     def check(self, ctx: LintContext) -> Iterable[Diagnostic]:
         for element, constraints in _constrained(ctx):
-            tag = str(element.tag)
             for fact in constraints:
-                if isinstance(fact, MutuallyExclusive):
-                    if fact in _COUNT_RANGE_FACTS:
-                        continue  # DM201 reports count-vs-range with its friendlier message
-                    modes = sorted(attr for attr in fact.attrs if element.get(attr) is not None)
-                    if len(modes) > 1:
-                        yield ctx.diag(
-                            type(self),
-                            element,
-                            evidence=f"<{tag}> sets modes {', '.join(modes)}",
-                            severity=type(self).definition.severity_for(advisory=fact.lint_only),
-                        )
-                elif isinstance(fact, RequiredOneOf):
-                    if fact == EXIST_COUNT:
-                        continue  # DM202 reports missing count with the time-series interplay
-                    if all(element.get(attr) is None for attr in fact.attrs):
-                        options = ", ".join(f"{attr}=" for attr in sorted(fact.attrs))
-                        yield ctx.diag(
-                            type(self),
-                            element,
-                            evidence=f"<{tag}> has no value source",
-                            fix_context=f"Available modes: {options}.",
-                            severity=type(self).definition.severity_for(advisory=fact.lint_only),
-                        )
-            if WEIGHTS_REQUIRE_VALUES in constraints:
-                diag = _model_util_diag(
-                    type(self),
-                    ctx,
-                    element,
-                    ModelUtil.check_weights_require_values,
-                    fix_context="For weighted literals, add values=.",
-                )
+                diag = _generation_mode_diag(type(self), ctx, element, fact)
                 if diag:
                     yield diag
+            weights_diag = _weights_require_values_diag(type(self), ctx, element, constraints)
+            if weights_diag:
+                yield weights_diag
 
 
 class UniqueConstraints(Rule):
@@ -333,46 +481,14 @@ class SourceCompanionsWithoutSource(Rule):
     definition = authoring_rule_definition("DM214")
 
     def check(self, ctx: LintContext) -> Iterable[Diagnostic]:
-        source_needs = frozenset((ATTR_SOURCE,))
         for element, constraints in _constrained(ctx):
-            violated: dict[tuple[frozenset[str], bool, str | None], list[str]] = {}
-            for fact in constraints:
-                if not isinstance(fact, Requires) or fact in _REQUIRES_OWNED_ELSEWHERE or _is_unique_constraint(fact):
-                    continue
-                if not _gate_open(element, fact):
-                    continue
-                if any(element.get(need) is not None for need in fact.needs):
-                    continue
-                violated.setdefault((fact.needs, fact.lint_only, fact.message), []).append(fact.attr)
-            for (needs, lint_only, declared_message), attrs in sorted(
-                violated.items(), key=lambda item: (sorted(item[0][0]), item[0][1], item[0][2] or "")
-            ):
-                present = ", ".join(sorted(attrs))
-                if declared_message is not None:
-                    yield ctx.diag(
-                        type(self),
-                        element,
-                        evidence=f"{declared_message}; present: {present}",
-                        fix_context=f"Required: {' or '.join(f'{need}=' for need in sorted(needs))}.",
-                        severity=type(self).definition.severity_for(advisory=lint_only),
-                    )
-                    continue
-                if needs == source_needs:
-                    yield ctx.diag(
-                        type(self),
-                        element,
-                        evidence=f"{present} is present without source=",
-                        severity=type(self).definition.severity_for(advisory=lint_only),
-                    )
-                else:
-                    needed = " or ".join(f"{need}=" for need in sorted(needs))
-                    yield ctx.diag(
-                        type(self),
-                        element,
-                        evidence=f"{present} is present without {needed}",
-                        fix_context=f"Required: {needed}.",
-                        severity=type(self).definition.severity_for(advisory=lint_only),
-                    )
+            violations = _requires_violations(element, constraints)
+            ordered = sorted(
+                violations.items(),
+                key=lambda item: (sorted(item[0][0]), item[0][1], item[0][2] or ""),
+            )
+            for key, attrs in ordered:
+                yield _source_companion_diag(type(self), ctx, element, key, attrs)
 
 
 class NestedKeyNeedsType(Rule):
@@ -457,27 +573,10 @@ class ForbiddenCompanions(Rule):
 
     def check(self, ctx: LintContext) -> Iterable[Diagnostic]:
         for element, constraints in _constrained(ctx):
-            tag = str(element.tag)
             for fact in constraints:
-                if not isinstance(fact, Forbids) or _is_unique_constraint(fact):
-                    continue
-                if not _gate_open(element, fact):
-                    continue
-                # When excludes_when_true=True, excluded attr must also be truthy for violation
-                if fact.excludes_when_true:
-                    present = sorted(attr for attr in fact.excludes if _attr_true(element.get(attr)))
-                else:
-                    present = sorted(attr for attr in fact.excludes if element.get(attr) is not None)
-                if not present:
-                    continue
-                message = fact.message or (f"<{tag}> {fact.attr}= cannot be combined with: {', '.join(present)}.")
-                yield ctx.diag(
-                    type(self),
-                    element,
-                    evidence=f"{message} Present forbidden attributes: {', '.join(present)}",
-                    fix_context=f"Remove {', '.join(f'{attr}=' for attr in present)} or {fact.attr}=.",
-                    severity=type(self).definition.severity_for(advisory=fact.lint_only),
-                )
+                diag = _forbidden_companion_diag(type(self), ctx, element, fact)
+                if diag:
+                    yield diag
 
 
 class DeclaredValidValues(Rule):
@@ -525,36 +624,9 @@ class AllowedValuesWhenConstraint(Rule):
     def check(self, ctx: LintContext) -> Iterable[Diagnostic]:
         for element, constraints in _constrained(ctx):
             for fact in constraints:
-                if not isinstance(fact, AllowedValuesWhen) or _is_unique_constraint(fact):
-                    continue
-                # Gate on when_attr's presence or truthiness
-                gate_value = element.get(fact.when_attr)
-                should_check = (not fact.when_true and fact.when_attr in element.attrib) or (
-                    fact.when_true and _attr_true(gate_value)
-                )
-                if not should_check:
-                    continue
-                # Only validate if attr is also present
-                value = element.get(fact.attr)
-                if value is None:
-                    continue
-                allowed = resolved_allowed(fact)
-                if value in allowed:
-                    continue
-                options = ", ".join(sorted(allowed))
-                message = (
-                    fact.message.replace("{actual_value}", value)
-                    if fact.message is not None
-                    else f"when '{fact.when_attr}' is set, '{fact.attr}' value must be one of "
-                    f"[{options}], but got: '{value}'"
-                )
-                yield ctx.diag(
-                    type(self),
-                    element,
-                    evidence=f"{message} Actual {fact.attr}='{value}'",
-                    fix_context=f"Allowed values: {options}.",
-                    severity=type(self).definition.severity_for(advisory=fact.lint_only),
-                )
+                diag = _allowed_values_diag(type(self), ctx, element, fact)
+                if diag:
+                    yield diag
 
 
 class ConditionalDeclaredConstraints(Rule):

--- a/datamimic_ce/authoring/service.py
+++ b/datamimic_ce/authoring/service.py
@@ -28,6 +28,8 @@ from datamimic_ce.authoring.contracts import (
     GeneratedProductCompilePlan,
     IntentValidationIssue,
     IntentValidationIssueCode,
+    ProductCaptureEvidence,
+    ProductCompilePlan,
     RetryWithParameterRemediation,
     RunRequest,
     RunResult,
@@ -153,11 +155,28 @@ def run(request: RunRequest) -> RunResult:
     return result
 
 
-def _max_count_remediations(
+def _minimum_required_for_capped_product(
+    planned: ProductCompilePlan,
+    evidence: ProductCaptureEvidence,
+) -> int:
+    """Resolve the complete bounded count from one typed product plan."""
+
+    if isinstance(planned, GeneratedProductCompilePlan):
+        return planned.count_per_parent or planned.static_count
+    if isinstance(planned, TimeSeriesProductCompilePlan):
+        return planned.series_count
+    if isinstance(planned, SourceProductCompilePlan):
+        if evidence.requested is None:
+            raise ValueError("capped source evidence requires a requested count")
+        return evidence.requested
+    raise TypeError(f"Unsupported product plan: {type(planned).__name__}")
+
+
+def _capped_product_minimums(
     plan: CompilePlan,
     captured: CapturedProducts,
-) -> list[RetryWithParameterRemediation]:
-    """Derive one retry action from typed, statically bounded cap evidence."""
+) -> dict[str, int]:
+    """Return products whose statically complete count exceeds the capture bound."""
 
     products_by_name = {product.name: product for product in plan.products}
     minimums: dict[str, int] = {}
@@ -171,21 +190,18 @@ def _max_count_remediations(
             or planned is None
         ):
             continue
-        if isinstance(planned, GeneratedProductCompilePlan):
-            minimum = planned.count_per_parent or planned.static_count
-        elif isinstance(planned, TimeSeriesProductCompilePlan):
-            minimum = planned.series_count
-        elif isinstance(planned, SourceProductCompilePlan):
-            minimum = evidence.requested
-        else:
-            continue
+        minimum = _minimum_required_for_capped_product(planned, evidence)
         if minimum > captured.max_count:
             minimums[product.name] = minimum
-    if not minimums:
-        return []
-    required_minimum = max(minimums.values())
-    if required_minimum > MAX_DRY_RUN_COUNT:
-        return []
+    return minimums
+
+
+def _affected_capped_products(
+    plan: CompilePlan,
+    captured: CapturedProducts,
+    minimums: dict[str, int],
+) -> set[str]:
+    """Include captured descendants whose rows depend on a capped parent."""
 
     captured_names = {product.name for product in captured.products}
     affected = set(minimums)
@@ -200,6 +216,23 @@ def _max_count_remediations(
             ):
                 affected.add(relationship.child)
                 changed = True
+    return affected
+
+
+def _max_count_remediations(
+    plan: CompilePlan,
+    captured: CapturedProducts,
+) -> list[RetryWithParameterRemediation]:
+    """Derive one retry action from typed, statically bounded cap evidence."""
+
+    minimums = _capped_product_minimums(plan, captured)
+    if not minimums:
+        return []
+    required_minimum = max(minimums.values())
+    if required_minimum > MAX_DRY_RUN_COUNT:
+        return []
+
+    affected = _affected_capped_products(plan, captured, minimums)
     return [
         RetryWithParameterRemediation(
             minimum_value=required_minimum,

--- a/datamimic_ce/authoring/spec.py
+++ b/datamimic_ce/authoring/spec.py
@@ -41,6 +41,7 @@ PositiveStrictInt = Annotated[StrictInt, Field(gt=0)]
 NonNegativeStrictInt = Annotated[StrictInt, Field(ge=0)]
 NonEmptyStrictStr = Annotated[StrictStr, Field(min_length=1)]
 INTENT_REPAIR_ALIASES_SCHEMA_KEY = "x-datamimic-repair-aliases"
+_ORDERED_BOUNDS_ERROR = "minimum must not exceed maximum"
 
 
 class FieldIntentKind(StrEnum):
@@ -201,7 +202,7 @@ class IntegerRangeField(FieldIntent):
     @model_validator(mode="after")
     def _ordered_bounds(self) -> IntegerRangeField:
         if self.minimum > self.maximum:
-            raise ValueError("minimum must not exceed maximum")
+            raise ValueError(_ORDERED_BOUNDS_ERROR)
         return self
 
 
@@ -213,7 +214,7 @@ class DecimalRangeField(FieldIntent):
     @model_validator(mode="after")
     def _ordered_bounds(self) -> DecimalRangeField:
         if self.minimum > self.maximum:
-            raise ValueError("minimum must not exceed maximum")
+            raise ValueError(_ORDERED_BOUNDS_ERROR)
         return self
 
 
@@ -225,7 +226,7 @@ class StringLengthField(FieldIntent):
     @model_validator(mode="after")
     def _ordered_bounds(self) -> StringLengthField:
         if self.minimum > self.maximum:
-            raise ValueError("minimum must not exceed maximum")
+            raise ValueError(_ORDERED_BOUNDS_ERROR)
         return self
 
 
@@ -365,9 +366,7 @@ def _file_export_schema(schema: JsonDict) -> None:
     if isinstance(properties, dict):
         format_schema = properties.get("format")
         if isinstance(format_schema, dict):
-            enum_values: list[JsonValue] = [
-                name for name in sorted(buffered_exporter_names())
-            ]
+            enum_values = list[JsonValue](sorted(buffered_exporter_names()))
             format_schema["enum"] = enum_values
 
 
@@ -554,7 +553,7 @@ class RangeExpectation(IntentModel):
     @model_validator(mode="after")
     def _ordered_bounds(self) -> RangeExpectation:
         if self.minimum > self.maximum:
-            raise ValueError("minimum must not exceed maximum")
+            raise ValueError(_ORDERED_BOUNDS_ERROR)
         return self
 
 
@@ -577,6 +576,132 @@ ExpectationIntent = Annotated[
 ]
 
 
+class _IntentGraphIndex:
+    def __init__(self, products: tuple[ProductIntentUnion, ...]) -> None:
+        self.products = _intent_products(products)
+        self.fields = _intent_fields(self.products)
+        self.nested_edges = _intent_nested_edges(products)
+
+    def require_product(self, name: str, context: str) -> None:
+        if name not in self.products:
+            raise ValueError(f"{context} references unknown product '{name}'")
+
+    def require_field(self, product: str, field: str, context: str) -> None:
+        self.require_product(product, context)
+        if field not in self.fields[product]:
+            raise ValueError(
+                f"{context} references unknown field '{field}' on product '{product}'"
+            )
+
+
+def _intent_products(
+    products: tuple[ProductIntentUnion, ...],
+) -> dict[str, ProductIntent | NestedGeneratedProduct]:
+    names: list[str] = []
+    products_by_name: dict[str, ProductIntent | NestedGeneratedProduct] = {}
+    for product in products:
+        names.append(product.name)
+        products_by_name[product.name] = product
+        if isinstance(product, GeneratedProduct):
+            names.extend(child.name for child in product.children)
+            products_by_name.update({child.name: child for child in product.children})
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    if duplicates:
+        raise ValueError(f"product names must be unique: {', '.join(duplicates)}")
+    return products_by_name
+
+
+def _intent_fields(
+    products: dict[str, ProductIntent | NestedGeneratedProduct],
+) -> dict[str, set[str]]:
+    return {
+        name: {field.name for field in product.fields}
+        for name, product in products.items()
+    }
+
+
+def _intent_nested_edges(
+    products: tuple[ProductIntentUnion, ...],
+) -> set[tuple[str, str]]:
+    return {
+        (product.name, child.name)
+        for product in products
+        if isinstance(product, GeneratedProduct)
+        for child in product.children
+    }
+
+
+def _validate_intent_roles(index: _IntentGraphIndex) -> None:
+    for product_name, product in index.products.items():
+        for field in product.fields:
+            _validate_nested_identifier_role(product_name, product, field)
+            for role in field.roles:
+                if isinstance(role, ForeignKeyRole):
+                    index.require_field(
+                        role.parent_product,
+                        role.parent_field,
+                        f"foreign-key role on {product_name}.{field.name}",
+                    )
+
+
+def _validate_nested_identifier_role(
+    product_name: str,
+    product: ProductIntent | NestedGeneratedProduct,
+    field: FieldIntentUnion,
+) -> None:
+    if not isinstance(product, NestedGeneratedProduct):
+        return
+    if not isinstance(field, IncrementField):
+        return
+    if any(isinstance(role, IdentifierRole) for role in field.roles):
+        raise ValueError(
+            f"nested Increment field '{product_name}.{field.name}' is local per "
+            "parent and cannot claim the global identifier role"
+        )
+
+
+def _validate_unique_expectations(expectations: tuple[ExpectationIntent, ...]) -> None:
+    duplicate_kinds = [
+        expectation.kind
+        for index, expectation in enumerate(expectations)
+        if expectation in expectations[:index]
+    ]
+    if duplicate_kinds:
+        kinds = ", ".join(duplicate_kinds)
+        raise ValueError(f"explicit expectations must be unique; duplicates: {kinds}")
+
+
+def _validate_expectation(
+    expectation: ExpectationIntent,
+    index: _IntentGraphIndex,
+) -> None:
+    context = f"{expectation.kind} expectation"
+    if isinstance(expectation, ExactCountExpectation | RowConditionExpectation):
+        index.require_product(expectation.product, context)
+    elif isinstance(expectation, PerParentCountExpectation):
+        index.require_product(expectation.parent_product, context)
+        index.require_product(expectation.child_product, context)
+        if (expectation.parent_product, expectation.child_product) not in index.nested_edges:
+            raise ValueError(
+                f"{context} requires a nested parent-child relationship between "
+                f"'{expectation.parent_product}' and '{expectation.child_product}'"
+            )
+    elif isinstance(expectation, UniqueExpectation | AllowedValuesExpectation | RangeExpectation):
+        index.require_field(expectation.product, expectation.field, context)
+    else:
+        index.require_field(expectation.child_product, expectation.child_field, context)
+        index.require_field(expectation.parent_product, expectation.parent_field, context)
+
+
+def _validate_expectations(
+    expectations: tuple[ExpectationIntent, ...],
+    index: _IntentGraphIndex,
+) -> None:
+    _validate_unique_expectations(expectations)
+    for expectation in expectations:
+        _validate_expectation(expectation, index)
+
+
 class AuthoringSpecV1(IntentModel):
     """Canonical contents of a ``model.dm.json`` authoring artifact."""
 
@@ -587,92 +712,9 @@ class AuthoringSpecV1(IntentModel):
 
     @model_validator(mode="after")
     def _unique_product_names(self) -> AuthoringSpecV1:
-        names: list[str] = []
-        products_by_name: dict[str, ProductIntent | NestedGeneratedProduct] = {}
-        for product in self.products:
-            names.append(product.name)
-            products_by_name[product.name] = product
-            if isinstance(product, GeneratedProduct):
-                names.extend(child.name for child in product.children)
-                products_by_name.update({child.name: child for child in product.children})
-        duplicates = sorted({name for name in names if names.count(name) > 1})
-        if duplicates:
-            raise ValueError(f"product names must be unique: {', '.join(duplicates)}")
-
-        fields_by_product = {
-            name: {field.name for field in product.fields} for name, product in products_by_name.items()
-        }
-
-        def require_product(name: str, context: str) -> None:
-            if name not in products_by_name:
-                raise ValueError(f"{context} references unknown product '{name}'")
-
-        def require_field(product: str, field: str, context: str) -> None:
-            require_product(product, context)
-            if field not in fields_by_product[product]:
-                raise ValueError(f"{context} references unknown field '{field}' on product '{product}'")
-
-        for product_name, resolved_product in products_by_name.items():
-            for field in resolved_product.fields:
-                if (
-                    isinstance(resolved_product, NestedGeneratedProduct)
-                    and isinstance(field, IncrementField)
-                    and any(isinstance(role, IdentifierRole) for role in field.roles)
-                ):
-                    raise ValueError(
-                        f"nested Increment field '{product_name}.{field.name}' is local per "
-                        "parent and cannot claim the global identifier role"
-                    )
-                for role in field.roles:
-                    if isinstance(role, ForeignKeyRole):
-                        require_field(
-                            role.parent_product,
-                            role.parent_field,
-                            f"foreign-key role on {product_name}.{field.name}",
-                        )
-
-        nested_edges = {
-            (product.name, child.name)
-            for product in self.products
-            if isinstance(product, GeneratedProduct)
-            for child in product.children
-        }
-        duplicate_expectation_kinds = [
-            expectation.kind
-            for index, expectation in enumerate(self.expectations)
-            if expectation in self.expectations[:index]
-        ]
-        if duplicate_expectation_kinds:
-            kinds = ", ".join(duplicate_expectation_kinds)
-            raise ValueError(f"explicit expectations must be unique; duplicates: {kinds}")
-        for expectation in self.expectations:
-            context = f"{expectation.kind} expectation"
-            if isinstance(expectation, ExactCountExpectation | RowConditionExpectation):
-                require_product(expectation.product, context)
-            elif isinstance(expectation, PerParentCountExpectation):
-                require_product(expectation.parent_product, context)
-                require_product(expectation.child_product, context)
-                if (expectation.parent_product, expectation.child_product) not in nested_edges:
-                    raise ValueError(
-                        f"{context} requires a nested parent-child relationship between "
-                        f"'{expectation.parent_product}' and '{expectation.child_product}'"
-                    )
-            elif isinstance(
-                expectation,
-                UniqueExpectation | AllowedValuesExpectation | RangeExpectation,
-            ):
-                require_field(expectation.product, expectation.field, context)
-            elif isinstance(expectation, ForeignKeyExpectation):
-                require_field(
-                    expectation.child_product,
-                    expectation.child_field,
-                    context,
-                )
-                require_field(
-                    expectation.parent_product,
-                    expectation.parent_field,
-                    context,
-                )
+        index = _IntentGraphIndex(self.products)
+        _validate_intent_roles(index)
+        _validate_expectations(self.expectations, index)
         return self
 
 

--- a/datamimic_ce/authoring/spec.py
+++ b/datamimic_ce/authoring/spec.py
@@ -366,7 +366,8 @@ def _file_export_schema(schema: JsonDict) -> None:
     if isinstance(properties, dict):
         format_schema = properties.get("format")
         if isinstance(format_schema, dict):
-            enum_values = list[JsonValue](sorted(buffered_exporter_names()))
+            enum_values: list[JsonValue] = []
+            enum_values.extend(sorted(buffered_exporter_names()))
             format_schema["enum"] = enum_values
 
 

--- a/datamimic_ce/cli.py
+++ b/datamimic_ce/cli.py
@@ -8,11 +8,11 @@ import os
 import platform
 from importlib.resources import files
 from pathlib import Path
-from typing import Any
+from typing import Any, Never
 
 import toml
 import typer
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -29,7 +29,9 @@ from datamimic_ce.authoring.contracts import (
     AuthoringResponseFormat,
     AuthoringStage,
     CheckRequest,
+    CheckResult,
     RunRequest,
+    RunResult,
     ScaffoldRequest,
     ScaffoldResult,
     ScaffoldVerification,
@@ -154,7 +156,7 @@ def info():
     console.print(info_table)
 
 
-def _emit_error(output_format: str, message: str, exit_code: int = 2) -> None:
+def _emit_error(output_format: str, message: str, exit_code: int = 2) -> Never:
     """Shared error output contract: text for invalid format, JSON when format is valid but error occurred."""
     if output_format not in ("text", "json"):
         # Invalid format itself — emit plain text + exit code
@@ -166,6 +168,38 @@ def _emit_error(output_format: str, message: str, exit_code: int = 2) -> None:
     else:
         typer.echo(f"Error: {message}")
     raise typer.Exit(exit_code)
+
+
+def _emit_lint_result(
+    descriptor_path: Path,
+    output_format: str,
+    result: CheckResult,
+) -> None:
+    if output_format == "json":
+        typer.echo(result.model_dump_json(indent=2))
+        return
+    for diagnostic in result.diagnostics:
+        location = (
+            f"{descriptor_path}:{diagnostic.line}"
+            if diagnostic.line
+            else str(descriptor_path)
+        )
+        typer.echo(
+            f"{location}  {diagnostic.severity.value.upper():<7} "
+            f"{diagnostic.rule}  {diagnostic.message}"
+        )
+        typer.echo(f"    -> {diagnostic.fix_hint}")
+    truncated = f" (+{result.truncated} truncated)" if result.truncated else ""
+    typer.echo(f"Summary: {result.summary()}{truncated}")
+
+
+def _lint_exit_code(result: CheckResult, fail_on: str) -> int:
+    fail_severities = {"error"} if fail_on == "error" else {"error", "warning"}
+    failed = any(
+        diagnostic.severity.value in fail_severities
+        for diagnostic in result.diagnostics
+    )
+    return 1 if failed else 0
 
 
 def _lint(descriptor_path: Path, output_format: str, fail_on: str, max_diagnostics: int) -> None:
@@ -200,18 +234,8 @@ def _lint(descriptor_path: Path, output_format: str, fail_on: str, max_diagnosti
     except Exception as e:  # unexpected linter crash — distinct from findings
         _emit_error(output_format, f"Lint error: {e}", exit_code=2)
 
-    if output_format == "json":
-        typer.echo(result.model_dump_json(indent=2))
-    else:
-        for diag in result.diagnostics:
-            location = f"{descriptor_path}:{diag.line}" if diag.line else str(descriptor_path)
-            typer.echo(f"{location}  {diag.severity.value.upper():<7} {diag.rule}  {diag.message}")
-            typer.echo(f"    -> {diag.fix_hint}")
-        typer.echo(f"Summary: {result.summary()}" + (f" (+{result.truncated} truncated)" if result.truncated else ""))
-
-    fail_severities = {"error"} if fail_on == "error" else {"error", "warning"}
-    failed = any(diag.severity.value in fail_severities for diag in result.diagnostics)
-    raise typer.Exit(1 if failed else 0)
+    _emit_lint_result(descriptor_path, output_format, result)
+    raise typer.Exit(_lint_exit_code(result, fail_on))
 
 
 @app.command("lint", help="Lint a DATAMIMIC descriptor: schema, semantics, best practices.")
@@ -253,6 +277,90 @@ def capabilities():
     typer.echo(json.dumps(capabilities_manifest(), indent=2, default=str))
 
 
+def _run_request_validation_message(
+    max_count: int,
+    sample_rows: int,
+    timeout_seconds: int,
+) -> str | None:
+    if not MIN_DRY_RUN_COUNT <= max_count <= MAX_DRY_RUN_COUNT:
+        return (
+            "Invalid max-count. Expected an integer from "
+            f"{MIN_DRY_RUN_COUNT} to {MAX_DRY_RUN_COUNT}"
+        )
+    if not MIN_SAMPLE_ROWS <= sample_rows <= MAX_SAMPLE_ROWS:
+        return (
+            "Invalid sample-rows. Expected an integer from "
+            f"{MIN_SAMPLE_ROWS} to {MAX_SAMPLE_ROWS}"
+        )
+    if not MIN_TIMEOUT_SECONDS <= timeout_seconds <= MAX_TIMEOUT_SECONDS:
+        return (
+            "Invalid timeout. Expected an integer from "
+            f"{MIN_TIMEOUT_SECONDS} to {MAX_TIMEOUT_SECONDS}"
+        )
+    return None
+
+
+def _build_run_request(
+    descriptor_path: Path,
+    max_count: int,
+    sample_rows: int,
+    allow_side_effects: bool,
+    timeout_seconds: int,
+    smoke_export: bool,
+    output_format: str,
+) -> RunRequest:
+    try:
+        return RunRequest(
+            xml=None,
+            path=str(descriptor_path),
+            response_format=AuthoringResponseFormat.DETAILED,
+            max_count=max_count,
+            sample_rows=sample_rows,
+            allow_side_effects=allow_side_effects,
+            timeout_seconds=timeout_seconds,
+            smoke_export=smoke_export,
+        )
+    except ValidationError:
+        message = _run_request_validation_message(
+            max_count,
+            sample_rows,
+            timeout_seconds,
+        )
+        if message is None:
+            raise
+        _emit_error(output_format, message, exit_code=2)
+
+
+def _emit_run_result(result: RunResult, output_format: str) -> None:
+    if output_format == "json":
+        typer.echo(result.model_dump_json(indent=2))
+        return
+    typer.echo(f"ok: {result.ok}")
+    typer.echo(f"stage: {result.stage.value}")
+    if result.timing_ms is not None:
+        typer.echo(f"timing: {result.timing_ms}ms")
+
+    if result.products:
+        typer.echo("")
+        for product in result.products:
+            truncated_note = " (truncated)" if product.truncated_rows else ""
+            typer.echo(f"{product.name}: {product.count} rows{truncated_note}")
+            for row in product.sample:
+                typer.echo(f"  {row}")
+
+    if result.products_truncated > 0:
+        typer.echo(f"(+{result.products_truncated} products truncated)")
+
+    if result.diagnostics:
+        typer.echo("")
+        for diagnostic in result.diagnostics:
+            typer.echo(
+                f"{diagnostic.severity.value.upper():<7} "
+                f"{diagnostic.rule}  {diagnostic.message}"
+            )
+            typer.echo(f"    -> {diagnostic.fix_hint}")
+
+
 def _dry_run(
     descriptor_path: Path,
     max_count: int,
@@ -268,34 +376,15 @@ def _dry_run(
     # Validate format first (before file check, so unknown format is reported immediately)
     if output_format not in ("text", "json"):
         _emit_error(output_format, f"Invalid format '{output_format}'. Expected: text | json", exit_code=2)
-    try:
-        request = RunRequest(
-            xml=None,
-            path=str(descriptor_path),
-            response_format=AuthoringResponseFormat.DETAILED,
-            max_count=max_count,
-            sample_rows=sample_rows,
-            allow_side_effects=allow_side_effects,
-            timeout_seconds=timeout_seconds,
-            smoke_export=smoke_export,
-        )
-    except ValidationError as error:
-        invalid_field = str(error.errors()[0]["loc"][0])
-        messages = {
-            "max_count": (
-                "Invalid max-count. Expected an integer from "
-                f"{MIN_DRY_RUN_COUNT} to {MAX_DRY_RUN_COUNT}"
-            ),
-            "sample_rows": (
-                "Invalid sample-rows. Expected an integer from "
-                f"{MIN_SAMPLE_ROWS} to {MAX_SAMPLE_ROWS}"
-            ),
-            "timeout_seconds": (
-                "Invalid timeout. Expected an integer from "
-                f"{MIN_TIMEOUT_SECONDS} to {MAX_TIMEOUT_SECONDS}"
-            ),
-        }
-        _emit_error(output_format, messages[invalid_field], exit_code=2)
+    request = _build_run_request(
+        descriptor_path,
+        max_count,
+        sample_rows,
+        allow_side_effects,
+        timeout_seconds,
+        smoke_export,
+        output_format,
+    )
 
     if not descriptor_path.is_file():
         _emit_error(output_format, f"File not found: {descriptor_path}", exit_code=2)
@@ -305,33 +394,7 @@ def _dry_run(
     except Exception as e:  # unexpected dry-run crash — distinct from findings
         _emit_error(output_format, f"Dry-run error: {e}", exit_code=2)
 
-    if output_format == "json":
-        typer.echo(result.model_dump_json(indent=2))
-    else:
-        # Text format: print summary, products, then diagnostics
-        typer.echo(f"ok: {result.ok}")
-        typer.echo(f"stage: {result.stage.value}")
-        if result.timing_ms is not None:
-            typer.echo(f"timing: {result.timing_ms}ms")
-
-        if result.products:
-            typer.echo("")
-            for product in result.products:
-                truncated_note = " (truncated)" if product.truncated_rows else ""
-                typer.echo(f"{product.name}: {product.count} rows{truncated_note}")
-                for row in product.sample:
-                    typer.echo(f"  {row}")
-
-        if result.products_truncated > 0:
-            typer.echo(f"(+{result.products_truncated} products truncated)")
-
-        # Print diagnostics in the same format as _lint
-        if result.diagnostics:
-            typer.echo("")
-            for diag in result.diagnostics:
-                typer.echo(f"{diag.severity.value.upper():<7} {diag.rule}  {diag.message}")
-                typer.echo(f"    -> {diag.fix_hint}")
-
+    _emit_run_result(result, output_format)
     raise typer.Exit(0 if result.ok else 1)
 
 
@@ -373,160 +436,157 @@ def dry_run_cmd(
     )
 
 
-def _scaffold(
-    spec_path: Path,
+class _ScaffoldDiagnosticView(BaseModel):
+    """Typed CLI projection of the canonical concise diagnostic dictionary."""
+
+    rule: str = "UNKNOWN"
+    severity: str = "unknown"
+    message: str = ""
+    fix_hint: str = ""
+
+
+def _scaffold_failure(output_format: str, exit_code: int, message: str) -> Never:
+    if output_format == "json":
+        payload: dict[str, Any] = {"ok": False, "error": message}
+        typer.echo(json.dumps(payload, indent=2, default=str))
+    else:
+        typer.echo(f"Error: {message}")
+    raise typer.Exit(exit_code)
+
+
+def _scaffold_exit_code(result: ScaffoldResult) -> int:
+    if not result.ok:
+        return 2 if result.stage is AuthoringStage.RENDER else 1
+    if result.stage is AuthoringStage.ACCEPTANCE and not result.verified:
+        return 1
+    return 0
+
+
+def _emit_scaffold_diagnostics(result: ScaffoldResult) -> None:
+    for raw_diagnostic in result.diagnostics:
+        diagnostic = _ScaffoldDiagnosticView.model_validate(raw_diagnostic)
+        typer.echo(
+            f"{diagnostic.severity.upper():<7} "
+            f"{diagnostic.rule}  {diagnostic.message}"
+        )
+        typer.echo(f"    -> {diagnostic.fix_hint}")
+
+
+def _emit_scaffold_lint_result(result: ScaffoldResult) -> None:
+    _emit_scaffold_diagnostics(result)
+    if result.summary:
+        typer.echo(f"Summary: {result.summary}")
+    if result.ok and result.xml:
+        typer.echo("")
+        typer.echo(result.xml)
+
+
+def _emit_scaffold_dry_run_result(result: ScaffoldResult) -> None:
+    _emit_scaffold_diagnostics(result)
+    if result.xml:
+        typer.echo("")
+        typer.echo(result.xml)
+    if result.ok and result.products:
+        typer.echo("")
+        typer.echo("Dry-run successful:")
+        for product in result.products:
+            typer.echo(f"  {product.name}: {product.count} rows")
+
+
+def _emit_scaffold_acceptance_result(result: ScaffoldResult) -> None:
+    if result.xml:
+        typer.echo(result.xml)
+    if result.products:
+        typer.echo("")
+        typer.echo(
+            "Dry-run successful:"
+            if result.verified
+            else "Bounded dry-run completed without full verification:"
+        )
+        for product in result.products:
+            typer.echo(f"  {product.name}: {product.count} rows")
+    if result.acceptance is not None:
+        report = result.acceptance
+        typer.echo("")
+        typer.echo(
+            f"Acceptance: {report.passed} passed, {report.failed} failed, "
+            f"{report.unevaluable} unevaluable"
+        )
+        for evidence in report.results:
+            typer.echo(
+                f"  {evidence.status.upper():<11} "
+                f"{evidence.kind}: {evidence.message}"
+            )
+    typer.echo("")
+    typer.echo(
+        "Smoke export: "
+        f"{result.verification.smoke_export.status.value} — "
+        f"{result.verification.smoke_export.reason}"
+    )
+    typer.echo(
+        "Deterministic replay: "
+        f"{result.verification.deterministic_replay.status.value} — "
+        f"{result.verification.deterministic_replay.reason}"
+    )
+
+
+def _emit_scaffold_text_result(result: ScaffoldResult) -> None:
+    if result.stage is AuthoringStage.RENDER:
+        typer.echo(f"Error: {result.error}")
+    elif result.stage is AuthoringStage.LINT:
+        _emit_scaffold_lint_result(result)
+    elif result.stage is AuthoringStage.DRY_RUN:
+        _emit_scaffold_dry_run_result(result)
+    elif result.stage in (AuthoringStage.ACCEPTANCE, AuthoringStage.VERIFICATION):
+        _emit_scaffold_acceptance_result(result)
+
+    for note in result.normalization_notes:
+        typer.echo(f"note: {note}")
+
+
+def _emit_scaffold_result(result: ScaffoldResult, output_format: str) -> Never:
+    if output_format == "json":
+        typer.echo(
+            json.dumps(
+                result.model_dump(mode="json", exclude_none=True),
+                indent=2,
+            )
+        )
+    else:
+        _emit_scaffold_text_result(result)
+    raise typer.Exit(_scaffold_exit_code(result))
+
+
+def _read_scaffold_spec(spec_path: Path, output_format: str) -> dict[str, Any]:
+    import sys
+
+    try:
+        if str(spec_path) == "-":
+            spec_text = sys.stdin.read()
+        else:
+            if not spec_path.is_file():
+                _scaffold_failure(output_format, 2, f"File not found: {spec_path}")
+            spec_text = spec_path.read_text(encoding="utf-8")
+        return json.loads(spec_text)
+    except typer.Exit:
+        raise
+    except json.JSONDecodeError as error:
+        _scaffold_failure(output_format, 2, f"Invalid JSON: {error}")
+    except Exception as error:
+        _scaffold_failure(output_format, 2, f"Failed to read spec: {error}")
+
+
+def _build_scaffold_request(
+    spec: dict[str, Any],
     output_format: str,
     max_count: int,
     sample_rows: int,
     smoke_export: bool,
     deterministic_replay: bool,
-) -> None:
-    """Shared implementation for `scaffold` command (exit codes: 0 = ok, 1 = findings, 2 = file/input error).
-
-    Uses the service layer (datamimic_ce.authoring.service.scaffold) for the render ->
-    lint -> bounded run -> acceptance pipeline so the CLI and MCP surfaces can't drift. Only
-    output formatting (JSON vs text) and exit code mapping are CLI-specific.
-
-    Supports stdin via '-' as spec_path.
-    """
-    import sys
-
-    from datamimic_ce.authoring.service import scaffold
-
-    # Validate output format early
-    if output_format not in ("text", "json"):
-        typer.echo(f"Error: Invalid format '{output_format}'. Expected: text | json")
-        raise typer.Exit(2)
-
-    def _fail(exit_code: int, message: str) -> None:
-        if output_format == "json":
-            payload: dict[str, Any] = {"ok": False, "error": message}
-            typer.echo(json.dumps(payload, indent=2, default=str))
-        else:
-            typer.echo(f"Error: {message}")
-        raise typer.Exit(exit_code)
-
-    def _emit_result(result_obj: ScaffoldResult) -> None:
-        """Emit the result in the requested format and exit appropriately."""
-        # Determine exit code based on ok flag and stage
-        if not result_obj.ok:
-            exit_code = 2 if result_obj.stage is AuthoringStage.RENDER else 1
-        elif result_obj.stage is AuthoringStage.ACCEPTANCE and not result_obj.verified:
-            exit_code = 1
-        else:
-            exit_code = 0
-
-        if output_format == "json":
-            typer.echo(
-                json.dumps(
-                    result_obj.model_dump(mode="json", exclude_none=True),
-                    indent=2,
-                )
-            )
-        else:
-            # Text format output
-            if result_obj.stage is AuthoringStage.RENDER:
-                typer.echo(f"Error: {result_obj.error}")
-            elif result_obj.stage is AuthoringStage.LINT:
-                if result_obj.diagnostics:
-                    for diag in result_obj.diagnostics:
-                        rule = diag.get("rule", "UNKNOWN")
-                        severity = diag.get("severity", "unknown").upper()
-                        message = diag.get("message", "")
-                        fix_hint = diag.get("fix_hint", "")
-                        typer.echo(f"{severity:<7} {rule}  {message}")
-                        typer.echo(f"    -> {fix_hint}")
-                if result_obj.summary:
-                    typer.echo(f"Summary: {result_obj.summary}")
-                if not result_obj.ok and result_obj.xml:
-                    pass  # lint failure, no XML output
-                elif result_obj.ok and result_obj.xml:
-                    typer.echo("")
-                    typer.echo(result_obj.xml)
-            elif result_obj.stage is AuthoringStage.DRY_RUN:
-                if result_obj.diagnostics:
-                    for diag in result_obj.diagnostics:
-                        rule = diag.get("rule", "UNKNOWN")
-                        severity = diag.get("severity", "unknown").upper()
-                        message = diag.get("message", "")
-                        fix_hint = diag.get("fix_hint", "")
-                        typer.echo(f"{severity:<7} {rule}  {message}")
-                        typer.echo(f"    -> {fix_hint}")
-                if result_obj.xml:
-                    typer.echo("")
-                    typer.echo(result_obj.xml)
-                if result_obj.ok and result_obj.products:
-                    typer.echo("")
-                    typer.echo("Dry-run successful:")
-                    for product in result_obj.products:
-                        typer.echo(f"  {product.name}: {product.count} rows")
-            elif result_obj.stage in (
-                AuthoringStage.ACCEPTANCE,
-                AuthoringStage.VERIFICATION,
-            ):
-                if result_obj.xml:
-                    typer.echo(result_obj.xml)
-                if result_obj.products:
-                    typer.echo("")
-                    typer.echo(
-                        "Dry-run successful:"
-                        if result_obj.verified
-                        else "Bounded dry-run completed without full verification:"
-                    )
-                    for product in result_obj.products:
-                        typer.echo(f"  {product.name}: {product.count} rows")
-                if result_obj.acceptance is not None:
-                    report = result_obj.acceptance
-                    typer.echo("")
-                    typer.echo(
-                        f"Acceptance: {report.passed} passed, {report.failed} failed, {report.unevaluable} unevaluable"
-                    )
-                    for evidence in report.results:
-                        typer.echo(f"  {evidence.status.upper():<11} {evidence.kind}: {evidence.message}")
-                typer.echo("")
-                typer.echo(
-                    "Smoke export: "
-                    f"{result_obj.verification.smoke_export.status.value} — "
-                    f"{result_obj.verification.smoke_export.reason}"
-                )
-                typer.echo(
-                    "Deterministic replay: "
-                    f"{result_obj.verification.deterministic_replay.status.value} — "
-                    f"{result_obj.verification.deterministic_replay.reason}"
-                )
-
-            # Normalization notes surface in text mode on EVERY outcome, success included —
-            # a repaired near-miss the caller never sees is a hidden semantic rewrite.
-            for note in result_obj.normalization_notes:
-                typer.echo(f"note: {note}")
-
-        raise typer.Exit(exit_code)
-
-    # Load the JSON spec from file or stdin
+) -> ScaffoldRequest:
     try:
-        spec_str = str(spec_path)
-        if spec_str == "-":
-            # Read from stdin
-            spec_text = sys.stdin.read()
-        else:
-            # Read from file
-            spec_path_obj = Path(spec_path)
-            if not spec_path_obj.is_file():
-                _fail(2, f"File not found: {spec_path_obj}")
-            spec_text = spec_path_obj.read_text(encoding="utf-8")
-
-        spec_dict = json.loads(spec_text)
-    except typer.Exit:
-        raise
-    except json.JSONDecodeError as e:
-        _fail(2, f"Invalid JSON: {e}")
-    except Exception as e:
-        _fail(2, f"Failed to read spec: {e}")
-
-    # Validate inputs through ScaffoldRequest (gives us bounds checking)
-    try:
-        request = ScaffoldRequest(
-            spec=spec_dict,
+        return ScaffoldRequest(
+            spec=spec,
             max_count=max_count,
             sample_rows=sample_rows,
             response_format=AuthoringResponseFormat.CONCISE,
@@ -535,12 +595,36 @@ def _scaffold(
                 deterministic_replay=deterministic_replay,
             ),
         )
-    except ValueError as e:
-        _fail(2, str(e))
+    except ValueError as error:
+        _scaffold_failure(output_format, 2, str(error))
 
+
+def _scaffold(
+    spec_path: Path,
+    output_format: str,
+    max_count: int,
+    sample_rows: int,
+    smoke_export: bool,
+    deterministic_replay: bool,
+) -> None:
+    """Validate CLI input, call the authoring service, and project its result."""
+
+    from datamimic_ce.authoring.service import scaffold
+
+    if output_format not in ("text", "json"):
+        typer.echo(f"Error: Invalid format '{output_format}'. Expected: text | json")
+        raise typer.Exit(2)
+    spec = _read_scaffold_spec(spec_path, output_format)
+    request = _build_scaffold_request(
+        spec,
+        output_format,
+        max_count,
+        sample_rows,
+        smoke_export,
+        deterministic_replay,
+    )
     result = scaffold(request)
-
-    _emit_result(result)
+    _emit_scaffold_result(result, output_format)
 
 
 @app.command(

--- a/datamimic_ce/model/constraints.py
+++ b/datamimic_ce/model/constraints.py
@@ -551,6 +551,8 @@ def _rule_definition(
 
 # Public authoring evaluator catalog. Keep IDs stable: benchmark fixtures and
 # downstream agent tooling use them as machine contracts.
+_MINIMAL_GENERATE_EXAMPLE = '<generate name="g" count="1"/>'
+
 _AUTHORING_RULE_DEFINITIONS: tuple[RuleDefinition, ...] = (
     _rule_definition(
         "DM101",
@@ -579,7 +581,7 @@ _AUTHORING_RULE_DEFINITIONS: tuple[RuleDefinition, ...] = (
         "An element contains an attribute absent from its registered runtime model.",
         "Use an attribute exposed by the element model.",
         "Pydantic runtime model field contract.",
-        '<generate name="g" count="1"/>',
+        _MINIMAL_GENERATE_EXAMPLE,
         '<generate name="g" couunt="1"/>',
     ),
     _rule_definition(
@@ -589,7 +591,7 @@ _AUTHORING_RULE_DEFINITIONS: tuple[RuleDefinition, ...] = (
         "A required runtime-model attribute is absent.",
         "Add the required attribute.",
         "Pydantic runtime model required-field contract.",
-        '<generate name="g" count="1"/>',
+        _MINIMAL_GENERATE_EXAMPLE,
         '<generate count="1"/>',
     ),
     _rule_definition(
@@ -610,7 +612,7 @@ _AUTHORING_RULE_DEFINITIONS: tuple[RuleDefinition, ...] = (
         "Wrap the descriptor in a setup element.",
         "Setup parser root contract.",
         "<setup/>",
-        '<generate name="g" count="1"/>',
+        _MINIMAL_GENERATE_EXAMPLE,
     ),
     _rule_definition(
         "DM107",
@@ -640,7 +642,7 @@ _AUTHORING_RULE_DEFINITIONS: tuple[RuleDefinition, ...] = (
         "another declared mode supplies cardinality.",
         "Add a supported cardinality source.",
         "EXIST_COUNT central constraint and ADR-006 count fallback.",
-        '<generate name="g" count="1"/>',
+        _MINIMAL_GENERATE_EXAMPLE,
         '<generate name="g"/>',
     ),
     _rule_definition(
@@ -1617,52 +1619,10 @@ def serialize_constraints(constraints: tuple[Constraint, ...]) -> list[dict[str,
     if not constraints:
         return []
 
-    serialized = []
+    serialized: list[dict[str, Any]] = []
     for fact in constraints:
         serialized_fact: dict[str, Any] = {"kind": _constraint_kind(fact)}
-
-        if isinstance(fact, RequiredOneOf | MutuallyExclusive):
-            serialized_fact["attrs"] = sorted(fact.attrs)
-        elif isinstance(fact, MutuallyExclusiveWhen):
-            serialized_fact["when_attr"] = fact.when_attr
-            serialized_fact["attrs"] = sorted(fact.attrs)
-            serialized_fact["when_true"] = fact.when_true
-        elif isinstance(fact, Requires):
-            serialized_fact["attr"] = fact.attr
-            serialized_fact["needs"] = sorted(fact.needs)
-            serialized_fact["when_true"] = fact.when_true
-        elif isinstance(fact, RequiresWhenValue):
-            serialized_fact["when_attr"] = fact.when_attr
-            serialized_fact["when_values"] = sorted(fact.when_values)
-            serialized_fact["needs"] = sorted(fact.needs)
-            serialized_fact["unless"] = sorted(fact.unless)
-        elif isinstance(fact, AllOrNone):
-            serialized_fact["attrs"] = sorted(fact.attrs)
-        elif isinstance(fact, Forbids):
-            serialized_fact["attr"] = fact.attr
-            serialized_fact["excludes"] = sorted(fact.excludes)
-            serialized_fact["when_true"] = fact.when_true
-            serialized_fact["excludes_when_true"] = fact.excludes_when_true
-        elif isinstance(fact, ForbidsWhenValue):
-            serialized_fact["when_attr"] = fact.when_attr
-            serialized_fact["when_values"] = sorted(fact.when_values)
-            serialized_fact["excludes"] = sorted(fact.excludes)
-        elif isinstance(fact, ValidValues):
-            serialized_fact["attr"] = fact.attr
-            # Evaluate callable values to sorted list; static sets are already sorted
-            if callable(fact.values):
-                serialized_fact["values"] = sorted(fact.values())
-            else:
-                serialized_fact["values"] = sorted(fact.values)
-        elif isinstance(fact, AllowedValuesWhen):
-            serialized_fact["attr"] = fact.attr
-            # Evaluate callable allowed to sorted list; static sets are already sorted
-            if callable(fact.allowed):
-                serialized_fact["allowed"] = sorted(fact.allowed())
-            else:
-                serialized_fact["allowed"] = sorted(fact.allowed)
-            serialized_fact["when_attr"] = fact.when_attr
-            serialized_fact["when_true"] = fact.when_true
+        serialized_fact.update(_serialized_constraint_fields(fact))
 
         # Only serialize lint_only if True (non-default)
         if fact.lint_only:
@@ -1675,6 +1635,53 @@ def serialize_constraints(constraints: tuple[Constraint, ...]) -> list[dict[str,
         serialized.append(serialized_fact)
 
     return serialized
+
+
+def _serialized_constraint_fields(fact: Constraint) -> dict[str, Any]:
+    if isinstance(fact, RequiredOneOf | MutuallyExclusive | AllOrNone):
+        return {"attrs": sorted(fact.attrs)}
+    if isinstance(fact, MutuallyExclusiveWhen):
+        return {
+            "when_attr": fact.when_attr,
+            "attrs": sorted(fact.attrs),
+            "when_true": fact.when_true,
+        }
+    if isinstance(fact, Requires):
+        return {
+            "attr": fact.attr,
+            "needs": sorted(fact.needs),
+            "when_true": fact.when_true,
+        }
+    if isinstance(fact, RequiresWhenValue):
+        return {
+            "when_attr": fact.when_attr,
+            "when_values": sorted(fact.when_values),
+            "needs": sorted(fact.needs),
+            "unless": sorted(fact.unless),
+        }
+    if isinstance(fact, Forbids):
+        return {
+            "attr": fact.attr,
+            "excludes": sorted(fact.excludes),
+            "when_true": fact.when_true,
+            "excludes_when_true": fact.excludes_when_true,
+        }
+    if isinstance(fact, ForbidsWhenValue):
+        return {
+            "when_attr": fact.when_attr,
+            "when_values": sorted(fact.when_values),
+            "excludes": sorted(fact.excludes),
+        }
+    if isinstance(fact, ValidValues):
+        return {"attr": fact.attr, "values": sorted(resolved_values(fact))}
+    if isinstance(fact, AllowedValuesWhen):
+        return {
+            "attr": fact.attr,
+            "allowed": sorted(resolved_allowed(fact)),
+            "when_attr": fact.when_attr,
+            "when_true": fact.when_true,
+        }
+    raise TypeError(f"Unknown constraint type: {type(fact)}")
 
 
 def constraints_schema_extra(

--- a/datamimic_ce/model/model_util.py
+++ b/datamimic_ce/model/model_util.py
@@ -6,7 +6,6 @@
 
 import re
 from collections.abc import Set as AbstractSet
-from typing import TYPE_CHECKING
 
 from pydantic import TypeAdapter, ValidationError
 
@@ -22,10 +21,22 @@ from datamimic_ce.constants.attribute_constants import (
     ATTR_TYPE,
 )
 from datamimic_ce.constants.data_type_constants import DATA_TYPE_STRING
+from datamimic_ce.model.constraints import (
+    AllOrNone,
+    AllowedValuesWhen,
+    Constraint,
+    Forbids,
+    ForbidsWhenValue,
+    MutuallyExclusive,
+    MutuallyExclusiveWhen,
+    RequiredOneOf,
+    Requires,
+    RequiresWhenValue,
+    ValidValues,
+    resolved_allowed,
+    resolved_values,
+)
 from datamimic_ce.utils.string_util import StringUtil
-
-if TYPE_CHECKING:
-    from datamimic_ce.model.constraints import Constraint
 
 # Parse XML bool attributes exactly like the pydantic bool fields do, so a "before"
 # cross-field check can never disagree with the coerced value (e.g. unique="yes").
@@ -39,6 +50,165 @@ def _attr_true(value: object) -> bool:
         return _BOOL_ADAPTER.validate_python(value)
     except ValidationError:
         return False
+
+
+def _constraint_gate_open(
+    values: dict,
+    attr: str,
+    when_true: bool,
+) -> bool:
+    return _attr_true(values.get(attr)) if when_true else attr in values
+
+
+def _required_one_of_error(values: dict, fact: RequiredOneOf) -> str | None:
+    if any(attr in values for attr in fact.attrs):
+        return None
+    attrs_str = ", ".join(sorted(fact.attrs))
+    return fact.message or f"must define one of: {attrs_str}"
+
+
+def _mutually_exclusive_error(values: dict, fact: MutuallyExclusive) -> str | None:
+    present = [attr for attr in fact.attrs if attr in values]
+    if len(present) <= 1:
+        return None
+    attrs_str = ", ".join(sorted(fact.attrs))
+    return fact.message or f"at most one of [{attrs_str}] may be present, but got: {present}"
+
+
+def _mutually_exclusive_when_error(
+    values: dict,
+    fact: MutuallyExclusiveWhen,
+) -> str | None:
+    if not _constraint_gate_open(values, fact.when_attr, fact.when_true):
+        return None
+    present = [attr for attr in fact.attrs if attr in values]
+    if len(present) <= 1:
+        return None
+    attrs_str = ", ".join(sorted(fact.attrs))
+    return fact.message or (
+        f"when '{fact.when_attr}' is present, at most one of "
+        f"[{attrs_str}] may be present, but got: {present}"
+    )
+
+
+def _requires_error(values: dict, fact: Requires) -> str | None:
+    if not _constraint_gate_open(values, fact.attr, fact.when_true):
+        return None
+    if any(need in values for need in fact.needs):
+        return None
+    needs_str = ", ".join(sorted(fact.needs))
+    return fact.message or (
+        f"when '{fact.attr}' is present, at least one of [{needs_str}] must be present"
+    )
+
+
+def _requires_when_value_error(values: dict, fact: RequiresWhenValue) -> str | None:
+    if values.get(fact.when_attr) not in fact.when_values:
+        return None
+    if any(attr in values for attr in fact.unless):
+        return None
+    if any(need in values for need in fact.needs):
+        return None
+    needs_str = ", ".join(sorted(fact.needs))
+    values_str = ", ".join(sorted(fact.when_values))
+    return fact.message or (
+        f"when '{fact.when_attr}' is one of [{values_str}], at least one of "
+        f"[{needs_str}] must be present"
+    )
+
+
+def _all_or_none_error(values: dict, fact: AllOrNone) -> str | None:
+    present = [attr for attr in fact.attrs if attr in values]
+    if not present or len(present) == len(fact.attrs):
+        return None
+    attrs_str = ", ".join(sorted(fact.attrs))
+    return fact.message or f"either all of [{attrs_str}] must be present, or none"
+
+
+def _forbidden_attributes(values: dict, fact: Forbids) -> list[str]:
+    if fact.excludes_when_true:
+        return [attr for attr in fact.excludes if _attr_true(values.get(attr))]
+    return [attr for attr in fact.excludes if attr in values]
+
+
+def _forbids_error(values: dict, fact: Forbids) -> str | None:
+    if not _constraint_gate_open(values, fact.attr, fact.when_true):
+        return None
+    present = _forbidden_attributes(values, fact)
+    if not present:
+        return None
+    excludes_str = ", ".join(sorted(fact.excludes))
+    return fact.message or (
+        f"when '{fact.attr}' is present, none of [{excludes_str}] may be present, "
+        f"but got: {present}"
+    )
+
+
+def _forbids_when_value_error(values: dict, fact: ForbidsWhenValue) -> str | None:
+    if values.get(fact.when_attr) not in fact.when_values:
+        return None
+    present = [attr for attr in fact.excludes if attr in values]
+    if not present:
+        return None
+    excludes_str = ", ".join(sorted(fact.excludes))
+    values_str = ", ".join(sorted(fact.when_values))
+    return fact.message or (
+        f"when '{fact.when_attr}' is one of [{values_str}], none of "
+        f"[{excludes_str}] may be present, but got: {present}"
+    )
+
+
+def _valid_values_error(values: dict, fact: ValidValues) -> str | None:
+    if fact.attr not in values:
+        return None
+    attr_value = values[fact.attr]
+    valid_set = resolved_values(fact)
+    if attr_value in valid_set:
+        return None
+    valid_str = ", ".join(sorted(str(value) for value in valid_set))
+    return fact.message or (
+        f"'{fact.attr}' value must be one of [{valid_str}], but got: '{attr_value}'"
+    )
+
+
+def _allowed_values_error(values: dict, fact: AllowedValuesWhen) -> str | None:
+    if not _constraint_gate_open(values, fact.when_attr, fact.when_true):
+        return None
+    if fact.attr not in values:
+        return None
+    attr_value = values[fact.attr]
+    allowed_set = resolved_allowed(fact)
+    if attr_value in allowed_set:
+        return None
+    allowed_str = ", ".join(sorted(str(value) for value in allowed_set))
+    return (
+        fact.message.replace("{actual_value}", str(attr_value))
+        if fact.message is not None
+        else f"when '{fact.when_attr}' is present, '{fact.attr}' value must be one of "
+        f"[{allowed_str}], but got: '{attr_value}'"
+    )
+
+
+def _constraint_error(values: dict, fact: Constraint) -> str | None:
+    if isinstance(fact, RequiredOneOf):
+        return _required_one_of_error(values, fact)
+    if isinstance(fact, MutuallyExclusive):
+        return _mutually_exclusive_error(values, fact)
+    if isinstance(fact, MutuallyExclusiveWhen):
+        return _mutually_exclusive_when_error(values, fact)
+    if isinstance(fact, Requires):
+        return _requires_error(values, fact)
+    if isinstance(fact, RequiresWhenValue):
+        return _requires_when_value_error(values, fact)
+    if isinstance(fact, AllOrNone):
+        return _all_or_none_error(values, fact)
+    if isinstance(fact, Forbids):
+        return _forbids_error(values, fact)
+    if isinstance(fact, ForbidsWhenValue):
+        return _forbids_when_value_error(values, fact)
+    if isinstance(fact, ValidValues):
+        return _valid_values_error(values, fact)
+    return _allowed_values_error(values, fact)
 
 
 class ModelUtil:
@@ -357,156 +527,10 @@ class ModelUtil:
         Raises:
             ValueError: On constraint violation, with the fact's message or a generated default
         """
-        from datamimic_ce.model.constraints import (
-            AllOrNone,
-            AllowedValuesWhen,
-            Forbids,
-            ForbidsWhenValue,
-            MutuallyExclusive,
-            MutuallyExclusiveWhen,
-            RequiredOneOf,
-            Requires,
-            RequiresWhenValue,
-            ValidValues,
-        )
-
         for fact in constraints:
-            # Skip lint-only facts; they are not engine-enforced
             if fact.lint_only:
                 continue
-
-            if isinstance(fact, RequiredOneOf):
-                if all(attr not in values for attr in fact.attrs):
-                    attrs_str = ", ".join(sorted(fact.attrs))
-                    msg = fact.message or f"must define one of: {attrs_str}"
-                    raise ValueError(msg)
-
-            elif isinstance(fact, MutuallyExclusive):
-                present = [attr for attr in fact.attrs if attr in values]
-                if len(present) > 1:
-                    attrs_str = ", ".join(sorted(fact.attrs))
-                    msg = fact.message or f"at most one of [{attrs_str}] may be present, but got: {present}"
-                    raise ValueError(msg)
-
-            elif isinstance(fact, MutuallyExclusiveWhen):
-                gate_value = values.get(fact.when_attr)
-                should_check = (
-                    (not fact.when_true and fact.when_attr in values)
-                    or (fact.when_true and _attr_true(gate_value))
-                )
-                present = [attr for attr in fact.attrs if attr in values]
-                if should_check and len(present) > 1:
-                    attrs_str = ", ".join(sorted(fact.attrs))
-                    msg = fact.message or (
-                        f"when '{fact.when_attr}' is present, at most one of "
-                        f"[{attrs_str}] may be present, but got: {present}"
-                    )
-                    raise ValueError(msg)
-
-            elif isinstance(fact, Requires):
-                # Gate on presence; if when_true=True, gate on truthiness
-                attr_value = values.get(fact.attr)
-                should_check = (
-                    (not fact.when_true and fact.attr in values) or
-                    (fact.when_true and _attr_true(attr_value))
-                )
-
-                if should_check and all(need not in values for need in fact.needs):
-                    needs_str = ", ".join(sorted(fact.needs))
-                    msg = fact.message or (
-                        f"when '{fact.attr}' is present, at least one of "
-                        f"[{needs_str}] must be present"
-                    )
-                    raise ValueError(msg)
-
-            elif isinstance(fact, RequiresWhenValue):
-                if values.get(fact.when_attr) in fact.when_values:
-                    escaped = any(attr in values for attr in fact.unless)
-                    if not escaped and all(need not in values for need in fact.needs):
-                        needs_str = ", ".join(sorted(fact.needs))
-                        values_str = ", ".join(sorted(fact.when_values))
-                        msg = fact.message or (
-                            f"when '{fact.when_attr}' is one of [{values_str}], at least one of "
-                            f"[{needs_str}] must be present"
-                        )
-                        raise ValueError(msg)
-
-            elif isinstance(fact, AllOrNone):
-                present = [attr for attr in fact.attrs if attr in values]
-                if present and len(present) != len(fact.attrs):
-                    attrs_str = ", ".join(sorted(fact.attrs))
-                    msg = fact.message or f"either all of [{attrs_str}] must be present, or none"
-                    raise ValueError(msg)
-
-            elif isinstance(fact, Forbids):
-                # Gate on presence; if when_true=True, gate on truthiness
-                attr_value = values.get(fact.attr)
-                should_check = (
-                    (not fact.when_true and fact.attr in values) or
-                    (fact.when_true and _attr_true(attr_value))
-                )
-
-                if should_check:
-                    # If excludes_when_true=True, excluded attr must also be truthy for violation
-                    if fact.excludes_when_true:
-                        present_excludes = [attr for attr in fact.excludes if _attr_true(values.get(attr))]
-                    else:
-                        present_excludes = [attr for attr in fact.excludes if attr in values]
-                    if present_excludes:
-                        excludes_str = ", ".join(sorted(fact.excludes))
-                        msg = fact.message or (
-                            f"when '{fact.attr}' is present, none of "
-                            f"[{excludes_str}] may be present, but got: "
-                            f"{present_excludes}"
-                        )
-                        raise ValueError(msg)
-
-            elif isinstance(fact, ForbidsWhenValue):
-                if values.get(fact.when_attr) in fact.when_values:
-                    present_excludes = [attr for attr in fact.excludes if attr in values]
-                    if present_excludes:
-                        excludes_str = ", ".join(sorted(fact.excludes))
-                        values_str = ", ".join(sorted(fact.when_values))
-                        msg = fact.message or (
-                            f"when '{fact.when_attr}' is one of [{values_str}], none of "
-                            f"[{excludes_str}] may be present, but got: {present_excludes}"
-                        )
-                        raise ValueError(msg)
-
-            elif isinstance(fact, ValidValues) and fact.attr in values:
-                # Only validate if the attribute is present
-                attr_value = values[fact.attr]
-                # Resolve values set (may be callable)
-                valid_set = fact.values() if callable(fact.values) else fact.values
-                if attr_value not in valid_set:
-                    valid_str = ", ".join(sorted(str(v) for v in valid_set))
-                    msg = fact.message or (
-                        f"'{fact.attr}' value must be one of [{valid_str}], "
-                        f"but got: '{attr_value}'"
-                    )
-                    raise ValueError(msg)
-
-            elif isinstance(fact, AllowedValuesWhen):
-                # Gate on when_attr's presence or truthiness
-                when_value = values.get(fact.when_attr)
-                should_check = (
-                    (not fact.when_true and fact.when_attr in values) or
-                    (fact.when_true and _attr_true(when_value))
-                )
-
-                # Only validate if attr is also present
-                if should_check and fact.attr in values:
-                    attr_value = values[fact.attr]
-                    # Resolve allowed set (may be callable)
-                    allowed_set = fact.allowed() if callable(fact.allowed) else fact.allowed
-                    if attr_value not in allowed_set:
-                        allowed_str = ", ".join(sorted(str(v) for v in allowed_set))
-                        msg = (
-                            fact.message.replace("{actual_value}", str(attr_value))
-                            if fact.message is not None
-                            else f"when '{fact.when_attr}' is present, '{fact.attr}' value must be one of "
-                            f"[{allowed_str}], but got: '{attr_value}'"
-                        )
-                        raise ValueError(msg)
-
+            error = _constraint_error(values, fact)
+            if error is not None:
+                raise ValueError(error)
         return values

--- a/datamimic_ce/tasks/key_variable_task.py
+++ b/datamimic_ce/tasks/key_variable_task.py
@@ -57,13 +57,12 @@ class KeyVariableTask(Task):
     ):
         from datamimic_ce.tasks.task_util import TaskUtil
 
-        self._element_tag = (
-            EL_KEY
-            if isinstance(statement, KeyStatement)
-            else EL_VARIABLE
-            if isinstance(statement, VariableStatement)
-            else EL_ELEMENT
-        )
+        if isinstance(statement, KeyStatement):
+            self._element_tag = EL_KEY
+        elif isinstance(statement, VariableStatement):
+            self._element_tag = EL_VARIABLE
+        else:
+            self._element_tag = EL_ELEMENT
         self._statement = statement
         self._generator: WeightedDataSource | None = None
         self._pagination = pagination

--- a/datamimic_ce/utils/number_sequences.py
+++ b/datamimic_ce/utils/number_sequences.py
@@ -15,6 +15,8 @@ held generator object cannot be copied/pickled - a cursor survives the copy at t
 position it had."""
 
 import random
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterator
 from decimal import Decimal
 
 from datamimic_ce.enums.distribution_enums import POSITIONAL_NUMBER_SEQUENCES, NumberDistribution
@@ -26,7 +28,7 @@ def _grid_size(min_v: float, max_v: float, granularity: float) -> int:
     return int((Decimal(str(max_v)) - Decimal(str(min_v))) / Decimal(str(granularity))) + 1
 
 
-class _GridSequence:
+class _GridSequence(ABC, Iterator[int | float]):
     """Base: maps grid indices k -> values; subclasses advance a plain-int cursor."""
 
     def __init__(self, min_v: float, max_v: float, granularity: float, integral: bool):
@@ -40,8 +42,12 @@ class _GridSequence:
             return int(self._min) + k * int(self._granularity)
         return float(Decimal(str(self._min)) + k * Decimal(str(self._granularity)))
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[int | float]:
         return self
+
+    @abstractmethod
+    def __next__(self) -> int | float:
+        """Return the next value from the concrete grid traversal."""
 
 
 class _StepSequence(_GridSequence):
@@ -140,7 +146,7 @@ class _RandomWalkSequence(_GridSequence):
         return value
 
 
-class _RecurrenceSequence:
+class _RecurrenceSequence(Iterator[int]):
     """Recurrence VALUES within [min, max]: ends once the next value exceeds max; values below
     min are skipped so a min > 0 range still yields the in-range tail."""
 
@@ -155,7 +161,7 @@ class _RecurrenceSequence:
             self._pending = [1, 1, 1]
         self._is_fibonacci = distribution is NumberDistribution.FIBONACCI
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[int]:
         return self
 
     def __next__(self) -> int:
@@ -207,14 +213,17 @@ def build_number_sequence(
     granularity: float,
     rng: random.Random,
     integral: bool,
-):
+) -> Iterator[int | float]:
     """Value iterator for a sequence-type NumberDistribution. Exhaustion raises StopIteration -
     the engine treats it like a source running dry (the row loop ends)."""
     if distribution in (NumberDistribution.FIBONACCI, NumberDistribution.PADOVAN):
         return _RecurrenceSequence(distribution, min_v, max_v)
     if distribution is NumberDistribution.RANDOM_WALK:
         return _RandomWalkSequence(min_v, max_v, granularity, integral, rng)
-    sequence_classes = {
+    sequence_classes: dict[
+        NumberDistribution,
+        Callable[[float, float, float, bool], _GridSequence],
+    ] = {
         NumberDistribution.STEP: _StepSequence,
         NumberDistribution.INCREMENT: _StepSequence,
         NumberDistribution.SHUFFLE: _ShuffleSequence,

--- a/tests_ce/unit_tests/test_authoring/test_intent_compiler.py
+++ b/tests_ce/unit_tests/test_authoring/test_intent_compiler.py
@@ -438,6 +438,20 @@ def test_compile_plan_rejects_duplicate_products_in_isolation() -> None:
         )
 
 
+def test_compile_plan_rejects_duplicate_fields_in_isolation() -> None:
+    product = _minimal_compile_plan_product()
+    product["fields"] = [
+        {"kind": "increment", "name": "id"},
+        {"kind": "script", "name": "id"},
+    ]
+
+    with pytest.raises(
+        ValidationError,
+        match="duplicate field name 'id' in product 'rows'",
+    ):
+        CompilePlan.model_validate({"products": [product]})
+
+
 def test_compile_plan_rejects_dangling_relationship_in_isolation() -> None:
     with pytest.raises(ValidationError, match="relationship references unknown product 'missing'"):
         CompilePlan.model_validate(

--- a/tests_ce/unit_tests/test_generator/test_number_sequence_capacity.py
+++ b/tests_ce/unit_tests/test_generator/test_number_sequence_capacity.py
@@ -5,6 +5,8 @@
 
 """The authoring capacity API must stay identical to runtime iterator exhaustion."""
 
+import copy
+import pickle
 import random
 
 import pytest
@@ -24,6 +26,29 @@ def test_finite_capacity_matches_runtime_iterator(distribution: NumberDistributi
         integral=True,
     )
     assert finite_number_sequence_capacity(distribution, 1, 20, 1) == len(list(sequence))
+
+
+@pytest.mark.parametrize("distribution", sorted(POSITIONAL_NUMBER_SEQUENCES, key=lambda item: item.value))
+def test_number_sequence_iterator_preserves_cursor_when_copied(
+    distribution: NumberDistribution,
+) -> None:
+    sequence = build_number_sequence(
+        distribution,
+        min_v=1,
+        max_v=20,
+        granularity=1,
+        rng=random.Random(1),
+        integral=True,
+    )
+    assert iter(sequence) is sequence
+    next(sequence)
+
+    deep_copy = copy.deepcopy(sequence)
+    pickled_copy = pickle.loads(pickle.dumps(sequence))
+
+    expected_remaining = list(sequence)
+    assert list(deep_copy) == expected_remaining
+    assert list(pickled_copy) == expected_remaining
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- resolves the merge-relevant Sonar code smells through typed, owner-local decomposition
- fixes the iterator protocol quality-gate blocker
- preserves Authoring service, compiler, rule-SPOT, and acceptance execution boundaries
- adds focused iterator and CompilePlan regression coverage

## Verification

- 1,107 passed, 11 skipped across unit and agent CLI transport tests
- Ruff passes for production code and changed tests
- Mypy passes for all 17 changed production files
- independent read-only review found no P0/P1/P2 regressions

## Remaining gate

The draft remains open until the fresh SonarCloud PR analysis confirms that no extracted helper introduces a new cognitive-complexity finding.